### PR TITLE
Replace ModelAdmin with ModelView in sqla ModelView example

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -56,12 +56,12 @@ class ModelView(BaseModelView):
 
         For example::
 
-            class PostAdmin(ModelAdmin):
+            class PostAdmin(ModelView):
                 column_select_related_list = ('user', 'city')
 
         You can also use properties::
 
-            class PostAdmin(ModelAdmin):
+            class PostAdmin(ModelView):
                 column_select_related_list = (Post.user, Post.city)
 
         Please refer to the `subqueryload` on list of possible values.


### PR DESCRIPTION
After playing around a little bit with flask-admin, I stumbled over a wrong base class in docs for sqla integration.

I've updated the example (it's a really small fix)

Cheers,
Flo
