### PR TITLE
Fix sqlamodel.get_one() when using modified get_query()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/*
 make.bat
 venv
 *.sqlite
+*.sublime-*

--- a/flask_admin/contrib/sqlamodel/view.py
+++ b/flask_admin/contrib/sqlamodel/view.py
@@ -570,7 +570,7 @@ class ModelView(BaseModelView):
             :param id:
                 Model id
         """
-        return self.get_query().get(id)
+        return self.session.query(self.model).get(id)
 
     # Model handlers
     def create_model(self, form):


### PR DESCRIPTION
Don't use `get_query()` within `get_one()` as SQLAlchemy `get()` can not have any additional filters applied to the Query.

Fixes error: `InvalidRequestError: Query.get() being called on a Query with existing criterion.`
