### PR TITLE
Inherit pk weak entities

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -51,8 +51,9 @@ def is_inherited_primary_key(prop):
         :return: Boolean
         :raises: Exceptions as they occur - no ExceptionHandling here
     """
-    return (len([column for column in prop.columns if column.primary_key]) == len(prop.columns) and
-            len([column for column in prop.columns if column.foreign_keys]) == len(prop.columns) - 1)
+    if prop.expression.primary_key:
+        return len(prop._orig_columns) == len(prop.columns)-1
+    return False
 
 def get_column_for_current_model(prop):
     """

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -323,7 +323,7 @@ class ModelView(BaseModelView):
                     if is_inherited_primary_key(p):
                         column = get_column_for_current_model(p)
                     else:
-                        raise TypeError('Can not convert multiple-column properties (%s.%s)' % (model, p.key))
+                        raise TypeError('Can not convert multiple-column properties (%s.%s)' % (self.model, p.key))
                 else:
                     # Grab column
                     column = p.columns[0]


### PR DESCRIPTION
flask_admin.contrib.sqla.tools.is_inherited_primary_key() now works even if the inherited primary key is itself a foreign key. This leads to a better support of SQLAlchemies _joined table inheritance_
