### PR TITLE
Added is_creating parameter for BaseModelView.on_model_change

### DIFF
--- a/examples/pymongo/simple.py
+++ b/examples/pymongo/simple.py
@@ -96,7 +96,7 @@ class TweetView(ModelView):
         return self._feed_user_choices(form)
 
     # Correct user_id reference before saving
-    def on_model_change(self, form, model):
+    def on_model_change(self, form, model, is_creating):
         user_id = model.get('user_id')
         model['user_id'] = ObjectId(user_id)
 

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -340,7 +340,7 @@ class ModelView(BaseModelView):
         try:
             model = self.model()
             form.populate_obj(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, True)
             model.save()
         except Exception as ex:
             flash(gettext('Failed to create model. %(error)s', error=str(ex)),
@@ -363,7 +363,7 @@ class ModelView(BaseModelView):
         """
         try:
             form.populate_obj(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, False)
             model.save()
         except Exception as ex:
             flash(gettext('Failed to update model. %(error)s', error=str(ex)),

--- a/flask_admin/contrib/peeweemodel/view.py
+++ b/flask_admin/contrib/peeweemodel/view.py
@@ -336,7 +336,7 @@ class ModelView(BaseModelView):
         try:
             model = self.model()
             form.populate_obj(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, True)
             model.save()
 
             # For peewee have to save inline forms after model was saved
@@ -353,7 +353,7 @@ class ModelView(BaseModelView):
     def update_model(self, form, model):
         try:
             form.populate_obj(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, False)
             model.save()
 
             # For peewee have to save inline forms after model was saved

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -254,7 +254,7 @@ class ModelView(BaseModelView):
         """
         try:
             model = form.data
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, True)
             self.coll.insert(model)
         except Exception as ex:
             flash(gettext('Failed to create model. %(error)s', error=str(ex)),
@@ -277,7 +277,7 @@ class ModelView(BaseModelView):
         """
         try:
             model.update(form.data)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, False)
 
             pk = self.get_pk_value(model)
             self.coll.update({'_id': pk}, model)

--- a/flask_admin/contrib/sqlamodel/view.py
+++ b/flask_admin/contrib/sqlamodel/view.py
@@ -763,7 +763,7 @@ class ModelView(BaseModelView):
             model = self.model()
             form.populate_obj(model)
             self.session.add(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, True)
             self.session.commit()
         except Exception as ex:
             flash(gettext('Failed to create model. %(error)s', error=str(ex)), 'error')
@@ -786,7 +786,7 @@ class ModelView(BaseModelView):
         """
         try:
             form.populate_obj(model)
-            self.on_model_change(form, model)
+            self.on_model_change(form, model, False)
             self.session.commit()
         except Exception as ex:
             flash(gettext('Failed to update model. %(error)s', error=str(ex)), 'error')

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -682,7 +682,7 @@ class BaseModelView(BaseView, ActionsMixin):
         raise NotImplemented('Please implement get_one method')
 
     # Model event handlers
-    def on_model_change(self, form, model):
+    def on_model_change(self, form, model, is_creating):
         """
             Perform some actions after a model is created or updated.
 
@@ -695,6 +695,8 @@ class BaseModelView(BaseView, ActionsMixin):
                 Form used to create/update model
             :param model:
                 Model that will be created/updated
+            :param is_creating:
+                True if model will be created, False if model will be updated
         """
         pass
 

--- a/flask_admin/tests/sqlamodel/test_basic.py
+++ b/flask_admin/tests/sqlamodel/test_basic.py
@@ -473,7 +473,7 @@ def test_on_model_change_delete():
     db.create_all()
 
     class ModelView(CustomModelView):
-        def on_model_change(self, form, model):
+        def on_model_change(self, form, model, is_creating):
             model.test1 = model.test1.upper()
 
         def on_model_delete(self, model):


### PR DESCRIPTION
On my `User` model I have two special required fileds `password` (hash digets) and `password_salt` (random string) which genereted from user readable password (`password = hash(readable_password + password_salt)`). When user create account my code populate it.

So now I want create users with `flask-admin`:  populate fileds when `on_model_change` will be called.

When I override `on_model_change` with my code then on creating fields populated but on update it also will be updated. I prefere avoid this fileds updating on update.
