### PR TITLE
Fixed #379. Redirect using request.url when using "save and continue" in model edit_view

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1246,7 +1246,7 @@ class BaseModelView(BaseView, ActionsMixin):
             if self.update_model(form, model):
                 if '_continue_editing' in request.form:
                     flash(gettext('Model was successfully saved.'))
-                    return redirect(request.full_path)
+                    return redirect(request.url)
                 else:
                     return redirect(return_url)
 


### PR DESCRIPTION
this will work for apps located at places other than the server root
