### PR TITLE
Fixes for boolean fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Patches and Suggestions
 - Salem Harrache <salem@harrache.info>
 - F. Gabriel Gosselin
 - Leonardinius <leonids.maslovs@galeoconsulting.com>
+- Peter Ward <peteraward@gmail.com>

--- a/flask_admin/contrib/sqlamodel/form.py
+++ b/flask_admin/contrib/sqlamodel/form.py
@@ -1,4 +1,5 @@
 from wtforms import fields, validators
+from sqlalchemy import Boolean
 
 from flask.ext.admin import form
 from flask.ext.admin.model.form import converts, ModelConverterBase, InlineFormAdmin
@@ -125,7 +126,7 @@ class AdminModelConverter(ModelConverterBase):
                                                        model,
                                                        column))
 
-                if not column.nullable:
+                if not column.nullable and not isinstance(column.type, Boolean):
                     kwargs['validators'].append(validators.Required())
 
                 # Apply label

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -77,7 +77,7 @@ class BaseBooleanFilter(BaseFilter):
     """
         Base boolean filter, uses fixed list of options.
     """
-    def __init__(self, name, data_type=None):
+    def __init__(self, name, options=None, data_type=None):
         super(BaseBooleanFilter, self).__init__(name,
                                                 (('1', lazy_gettext('Yes')),
                                                  ('0', lazy_gettext('No'))),


### PR DESCRIPTION
If you have a boolean field with `nullable=False`, then it puts a `Required` validator on it, which means you can’t enter False as a valid value.

Also, filtering by booleans seemed to be broken, due to the MRO of `__init__`. I’ve fixed it, but it’s a tiny bit of a hack, and there’s possibly a better solution.
