### PR TITLE
bugfix: inline form 'new' template - now submits all added fields correc...

### DIFF
--- a/flask_admin/templates/admin/model/inline_form.html
+++ b/flask_admin/templates/admin/model/inline_form.html
@@ -1,4 +1,4 @@
 {% import 'admin/lib.html' as lib with context %}
-<div class="inline-form">
+<div class="fa-inline-field">
   {{ lib.render_form_fields(field, False) }}
 </div>


### PR DESCRIPTION
...tly

I noticed that in form.js:28, we try to figure out the new field id by parsing the last inline-field's id:
var lastField = $el.children('.fa-inline-field').last();

When you add new fields in the /new form, they get class="inline-form" which would cause appended fields to all have an id that ends with 0.

From the manual tests I did, this seems to fix it.
