### PR TITLE
Non-nullable, non-required types for SQLAlchemy forms

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -26,6 +26,13 @@ class AdminModelConverter(ModelConverterBase):
     """
         SQLAlchemy model to form converter
     """
+
+    nullable_not_required_types = [Boolean]
+    """
+        Types which do not produce required fields if they are
+        non-nullable.
+    """
+    
     def __init__(self, session, view):
         super(AdminModelConverter, self).__init__()
 
@@ -191,7 +198,9 @@ class AdminModelConverter(ModelConverterBase):
                                                        model,
                                                        column))
 
-                if not column.nullable and not isinstance(column.type, Boolean):
+                if not column.nullable and not any(
+                        isinstance(column.type, _type)
+                        for _type in self.nullable_not_required_types):
                     kwargs['validators'].append(validators.InputRequired())
 
                 # Apply label and description if it isn't inline form field


### PR DESCRIPTION
This adds the class property `nullable_not_required_types' to
AdminModelConverter which can be used to allow empty strings in
generated forms even if they are non-nullable in the database.
