### PR TITLE
Add extra type formatter for `list` type

### DIFF
--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -31,7 +31,18 @@ def bool_formatter(value):
     return Markup('<i class="icon-ok"></i>' if value else '')
 
 
+def list_formatter(values):
+    """
+        Return string with comma separated values
+
+        :param values:
+            Value to check
+    """
+    return u', '.join(values)
+
+
 DEFAULT_FORMATTERS = {
     type(None): empty_formatter,
-    bool: bool_formatter
+    bool: bool_formatter,
+    list: list_formatter,
 }


### PR DESCRIPTION
It's a little bit confusing for admin users to see values for columns with list support (i.e. PgArray), represented like `["value1", "value2"]`
