### PR TITLE
Name all loggers.

### DIFF
--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -22,6 +22,10 @@ from .ajax import process_ajax_references, create_ajax_loader
 from .subdoc import convert_subdocuments
 
 
+# Set up logger
+log = logging.getLogger("flask-admin.mongo")
+
+
 SORTABLE_FIELDS = set((
     mongoengine.StringField,
     mongoengine.IntField,
@@ -478,7 +482,7 @@ class ModelView(BaseModelView):
             flash(gettext('Failed to create model. %(error)s',
                           error=format_error(ex)),
                   'error')
-            logging.exception('Failed to create model')
+            log.exception('Failed to create model')
             return False
         else:
             self.after_model_change(form, model, True)
@@ -505,7 +509,7 @@ class ModelView(BaseModelView):
             flash(gettext('Failed to update model. %(error)s',
                           error=format_error(ex)),
                   'error')
-            logging.exception('Failed to update model')
+            log.exception('Failed to update model')
             return False
         else:
             self.after_model_change(form, model, False)
@@ -530,7 +534,7 @@ class ModelView(BaseModelView):
             flash(gettext('Failed to delete model. %(error)s',
                           error=format_error(ex)),
                   'error')
-            logging.exception('Failed to delete model')
+            log.exception('Failed to delete model')
             return False
 
     # FileField access API

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -15,6 +15,9 @@ from .form import get_form, CustomModelConverter, InlineModelConverter, save_inl
 from .tools import get_primary_key, parse_like_term
 from .ajax import create_ajax_loader
 
+# Set up logger
+log = logging.getLogger("flask-admin.peewee")
+
 
 class ModelView(BaseModelView):
     column_filters = None
@@ -350,7 +353,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to create model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to create model')
+            log.exception('Failed to create model')
             return False
         else:
             self.after_model_change(form, model, True)
@@ -370,7 +373,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to update model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to update model')
+            log.exception('Failed to update model')
             return False
         else:
             self.after_model_change(form, model, False)
@@ -387,7 +390,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to delete model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to delete model')
+            log.exception('Failed to delete model')
             return False
 
     # Default model actions

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -15,6 +15,9 @@ from flask.ext.admin.helpers import get_form_data
 from .filters import BasePyMongoFilter
 from .tools import parse_like_term
 
+# Set up logger
+log = logging.getLogger("flask-admin.pymongo")
+
 
 class ModelView(BaseModelView):
     """
@@ -260,7 +263,7 @@ class ModelView(BaseModelView):
         except Exception as ex:
             flash(gettext('Failed to create model. %(error)s', error=str(ex)),
                   'error')
-            logging.exception('Failed to create model')
+            log.exception('Failed to create model')
             return False
         else:
             self.after_model_change(form, model, True)
@@ -285,7 +288,7 @@ class ModelView(BaseModelView):
         except Exception as ex:
             flash(gettext('Failed to update model. %(error)s', error=str(ex)),
                   'error')
-            logging.exception('Failed to update model')
+            log.exception('Failed to update model')
             return False
         else:
             self.after_model_change(form, model, False)
@@ -311,7 +314,7 @@ class ModelView(BaseModelView):
         except Exception as ex:
             flash(gettext('Failed to delete model. %(error)s', error=str(ex)),
                   'error')
-            logging.exception('Failed to delete model')
+            log.exception('Failed to delete model')
             return False
 
     # Default model actions

--- a/flask_admin/contrib/rediscli.py
+++ b/flask_admin/contrib/rediscli.py
@@ -10,6 +10,9 @@ from flask.ext.admin.base import BaseView, expose
 from flask.ext.admin.babel import gettext
 from flask.ext.admin._compat import VER
 
+# Set up logger
+log = logging.getLogger("flask-admin.redis")
+
 
 class CommandError(Exception):
     """
@@ -203,5 +206,5 @@ class RedisCli(BaseView):
         except CommandError as err:
             return self._error('Cli: %s' % err)
         except Exception as ex:
-            logging.exception(ex)
+            log.exception(ex)
             return self._error('Cli: %s' % ex)

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -19,6 +19,10 @@ from .tools import is_inherited_primary_key, get_column_for_current_model, get_q
 from .ajax import create_ajax_loader
 
 
+# Set up logger
+log = logging.getLogger("flask-admin.sqla")
+
+
 class ModelView(BaseModelView):
     """
         SQLAlchemy model view
@@ -792,7 +796,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to create model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to create model')
+            log.exception('Failed to create model')
             self.session.rollback()
             return False
         else:
@@ -818,7 +822,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to update model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to update model')
+            log.exception('Failed to update model')
             self.session.rollback()
 
             return False
@@ -845,7 +849,7 @@ class ModelView(BaseModelView):
                 raise
 
             flash(gettext('Failed to delete model. %(error)s', error=str(ex)), 'error')
-            logging.exception('Failed to delete model')
+            log.exception('Failed to delete model')
             self.session.rollback()
             return False
 


### PR DESCRIPTION
Instead of using the root logger, give all used loggers names related to the package and their location.
This allows users to work with flask-admin logs as they wish (picking them out/ suppressing them), as well as being more clear where the logs (and errors) are originating.

Will change log output from:

```
2013-08-15 22:57:47,607 - root - ERROR - Failed to create model
```

to:

```
2013-08-15 22:57:47,607 - flask-admin.sqla - ERROR - Failed to create model
```
