### PR TITLE
Don't use column name for pk

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -31,7 +31,7 @@ def get_primary_key(model):
                 if is_inherited_primary_key(p):
                     pks.append(get_column_for_current_model(p).key)
                 else:
-                    pks.append(p.columns[0].key)
+                    pks.append(p.key)
     if len(pks) == 1:
         return pks[0]
     elif len(pks) > 1:


### PR DESCRIPTION
Gets the attribute name of the model's pk column, rather than the
column's name (which can differ).

This probably needs to happen for inherited keys, too, but I have not
tested.
