### PR TITLE
Block for Overriding Row Actions

### DIFF
--- a/flask_admin/templates/admin/model/list.html
+++ b/flask_admin/templates/admin/model/list.html
@@ -138,18 +138,20 @@
                 </td>
                 {% endif %}
                 <td>
-                    {%- if admin_view.can_edit -%}
-                    <a class="icon" href="{{ url_for('.edit_view', id=get_pk_value(row), url=return_url) }}">
-                        <i class="icon-pencil"></i>
-                    </a>
-                    {%- endif -%}
-                    {%- if admin_view.can_delete -%}
-                    <form class="icon" method="POST" action="{{ url_for('.delete_view', id=get_pk_value(row), url=return_url) }}">
-                        <button onclick="return confirm('{{ _gettext('You sure you want to delete this item?') }}');">
-                            <i class="icon-remove"></i>
-                        </button>
-                    </form>
-                    {%- endif -%}
+                    {% block list_row_row_actions scoped %}
+                        {%- if admin_view.can_edit -%}
+                        <a class="icon" href="{{ url_for('.edit_view', id=get_pk_value(row), url=return_url) }}">
+                            <i class="icon-pencil"></i>
+                        </a>
+                        {%- endif -%}
+                        {%- if admin_view.can_delete -%}
+                        <form class="icon" method="POST" action="{{ url_for('.delete_view', id=get_pk_value(row), url=return_url) }}">
+                            <button onclick="return confirm('{{ _gettext('You sure you want to delete this item?') }}');">
+                                <i class="icon-remove"></i>
+                            </button>
+                        </form>
+                        {%- endif -%}
+                    {% endblock %}
                 </td>
                 {% for c, name in list_columns %}
                 <td>{{ get_value(row, c) }}</td>


### PR DESCRIPTION
I'd like to add a block to the admin/model/list.html template to allow for each row's "row action launchers" (the pencil and 'x' icons) to be overriden in a template that inherits from list.html .

My use case for this is a 'task admin' application, in which tasks can not only be created or deleted, but can also be triggered.  I'd like to add a 'run' icon to the pencil and 'x' for this purpose, but I'd like to keep the rest of the admin page.
