### PR TITLE
FileAdmin failed on file upload with message that FileField has not attribute 'has_file'

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -46,7 +46,7 @@ class UploadForm(form.BaseForm):
         super(UploadForm, self).__init__(helpers.get_form_data())
 
     def validate_upload(self, field):
-        if not self.upload.has_file():
+        if not self.upload.data:
             raise validators.ValidationError(gettext('File required.'))
 
         filename = self.upload.data.filename


### PR DESCRIPTION
fileadmin.py uses wtforms, not flask.ext.wtf, so FileField has not method has_file (it is method of this field from Flask-WTF) and failed on uploading.
