### PR TITLE
Fix missing FileAdmin class initialization

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -278,7 +278,7 @@ Here is simple example::
     admin = Admin(app)
 
     path = op.join(op.dirname(__file__), 'static')
-    admin.add_view(path, '/static/', name='Static Files')
+    admin.add_view(FileAdmin(path, '/static/', name='Static Files'))
 
 Sample screenshot:
 


### PR DESCRIPTION
In the FileAdmin code example the admin view wasn't really created, its arguments were passed directly to the `admin.add_view` function.
