### PR TITLE
process inherited primary keys correctly

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -12,6 +12,7 @@ from flask.ext.admin._compat import iteritems
 
 from .validators import Unique
 from .fields import QuerySelectField, QuerySelectMultipleField, InlineModelFormList
+from .tools import is_inherited_primary_key, get_column_for_current_model
 
 try:
     # Field has better input parsing capabilities.
@@ -132,17 +133,8 @@ class AdminModelConverter(ModelConverterBase):
             if hasattr(prop, 'columns'):
                 # Check if more than one column mapped to the property
                 if len(prop.columns) != 1:
-                    # Check if all columns are primary keys and _one_ does not have a foreign key -> looks like joined
-                    # table inheritance: http://docs.sqlalchemy.org/en/latest/orm/inheritance.html with "standard
-                    # practice" of same column name
-                    if len([column for column in prop.columns if column.primary_key]) == len(prop.columns) and \
-                            len([column for column in prop.columns if column.foreign_keys]) == len(prop.columns)-1:
-                        # Get the column(s) of the current model - should always be only one, I think (but not sure)
-                        candidates = [column for column in prop.columns if column.expression == prop.expression]
-                        if len(candidates) != 1:
-                            raise TypeError('Can not convert multiple-column pk-Property (%s.%s)' % (model, prop.key))
-                        else:
-                            column = candidates[0]
+                    if is_inherited_primary_key(prop):
+                        column = get_column_for_current_model(prop)
                     else:
                         raise TypeError('Can not convert multiple-column properties (%s.%s)' % (model, prop.key))
                 else:

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -25,3 +25,39 @@ def get_primary_key(model):
                     return p.key
 
     return None
+
+def is_inherited_primary_key(prop):
+    """
+        Return True, if the ColumnProperty is an inherited primary key
+
+        Check if all columns are primary keys and _one_ does not have a foreign key -> looks like joined
+        table inheritance: http://docs.sqlalchemy.org/en/latest/orm/inheritance.html with "standard
+        practice" of same column name.
+
+        :param prop: The ColumnProperty to check
+        :return: Boolean
+        :raises: Exceptions as they occur - no ExceptionHandling here
+    """
+    return len([column for column in prop.columns if column.primary_key]) == len(prop.columns) and \
+                len([column for column in prop.columns if column.foreign_keys]) == len(prop.columns)-1
+
+def get_column_for_current_model(prop):
+    """
+        Return the Column() of the ColumnProperty "prop", that refers to the current model
+
+        When using inheritance, a ColumnProperty may contain multiple columns. This function
+        returns the Column(), the belongs to the Model of the ColumnProperty - the "current"
+        model
+
+        :param prop: The ColumnProperty
+        :return: The column for the current model
+        :raises: TypeError if not exactely one Column() for the current model could be found.
+                    All other Exceptions not handled here but raised
+    """
+    candidates = [column for column in prop.columns if column.expression == prop.expression]
+    if len(candidates) != 1:
+        raise TypeError('Not exactly one column for the current model found. ' +
+                        'Found %d columns for property %s' % (len(candidates), prop))
+    else:
+        return candidates[0]
+


### PR DESCRIPTION
When using joined table inheritance (http://docs.sqlalchemy.org/en/latest/orm/inheritance.html), it is common practice to name the pk-property the same like the pk-property of the parent. (At least the documentation says so) The child-property ist a pk itself and has a foreign-key relationship to the pk-property of the parent.

Example:

```
class BaseWahl(Model):
    __tablename__ = 'basewahlen'

    id = Column(Integer, primary_key=True, autoincrement=True)
    discriminator = db.Column(db.String(50))

    __mapper_args__ = {
    'polymorphic_identity':'basewahl',
    'polymorphic_on': discriminator
    }

class Wahl(BaseWahl):
    __tablename__ = 'wahlen'

    id = Column(Integer, ForeignKey('basewahlen.id'), primary_key=True)
    __mapper_args__ = {
        'polymorphic_identity':'wahl',
    }
```

`AdminModelConverter.convert()` does not allow Properties with multiple columns, but will raise a `TypeError`. I changed it into the following way:
- If
  - more than 1 column for the property
  - all columns are primary keys
  - only _one_ does not have a Foreign key
  - only one column corresponds to the current model
- select the column, that corresponds to the current model

I applied the same code to `ModelView.scaffold_list_columns()` and extended it, the primary key in this special constellation actually is _not_ ignored, even if it has a foreign key property, so it can be displayed using `column_display_pk = True`.

This solution actually works for me. I do not have enough insight into _Flask-Admin_ and definitely even less into _sqlalchemy_ to think my solution is the correct one for every situation, but it may be something to think about.
