### PR TITLE
Do not enforce github ribbon over http

### DIFF
--- a/doc/_templates/sidebarintro.html
+++ b/doc/_templates/sidebarintro.html
@@ -5,4 +5,4 @@
 </ul>
 
 <a href="http://github.com/mrjoes/flask-admin"><img style="position: fixed; top: 0; right: 0; border: 0;"
-   src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+   src="//s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>


### PR DESCRIPTION
Docs in readthedocs run over https and Chrome recognize the ribbon as unsafe content.
