### PR TITLE
Fixed issue with constructing query with joins at sqlalchemy ModelView

### DIFF
--- a/flask_admin/contrib/sqlamodel/view.py
+++ b/flask_admin/contrib/sqlamodel/view.py
@@ -484,7 +484,8 @@ class ModelView(BaseModelView):
         if self._search_supported and search:
             # Apply search-related joins
             if self._search_joins:
-                query = query.join(*self._search_joins.values())
+                for j in self._search_joins.values():
+                    query = query.join(j)
                 joins = set(self._search_joins.keys())
 
             # Apply terms


### PR DESCRIPTION
If you use Flask-Admin for table B and this table have 2 foreign keys to tables A and C. And you want to be able to search by fields from all 3 tables. "get_list" method of ModelView will construct invalid query. 
