### PR TITLE
Setting admin endpoint url='/' allows non index_view views to generate url from endpoint

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -177,7 +177,10 @@ class BaseView(object):
             if self.admin.url != '/':
                 self.url = '%s/%s' % (self.admin.url, self.endpoint)
             else:
-                self.url = '/'
+                if self == admin.index_view:
+                    self.url = '/'
+                else:
+                    self.url = '/%s' % self.endpoint
         else:
             if not self.url.startswith('/'):
                 self.url = '%s/%s' % (self.admin.url, self.url)

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -150,6 +150,10 @@ def test_baseview_registration():
     view = MockView(url='/test/test')
     view.create_blueprint(base.Admin())
     eq_(view.url, '/test/test')
+    
+    view = MockView(endpoint='test')
+    view.create_blueprint(base.Admin(url='/'))
+    eq_(view.url, '/test')
 
 
 def test_baseview_urls():


### PR DESCRIPTION
Currently if you specify a url of '/' as an argument to Admin, it makes all views have a url of '/' unless explicitly specified.

This changes it so that non-index_view views will by default get a url of `/<endpoint>`
