### PR TITLE
Generating a proper breadcrumbs in FileAdmin

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -309,8 +309,11 @@ class FileAdmin(BaseView):
         items.sort(key=itemgetter(2), reverse=True)
 
         # Generate breadcrumbs
-        accumulator = ''
-        breadcrumbs = [(n, op.join(accumulator, n)) for n in path.split(os.sep)]
+        accumulator = []
+        breadcrumbs = []
+        for n in path.split(os.sep):
+            accumulator.append(n)
+            breadcrumbs.append((n, op.join(*accumulator)))
 
         return self.render(self.list_template,
                            dir_path=path,


### PR DESCRIPTION
Create this type of list:

```
[(u'download', u'download'), (u'archives', u'download/archives')]
```

instead of:

```
[(u'download', u'download'), (u'archives', u'archives')]
```
