### PR TITLE
Display foreign keys when explicitly instructed

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -156,8 +156,10 @@ class AdminModelConverter(ModelConverterBase):
                     # Grab column
                     column = prop.columns[0]
 
-                # Do not display foreign keys - use relations
-                if column.foreign_keys:
+                form_columns = getattr(self.view, 'form_columns', None) or ()
+
+                # Do not display foreign keys - use relations, except when explicitly instructed
+                if column.foreign_keys and prop.key not in form_columns:
                     return None
 
                 # Only display "real" columns
@@ -172,11 +174,6 @@ class AdminModelConverter(ModelConverterBase):
                         return fields.HiddenField()
                     else:
                         # By default, don't show primary keys either
-                        form_columns = getattr(self.view, 'form_columns', None)
-
-                        if form_columns is None:
-                            return None
-
                         # If PK is not explicitly allowed, ignore it
                         if prop.key not in form_columns:
                             return None


### PR DESCRIPTION
given the following situation

``` python
GENERAL, TYPE1 = range(2)


class SomeGeneralType(Base):
    __tablename__ = "some_general_table"
    id = Column(Unicode(255), primary_key=True)
    type = Column(Integer, nullable=False)
    __mapper_args__ = {
        "polymorphic_on": type,
        "polymorphic_identity": GENERAL,
    }

class Type1(SomeGeneralType):
    __tablename__ = "table1"
    id = Column(ForeignKey(SomeGeneralType.id), primary_key=True)
    __mapper_args__ = {
        "polymorphic_identity": TYPE1,
    }
```

since the ID is not auto-generated, user must to input it but it's also a foreign key and will be skipped before the patch.

And, some time there is just a foreign key without relationship defined... which is what I'm experiencing...

maybe also add a validator?
