### PR TITLE
Fix typo in docs

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -160,7 +160,7 @@ class BaseModelView(BaseView):
         Example::
 
             class MyModelView(BaseModelView):
-                list_columns = ('name', 'email')
+                form_columns = ('name', 'email')
     """
 
     excluded_form_columns = None


### PR DESCRIPTION
I guess `form_columns` docstring was copy-pasted from `list_columns` and the
occurrence of the identifier wasn't replaced.
