### PR TITLE
A bug occurred in get_one, solved in this change.

### DIFF
--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -1,6 +1,8 @@
 import logging
 
 import pymongo
+from bson import ObjectId
+from bson.errors import InvalidId
 
 from flask import flash
 from jinja2 import contextfunction
@@ -241,6 +243,13 @@ class ModelView(BaseModelView):
 
         return count, results
 
+    def _get_valid_id(self, id):
+        try:
+            return ObjectId(id)
+        except InvalidId:
+            return id
+
+
     def get_one(self, id):
         """
             Return single model instance by ID
@@ -248,8 +257,7 @@ class ModelView(BaseModelView):
             :param id:
                 Model ID
         """
-        # TODO: Validate if it is valid ID
-        return self.coll.find_one({'_id': id})
+        return self.coll.find_one({'_id': self._get_valid_id(id)})
 
     def edit_form(self, obj):
         """
@@ -336,7 +344,7 @@ class ModelView(BaseModelView):
 
             # TODO: Optimize me
             for pk in ids:
-                self.coll.remove({'_id': pk})
+                self.coll.remove({'_id': self._get_valid_id(pk)})
                 count += 1
 
             flash(ngettext('Model was successfully deleted.',


### PR DESCRIPTION
Casting to ObjectId when the database is using ObjectId as type of _id is mandatory, because usual type of _id field in wtf is StringField, so it should be converted to ObjectId in queries.
The best solution to support ObjectId and other types for _id is to try to convert given _id to ObjectId, if it was successful so we can put the ObjectId in query, otherwise we can put the original given _id to query (So the developer will be responsible for it's type matching).
I changed the code and tested it in various cases.
