### PR TITLE
make bulk deletes go through `delete_model`

### DIFF
--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -394,8 +394,7 @@ class ModelView(BaseModelView):
 
             all_ids = [ObjectId(pk) for pk in ids]
             for obj in self.get_query().in_bulk(all_ids).values():
-                obj.delete()
-                count += 1
+                count += self.delete_model(obj)
 
             flash(ngettext('Model was successfully deleted.',
                            '%(count)s models were successfully deleted.',


### PR DESCRIPTION
I'm not sure this is ideal (might hide some errors?) but it's the easiest way
to use the hook for both kinds of delete.
