### PR TITLE
move buttons to the bottom of the filter form

### DIFF
--- a/flask_admin/templates/admin/model/layout.html
+++ b/flask_admin/templates/admin/model/layout.html
@@ -13,12 +13,6 @@
 
 {% macro filter_form() %}
     <form id="filter_form" method="GET" action="{{ return_url }}">
-        <div class="pull-right">
-            <button type="submit" class="btn btn-primary" style="display: none">{{ _gettext('Apply') }}</button>
-            {% if active_filters %}
-            <a href="{{ clear_search_url }}" class="btn">{{ _gettext('Reset Filters') }}</a>
-            {% endif %}
-        </div>
 
         <table class="filters">
             {%- for i, flt in enumerate(active_filters) -%}
@@ -51,6 +45,13 @@
             </tr>
             {% endfor %}
         </table>
+
+        <div class="actions">
+            <button type="submit" class="btn btn-primary" style="display: none">{{ _gettext('Apply') }}</button>
+            {% if active_filters %}
+            <a href="{{ clear_search_url }}" class="btn">{{ _gettext('Reset Filters') }}</a>
+            {% endif %}
+        </div>
     </form>
     <div class="clearfix"></div>
 {% endmacro %}


### PR DESCRIPTION
The apply/reset button of the filter form, they float right on the window, it is too far away from the filter-fields-area. Especially when using wide-screen monitor.

 It look better if we put them below the filter-fields-area.

Preview

![selection_003](https://f.cloud.github.com/assets/330812/1680731/1e5fd8da-5d82-11e3-83d6-b5c193f7277a.png)
