### PR TITLE
Use `send_file` instead of `send_from_directory` to serve files in FileAdmin

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -7,7 +7,7 @@ import shutil
 from operator import itemgetter
 from werkzeug import secure_filename
 
-from flask import flash, url_for, redirect, abort, request, send_from_directory
+from flask import flash, url_for, redirect, abort, request, send_file
 
 from wtforms import fields, validators
 
@@ -526,7 +526,7 @@ class FileAdmin(BaseView, ActionsMixin):
             base_url = urljoin(url_for('.index'), base_url)
             return redirect(urljoin(base_url, path))
 
-        return send_from_directory(base_path, path)
+        return send_file(directory)
 
     @expose('/mkdir/', methods=('GET', 'POST'))
     @expose('/mkdir/<path:path>', methods=('GET', 'POST'))


### PR DESCRIPTION
The path is already validated in `_normalize_path`. Also, `send_from_directory` abort paths with backslash, breaking FileAdmin subfolders in Windows.

With `send_file`, we have a minor issue with the download URL, it has path with backslash, but `_normalize_path` fix this before download.
