### PR TITLE
Improve docs on how to use custom InlineFormAdmin for inline_models

### DIFF
--- a/flask_admin/contrib/peeweemodel/view.py
+++ b/flask_admin/contrib/peeweemodel/view.py
@@ -70,23 +70,23 @@ class ModelView(BaseModelView):
 
         Accept enumerable with one of the values:
 
-        1. Child model class
+        1. Child model class::
 
             class MyModelView(ModelView):
                 inline_models = (Post,)
 
-        2. Child model class and additional options
+        2. Child model class and additional options::
 
             class MyModelView(ModelView):
                 inline_models = [(Post, dict(form_columns=['title']))]
 
-        3. Django-like ``InlineFormAdmin`` class instance
+        3. Django-like ``InlineFormAdmin`` class instance::
 
-            class MyInlineForm(InlineFormAdmin):
-                forum_columns = ('title', 'date')
+            class MyInlineModelForm(InlineFormAdmin):
+                form_columns = ('title', 'date')
 
             class MyModelView(ModelView):
-                inline_models = (MyInlineForm,)
+                inline_models = (MyInlineModelForm(MyInlineModel),)
     """
 
     def __init__(self, model, name=None,
@@ -340,7 +340,7 @@ class ModelView(BaseModelView):
                     count += 1
 
             flash(ngettext('Model was successfully deleted.',
-                           '%(count)s models were sucessfully deleted.',
+                           '%(count)s models were successfully deleted.',
                            count,
                            count=count))
         except Exception, ex:

--- a/flask_admin/contrib/sqlamodel/view.py
+++ b/flask_admin/contrib/sqlamodel/view.py
@@ -145,7 +145,7 @@ class ModelView(BaseModelView):
 
     inline_models = None
     """
-        Inline related-model editing for models with parent to child relation.
+        Inline related-model editing for models with parent-child relations.
 
         Accepts enumerable with one of the following possible values:
 
@@ -161,11 +161,11 @@ class ModelView(BaseModelView):
 
         3. Django-like ``InlineFormAdmin`` class instance::
 
-            class MyInlineForm(InlineFormAdmin):
-                forum_columns = ('title', 'date')
+            class MyInlineModelForm(InlineFormAdmin):
+                form_columns = ('title', 'date')
 
             class MyModelView(ModelView):
-                inline_models = (MyInlineForm,)
+                inline_models = (MyInlineModelForm(MyInlineModel),)
     """
 
     def __init__(self, model, session,
@@ -657,7 +657,7 @@ class ModelView(BaseModelView):
             self.session.commit()
 
             flash(ngettext('Model was successfully deleted.',
-                           '%(count)s models were sucessfully deleted.',
+                           '%(count)s models were successfully deleted.',
                            count,
                            count=count))
         except Exception, ex:


### PR DESCRIPTION
Updated docs, though new syntax (see below) you showed in #86 doesn't work.

``` python
class SaleItemForm(object):
  model = SaleItem
  form_columns = ('amount',)

class SaleAdmin(sqlamodel.ModelView):
  inline_models = (SaleItemForm,)
```
