### PR TITLE
Fix counterintuitive editing of MongoDB Documents with ImageField

### DIFF
--- a/flask_admin/contrib/mongoengine/fields.py
+++ b/flask_admin/contrib/mongoengine/fields.py
@@ -6,6 +6,13 @@ from wtforms.fields.core import _unset_value
 from . import widgets
 
 
+def is_empty(file_object):
+    file_object.seek(0)
+    first_char = file_object.read(1)
+    file_object.seek(0)
+    return not bool(first_char)
+
+
 class ModelFormField(fields.FormField):
     """
         Customized ModelFormField for MongoEngine EmbeddedDocuments.
@@ -54,7 +61,7 @@ class MongoFileField(fields.FileField):
                 field.delete()
                 return
 
-            if isinstance(self.data, FileStorage):
+            if isinstance(self.data, FileStorage) and not is_empty(self.data.stream):
                 if not field.grid_id:
                     func = field.put
                 else:


### PR DESCRIPTION
When you modify a MongoEngine `Document` with an `ImageField` and no new image is submitted, a `ValidationError` is raised complaining that the image format isn't recognised. This forces to upload the image again whenever modifying the Document. My changes check that a new image file has been submitted before attempting at replacing the old image.
