### PR TITLE
Add ability to annotate field with help text

### DIFF
--- a/flask_admin/templates/admin/lib.html
+++ b/flask_admin/templates/admin/lib.html
@@ -90,6 +90,9 @@
               {{ f() }}
               {% endif %}
             </div>
+            {% if f.description %}
+            <p class="help-block">{{ f.description }}</p>
+            {% endif %}
             {% if f.errors %}
               <ul>
               {% for e in f.errors %}


### PR DESCRIPTION
As indicated in WTForms documentation, fields have a description, which is
typically used for help text [1].

Also, in Twitter Bootstrap, help text are supported by `p.help-block` element
[2].

[1] http://wtforms.simplecodes.com/docs/1.0.1/fields.html#wtforms.fields.Field.__init__
[2] http://twitter.github.com/bootstrap/base-css.html#forms
