### PR TITLE
The mongoengine auth example won't work TypeError and AttributeError

### DIFF
--- a/examples/auth-mongoengine/auth.py
+++ b/examples/auth-mongoengine/auth.py
@@ -37,7 +37,7 @@ class User(db.Document):
         return False
 
     def get_id(self):
-        return self.id
+        return str(self.id)
 
     # Required for administrative interface
     def __unicode__(self):
@@ -104,7 +104,7 @@ def index():
 @app.route('/login/', methods=('GET', 'POST'))
 def login_view():
     form = LoginForm(request.form)
-    if helpers.validate_form_on_submit(form):
+    if request.method == 'POST' and form.validate():
         user = form.get_user()
         login.login_user(user)
         return redirect(url_for('index'))
@@ -115,7 +115,7 @@ def login_view():
 @app.route('/register/', methods=('GET', 'POST'))
 def register_view():
     form = RegistrationForm(request.form)
-    if helpers.validate_form_on_submit(form):
+    if request.method == 'POST' and form.validate():
         user = User()
 
         form.populate_obj(user)


### PR DESCRIPTION
Steps to reproduce:

Create the virtualenv and do the regular installation:

```
pip install https://github.com/mrjoes/flask-admin/archive/master.zip
pip install flask-mongoengine
pip install flask-login
```
- go to the examples/auth-mongoengine directory and launch the app with python auth.py
- point the browser at http://localhost:5000/register/  and create try to create a user
- if you have an existing user go to http://localhost:5000/login/ and it will also show the same error

These are the issues fixed:

```
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: ObjectId('523b1c4b0840396b6b33c665') is not JSON serializable
```

And:

```
AttributeError: 'module' object has no attribute 'validate_form_on_submit'
```
