### PR TITLE
use prettify_name so that you can easily override the default prettification strategy

### DIFF
--- a/flask_admin/contrib/sqlamodel/form.py
+++ b/flask_admin/contrib/sqlamodel/form.py
@@ -1,4 +1,6 @@
 from wtforms import fields, validators
+# Field has better input parsing capabilities.
+from wtforms.ext.dateutil.fields import DateTimeField
 from sqlalchemy import Boolean, Column
 
 from flask.ext.admin import form
@@ -210,7 +212,7 @@ class AdminModelConverter(ModelConverterBase):
     @converts('DateTime')
     def convert_datetime(self, field_args, **extra):
         field_args['widget'] = form.DateTimePickerWidget()
-        return fields.DateTimeField(**field_args)
+        return DateTimeField(**field_args)
 
     @converts('Time')
     def convert_time(self, field_args, **extra):


### PR DESCRIPTION
I think the view.prettify_name should be called if _get_label cant get the label any other way. Then I can write:

```
class MyModelView(ModelView):
    def prettify_name(self, name):
        if not any(ch in name for ch in ' aeiouy'):
            return name.upper()
        return name.replace('_', ' ').title()
```

And automatically have field names that are abbrevations like "http" and "bpm" show up as "HTTP" and "BPM" everywhere instead of as "Http" and "Bpm". 
