### PR TITLE
Typo: Removed blanks surrouding a hyphen

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -89,7 +89,7 @@ Now, lets add an administrative view. To do this, you need to derive from :class
 
 If you will run this example, you will see that menu has two items: Home and Hello.
 
-Each view class should have default page - view method with '/' url. Following code won't work::
+Each view class should have default page-view method with '/' url. Following code won't work::
 
     class MyView(BaseView):
         @expose('/index/')


### PR DESCRIPTION
Typo: Removed blanks surrouding a hyphen
