### PR TITLE
Add full support for SQAlchemy Enum field

### DIFF
--- a/flask_admin/contrib/sqlamodel/filters.py
+++ b/flask_admin/contrib/sqlamodel/filters.py
@@ -90,30 +90,34 @@ class BooleanNotEqualFilter(FilterNotEqual, filters.BaseBooleanFilter):
 class FilterConverter(filters.BaseFilterConverter):
     strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike)
     numeric = (FilterEqual, FilterNotEqual, FilterGreater, FilterSmaller)
+    bool = (BooleanEqualFilter, BooleanNotEqualFilter)
+    emun = (FilterEqual, FilterNotEqual)
 
-    def convert(self, type_name, column, name):
+    def convert(self, type_name, column, name, **kwargs):
         if type_name in self.converters:
-            return self.converters[type_name](column, name)
-
+            return self.converters[type_name](column, name, **kwargs)
         return None
 
     @filters.convert('String', 'Unicode', 'Text', 'UnicodeText')
-    def conv_string(self, column, name):
-        return [f(column, name) for f in self.strings]
+    def conv_string(self, column, name, **kwargs):
+        return [f(column, name, **kwargs) for f in self.strings]
 
     @filters.convert('Boolean')
-    def conv_bool(self, column, name):
-        return [BooleanEqualFilter(column, name),
-                BooleanNotEqualFilter(column, name)]
+    def conv_bool(self, column, name, **kwargs):
+        return [f(column, name, **kwargs) for f in self.bool]
 
     @filters.convert('Integer', 'SmallInteger', 'Numeric', 'Float')
-    def conv_int(self, column, name):
-        return [f(column, name) for f in self.numeric]
+    def conv_int(self, column, name, **kwargs):
+        return [f(column, name, **kwargs) for f in self.numeric]
 
     @filters.convert('Date')
-    def conv_date(self, column, name):
-        return [f(column, name, data_type='datepicker') for f in self.numeric]
+    def conv_date(self, column, name, **kwargs):
+        return [f(column, name, data_type='datepicker', **kwargs) for f in self.numeric]
 
     @filters.convert('DateTime')
-    def conv_datetime(self, column, name):
-        return [f(column, name, data_type='datetimepicker') for f in self.numeric]
+    def conv_datetime(self, column, name, **kwargs):
+        return [f(column, name, data_type='datetimepicker', **kwargs) for f in self.numeric]
+
+    @filters.convert('Enum', 'ENUM')
+    def conv_enum(self, column, name, options, **kwargs):
+        return [f(column, name, options, **kwargs) for f in self.emun]

--- a/flask_admin/contrib/sqlamodel/form.py
+++ b/flask_admin/contrib/sqlamodel/form.py
@@ -1,5 +1,6 @@
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
+from wtfpeewee.fields import SelectChoicesField
 
 from flask.ext.admin import form
 from flask.ext.admin.tools import get_property
@@ -185,6 +186,16 @@ class AdminModelConverter(ModelConverterBase):
                 override = self._get_field_override(prop.key)
                 if override:
                     return override(**kwargs)
+
+                # Check choices
+                if mapper.class_ == self.view.model and self.view.form_choices:
+                    choices = self.view.form_choices.get(column.key)
+                    if choices:
+                        return SelectChoicesField(
+                            choices=choices,
+                            allow_blank=column.nullable,
+                            **kwargs
+                        )
 
                 # Run converter
                 converter = self.get_converter(column)

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -181,6 +181,20 @@ class BaseModelView(BaseView, ActionsMixin):
                 column_searchable_list = ('name', 'email')
     """
 
+    column_choices = None
+    """
+        Map choices to columns in list view
+
+        Example::
+
+            class MyModelView(BaseModelView):
+                column_choices = {
+                    'my_column': [
+                        ('db_value', 'display_value'),
+                    ]
+                }
+    """
+
     column_filters = None
     """
         Collection of the column filters.
@@ -349,6 +363,15 @@ class BaseModelView(BaseView, ActionsMixin):
         # Search
         self._search_supported = self.init_search()
 
+        # Choices
+        if self.column_choices:
+            self._column_choices_map = dict([
+                (column, dict(choices))
+                for column, choices in self.column_choices.items()
+            ])
+        else:
+            self.column_choices = self._column_choices_map = dict()
+
         # Filters
         self._filters = self.get_filters()
 
@@ -499,15 +522,14 @@ class BaseModelView(BaseView, ActionsMixin):
             collection = []
 
             for n in self.column_filters:
-                if not self.is_valid_filter(n):
+                if self.is_valid_filter(n):
+                    collection.append(n)
+                else:
                     flt = self.scaffold_filters(n)
                     if flt:
                         collection.extend(flt)
                     else:
                         raise Exception('Unsupported filter type %s' % n)
-                else:
-                    collection.append(n)
-
             return collection
         else:
             return None
@@ -793,6 +815,10 @@ class BaseModelView(BaseView, ActionsMixin):
             return column_fmt(context, model, name)
 
         value = rec_getattr(model, name)
+
+        choices_map = self._column_choices_map.get(name, {})
+        if choices_map:
+            return choices_map.get(value) or value
 
         type_fmt = self.column_type_formatters.get(type(value))
         if type_fmt is not None:


### PR DESCRIPTION
If you have code::

``` python

class Category(Model):
    status = Column(Enum('category_status1', 'category_status2'), name='statuses')

class Product(Model):
    status = Column(Enum('status1', 'status2'), name='statuses')
    category_id = Column(ForeignKey(Category.id))
    category = relationship(Category)

class ProductView(ModelView):
    column_labels = form_labels = {
         'status': u'Статус продукта',
         'category.status': u'Статус категории',
    }
    column_choices = form_choices = {
        'status': [
             ('status1', u'Статус продукта 1'), 
             ('status2', u'Статус продукта 2'), 
        ],
        'category.status': [
             ('category_status1', u'Статус категории 1'), 
             ('category_status2', u'Статус категории 2'), 
        ],
    }
    column_filters = [
        'status',
        'category.status',
    ]

```

then you will have automatically:
1. Correct and readable SelectField for `status` field
2. Readable values in table for columns `status`, `category.status`
3. Choice filters
