### PR TITLE
Avoid 404 error with FileAdmin

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -176,7 +176,7 @@ class FileAdmin(BaseView):
             Return base path. Override to customize behavior (per-user
             directories, etc)
         """
-        return self.base_path
+        return op.normpath(self.base_path)
 
     def get_base_url(self):
         """


### PR DESCRIPTION
an error occurs when you use '.' and '..' in your `base_path`::

```
>>> op.normpath(directory).startswith(base_path)
False
>>> op.normpath(directory)
u'/home/projects/mywebsite/static/utils'
>>> base_path
u'/home/projects/mywebsite/admin/../static'
>>> base_path = op.normpath(base_path)
>>> op.normpath(directory).startswith(base_path)
True
```
