### PR TITLE
SQL alchemy Unique validator allows multiple None values

### DIFF
--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -24,6 +24,10 @@ class Unique(object):
         self.message = message
 
     def __call__(self, form, field):
+        # databases allow multiple NULL values for unique columns
+        if field.data is None:
+            return
+
         try:
             obj = (self.db_session.query(self.model)
                    .filter(self.column == field.data)


### PR DESCRIPTION
Databases with unique column constraints allow multiple rows with NULL values. So emulate this behaviour in the Unique validator.
