### PR TITLE
Missing "op" alias for os.path

### DIFF
--- a/examples/layout/simple.py
+++ b/examples/layout/simple.py
@@ -1,4 +1,5 @@
 import os
+import os.path as op
 from flask import Flask
 from flask.ext.sqlalchemy import SQLAlchemy
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "simple.py", line 142, in <module>
    app_dir = op.realpath(os.path.dirname(**file**))
NameError: name 'op' is not defined
