### PR TITLE
Allow custom _id value type in mongoengine backend

### DIFF
--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -84,6 +84,22 @@ class ModelView(BaseModelView):
                 model_form_converter = MyModelConverter
     """
 
+    object_id_converter = ObjectId
+    """
+        Mongodb ``_id`` value conversion function. Default is `bson.ObjectId`.
+        Use this if you are using String, Binary and etc.
+
+        For example::
+
+            class MyModelView(BaseModelView):
+                object_id_converter = int
+
+        or::
+
+            class MyModelView(BaseModelView):
+                object_id_converter = str
+    """
+
     filter_converter = FilterConverter()
     """
         Field to filter converter.
@@ -549,7 +565,7 @@ class ModelView(BaseModelView):
 
         fs = gridfs.GridFS(get_db(db), coll)
 
-        data = fs.get(ObjectId(pk))
+        data = fs.get(self.object_id_converter(pk))
         if not data:
             abort(404)
 
@@ -574,7 +590,7 @@ class ModelView(BaseModelView):
         try:
             count = 0
 
-            all_ids = [ObjectId(pk) for pk in ids]
+            all_ids = [self.object_id_converter(pk) for pk in ids]
             for obj in self.get_query().in_bulk(all_ids).values():
                 count += self.delete_model(obj)
 


### PR DESCRIPTION
By default, the _id type converter is `bson.ObjectId`, If using integer type, when delete a document through selecting a checkbox way, it will fail with a `bson.errors.InvalidId` exception.

So it's better let developer custom a converter to convert the type.

Silimiar to #217 for pymongo backend.
