### PR TITLE
Update MongoEngine filters.py to include options description similar to BaseFilter

### DIFF
--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -17,7 +17,7 @@ class BaseMongoEngineFilter(filters.BaseFilter):
             :param name:
                 Display name
             :param options:
-                Fixed set of options
+                Fixed set of options. If provided, will use drop down instead of textbox.
             :param data_type:
                 Client data type
         """


### PR DESCRIPTION
MongoEngine filters.py is not clear what options are used for.
Including wording from BaseFilter
