### PR TITLE
Save form_overrides into CustomModelConverter, to fix #421, in conjunction with https://github.com/coleifer/wtf-peewee/pull/20

### DIFF
--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -90,6 +90,8 @@ class CustomModelConverter(ModelConverter):
         self.converters[DateField] = self.handle_date
         self.converters[TimeField] = self.handle_time
 
+        self.overrides = getattr(self.view, 'form_overrides', None) or {}
+
     def handle_foreign_key(self, model, field, **kwargs):
         loader = getattr(self.view, '_form_ajax_refs', {}).get(field.name)
 


### PR DESCRIPTION
I've taken the path of adding most of the necessary to wtf-peewee, because that's where the functionality seems to fit best (to avoid having to duplicate a big function from wtf-peewee).

This change is backwards-compatible so that old code will work with this flask-admin change, even without having to update the wtf-peewee version.

Refer https://github.com/coleifer/wtf-peewee/issues/18 and https://github.com/coleifer/wtf-peewee/pull/20 and https://github.com/mrjoes/flask-admin/issues/421
