### PR TITLE
sqla: consider MANYTOMANY in InlineModelConverter

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -538,7 +538,7 @@ class InlineModelConverter(InlineModelConverterBase):
         reverse_prop = None
 
         for prop in target_mapper.iterate_properties:
-            if hasattr(prop, 'direction') and prop.direction.name == 'MANYTOONE':
+            if hasattr(prop, 'direction'):
                 if issubclass(model, prop.mapper.class_):
                     reverse_prop = prop
                     break
@@ -549,7 +549,7 @@ class InlineModelConverter(InlineModelConverterBase):
         forward_prop = None
 
         for prop in mapper.iterate_properties:
-            if hasattr(prop, 'direction') and prop.direction.name == 'ONETOMANY':
+            if hasattr(prop, 'direction'):
                 if prop.mapper.class_ == target_mapper.class_:
                     forward_prop = prop
                     break


### PR DESCRIPTION
Apparently this is enough to make it working. Probably once I manage to use Association Object pattern with Flask-SQLAlchemy I might revisit it to inline edit/create the related item and the relationship-specific data at the same time.
