### PR TITLE
move the required-mark on right

### DIFF
--- a/flask_admin/static/admin/css/admin.css
+++ b/flask_admin/static/admin/css/admin.css
@@ -87,12 +87,17 @@ table.filters {
 /* Forms */
 .form-horizontal .control-label {
     width: 100px;
-    text-align: left;
-    margin-left: 4px;
+    text-align: right;
+    margin-right: 20px;
+    font-weight: bold;
 }
 
 .form-horizontal .controls {
     margin-left: 110px;
+}
+
+.form-horizontal .required-mark {
+    color: red;
 }
 
 /* Inline forms */

--- a/flask_admin/templates/admin/lib.html
+++ b/flask_admin/templates/admin/lib.html
@@ -79,17 +79,14 @@
   {% set direct_error = h.is_field_error(field.errors) %}
   <div class="control-group{{ ' error' if direct_error else '' }}">
     <div class="control-label">
-      <label for="{{ field.id }}">{{ field.label.text }}
-          {% if h.is_required_form_field(field) %}
-            <strong style="color: red">&#42;</strong>
-          {%- else -%}
-            &nbsp;
-          {%- endif %}
-      </label>
+      <label for="{{ field.id }}">{{ field.label.text }}</label>
     </div>
     <div class="controls">
     <div>
       {{ field(**kwargs)|safe }}
+      {% if h.is_required_form_field(field) %}
+        <span class="required-mark">&#42;</span>
+      {% endif %}
     </div>
     {% if field.description %}
     <p class="help-block">{{ field.description }}</p>


### PR DESCRIPTION
Move the required-mark on the right side of the input-field, and make it more semantic, easily style it with css. 

Then the label can right-align, make it close to the input field.

![selection_004](https://f.cloud.github.com/assets/330812/1681032/72edb2f2-5d8a-11e3-97da-24fdd9710d22.png)
