### PR TITLE
fix bug in form.py wen checking callable_default

### DIFF
--- a/flask_admin/contrib/sqlamodel/form.py
+++ b/flask_admin/contrib/sqlamodel/form.py
@@ -137,7 +137,7 @@ class AdminModelConverter(ModelConverterBase):
                 if default is not None:
                     callable_default = getattr(default, 'arg', None)
 
-                    if callable_default and callable(callable_default):
+                    if callable_default is not None and callable(callable_default):
                         default = callable_default(None)
 
                 if default is not None:


### PR DESCRIPTION
raise TypeError("Boolean value of this clause is not defined")
TypeError: Boolean value of this clause is not defined

see
http://www.sqlalchemy.org/trac/wiki/06Migration#AnImportantExpressionLanguageGotcha
