### PR TITLE
Sort fileadmin items by name additionally

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -375,7 +375,7 @@ class FileAdmin(BaseView, ActionsMixin):
             items.append((f, op.join(path, f), op.isdir(fp), op.getsize(fp)))
 
         # Sort by type
-        items.sort(key=itemgetter(2), reverse=True)
+        items.sort(key=itemgetter(2, 1), reverse=True)
 
         # Generate breadcrumbs
         accumulator = []


### PR DESCRIPTION
Hi mrjoes,

I would like to show the files order by name additionally using `File Admin`. Seems it only topped directories according to the `flask_admin/contrib/fileadmin.py` as below:

``` python
items.sort(key=itemgetter(2), reverse=True) 
```

But I think `itemgetter(2, 1)` would be better since it also sorts by name, and makes better readability for the file list.

How about you? Hope this patch makes sense and helps.

Cheers
