### PR TITLE
Added datepicker.css to the base template's head

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/base.html
+++ b/flask_admin/templates/bootstrap2/admin/base.html
@@ -12,6 +12,7 @@
     {% block head_css %}
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap2/css/bootstrap.css') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap2/css/bootstrap-responsive.css') }}" rel="stylesheet">
+        <link href="{{ admin_static.url(filename='datetimepicker/bootstrap-datetimepicker.css') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='admin/css/bootstrap2/admin.css') }}" rel="stylesheet">
     {% endblock %}
     {% block head %}


### PR DESCRIPTION
Datepicker form field widget lacked proper styling, so I added link to 'bootstrap-datetimepicker.css' in the base template <head> section.
