### PR TITLE
in examples: import flask-sqlalchemy from flask.ext hook

### DIFF
--- a/examples/auth/auth.py
+++ b/examples/auth/auth.py
@@ -1,5 +1,5 @@
 from flask import Flask, url_for, redirect, render_template, request
-from flaskext.sqlalchemy import SQLAlchemy
+from flask.ext.sqlalchemy import SQLAlchemy
 
 from flask.ext import admin, login, wtf
 from flask.ext.admin.contrib import sqlamodel

--- a/examples/babel/simple.py
+++ b/examples/babel/simple.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, session
-from flaskext.sqlalchemy import SQLAlchemy
+from flask.ext.sqlalchemy import SQLAlchemy
 
 from flask.ext import admin
 from flask.ext.babel import Babel

--- a/examples/sqla/simple.py
+++ b/examples/sqla/simple.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flaskext.sqlalchemy import SQLAlchemy
+from flask.ext.sqlalchemy import SQLAlchemy
 
 from flask.ext import admin, wtf
 from flask.ext.admin.contrib import sqlamodel


### PR DESCRIPTION
 to support flask-SQLAlchemy>=0.16 (this change is also backwards compatible for < 0.16)
