### PR TITLE
Fix static_url_path if Admin.url was set

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -415,7 +415,7 @@ class Admin(object):
                  index_view=None,
                  translations_path=None,
                  endpoint=None,
-                 static_url_path=None,
+                 static_url_path='/admin',
                  base_template=None):
         """
             Constructor.


### PR DESCRIPTION
If the Admin object is initialized with url='/' it uses '/' as prefix for the static url which breaks serving of the staic files (they are still serverd from the /admin/ prefix)

Not sure if this is the right place or if admin static files should be served from Admin.url if no Admin.static_url_path is set.

Cheers
