### PR TITLE
Enable column formatting via templates

### DIFF
--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -1,3 +1,4 @@
+import jinja2
 from flask import g, request
 from wtforms.validators import DataRequired, InputRequired
 
@@ -6,6 +7,11 @@ from ._compat import string_types
 
 def set_current_view(view):
     g._admin_view = view
+
+
+@jinja2.contextfunction
+def get_context(c):
+    return c
 
 
 def get_current_view():

--- a/flask_admin/templates/admin/model/list.html
+++ b/flask_admin/templates/admin/model/list.html
@@ -115,7 +115,13 @@
                     {% endblock %}
                 </td>
                 {% for c, name in list_columns %}
-                <td>{{ get_value(row, c) }}</td>
+                <td>
+                    {% if c in h.get_context() %}
+                        {{ h.get_context()[c](row) }}
+                    {% else %}
+                        {{ get_value(row, c) }}
+                    {% endif %}
+                </td>
                 {% endfor %}
             {% endblock %}
         </tr>


### PR DESCRIPTION
It gives an ability to move `html` from `Model.column_formatters`

Instead of doing

``` python
column_formatters = {
    'title': lambda view, c, obj, attr: obj.title: Markup(u'<strong>%s</strong>' % obj.title))
}
```

you can do in list template:

``` html
{% macro title(item) %}
    <strong>{{ item.title }}</strong>
{% endmacro %}
```
