### PR TITLE
Fix compat for CPython/PyPy 2.x

### DIFF
--- a/flask_admin/_compat.py
+++ b/flask_admin/_compat.py
@@ -49,7 +49,7 @@ else:
         return unicode(s)
 
     # Helpers
-    reduce = __builtins__.reduce
+    reduce = __builtins__['reduce'] if isinstance(__builtins__, dict) else __builtins__.reduce
     from urlparse import urljoin
 
 


### PR DESCRIPTION
`__builtins__` should be accessed as a module, not a dict.
