### PR TITLE
refs #3, fixed sqlalchemy.exc.DataError when saving empty AjaxSelectMultipleField

### DIFF
--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -183,7 +183,7 @@ class AjaxSelectMultipleField(AjaxSelectField):
 
             # TODO: Optimize?
             for item in formdata:
-                model = self.loader.get_one(item)
+                model = self.loader.get_one(item) if item else None
 
                 if model:
                     data.append(model)


### PR DESCRIPTION
The problem is that wtfforms calls method getlist (werkzeug.datastructures.ImmutableMultiDict), which for a field with a blank line returns list with one empty element.
