### PR TITLE
Prevent None being converted to string and causing confirmation pop-up

### DIFF
--- a/flask_admin/actions.py
+++ b/flask_admin/actions.py
@@ -56,7 +56,9 @@ class ActionsMixin(object):
                 text = unicode(text)
 
                 actions.append((name, text))
-                actions_confirmation[name] = unicode(self._actions_data[name][2])
+                confirmation = self._actions_data[name][2]
+                if confirmation:
+                    actions_confirmation[name] = unicode(confirmation)
 
         return actions, actions_confirmation
 


### PR DESCRIPTION
Not sure this is the cleanest way to handle, but it prevents the None being converted to u'None' and thus showing as a message for actions that don't require confirmation (in a JS confirm window).
