### PR TITLE
use unicode arrows in table column header

### DIFF
--- a/flask_admin/templates/admin/model/list.html
+++ b/flask_admin/templates/admin/model/list.html
@@ -65,14 +65,7 @@
                     <th>
                         {% if admin_view.is_sortable(c) %}
                             {% if sort_column == column %}
-                                <a href="{{ sort_url(column, True) }}">
-                                    {{ name }}
-                                    {% if sort_desc %}
-                                        <i class="icon-chevron-up"></i>
-                                    {% else %}
-                                        <i class="icon-chevron-down"></i>
-                                    {% endif %}
-                                </a>
+                                <a href="{{ sort_url(column, True) }}">{{ name }}</a><span class="arrow">{{ '↑' if sort_desc else '↓' }}</span>
                             {% else %}
                                 <a href="{{ sort_url(column) }}">{{ name }}</a>
                             {% endif %}


### PR DESCRIPTION
Replace the sort arrows image to unicode character, so we can stye them with css, and use other icon-set which not provide them with the same name.

Priview

![selection_002](https://f.cloud.github.com/assets/330812/1680363/f0457de0-5d74-11e3-9ad5-ecf44aa79cdb.png)
