### PR TITLE
fix the filter_groups keys non-string BUG

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -14,7 +14,7 @@ from flask.ext.admin.actions import ActionsMixin
 from flask.ext.admin.helpers import get_form_data, validate_form_on_submit, get_redirect_target
 from flask.ext.admin.tools import rec_getattr
 from flask.ext.admin._backwards import ObsoleteAttr
-from flask.ext.admin._compat import iteritems, OrderedDict
+from flask.ext.admin._compat import iteritems, OrderedDict, as_unicode
 from .helpers import prettify_name, get_mdict_item_or_list
 from .ajax import AjaxModelLoader
 
@@ -1076,6 +1076,11 @@ class BaseModelView(BaseView, ActionsMixin):
             Get unformatted field value from the model
         """
         return rec_getattr(model, name)
+    def _get_filter_dict(self):
+        """
+            Return flattened filter dictionary which can be JSON-serialized.
+        """
+            return OrderedDict((as_unicode(k), v) for k, v in iteritems(self._filter_groups))
 
     @contextfunction
     def get_list_value(self, context, model, name):

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1080,7 +1080,7 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             Return flattened filter dictionary which can be JSON-serialized.
         """
-            return OrderedDict((as_unicode(k), v) for k, v in iteritems(self._filter_groups))
+        return OrderedDict((as_unicode(k), v) for k, v in iteritems(self._filter_groups))
 
     @contextfunction
     def get_list_value(self, context, model, name):

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1076,7 +1076,7 @@ class BaseModelView(BaseView, ActionsMixin):
             Get unformatted field value from the model
         """
         return rec_getattr(model, name)
-    def _get_filter_dict(self):
+    def _get_filter_groups(self):
         """
             Return flattened filter dictionary which can be JSON-serialized.
         """

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -162,7 +162,7 @@
             {% if filter_groups %}
                 var filter = new AdminFilters(
                     '#filter_form', '.field-filters',
-                    {{ admin_view._get_filter_dict()|tojson|safe }}
+                    {{ admin_view._get_filter_groups()|tojson|safe }}
                 );
             {% endif %}
         })(jQuery);

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -162,7 +162,7 @@
             {% if filter_groups %}
                 var filter = new AdminFilters(
                     '#filter_form', '.field-filters',
-                    {{ filter_groups|tojson|safe }}
+                    {{ admin_view._get_filter_dict()|tojson|safe }}
                 );
             {% endif %}
         })(jQuery);

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -162,7 +162,7 @@
             {% if filter_groups %}
                 var filter = new AdminFilters(
                     '#filter_form', '.field-filters',
-                    {{ admin_view._get_filter_dict()|tojson|safe }}
+                    {{ admin_view._get_filter_groups()|tojson|safe }}
                 );
             {% endif %}
         })(jQuery);

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -162,7 +162,7 @@
             {% if filter_groups %}
                 var filter = new AdminFilters(
                     '#filter_form', '.field-filters',
-                    {{ filter_groups|tojson|safe }}
+                    {{ admin_view._get_filter_dict()|tojson|safe }}
                 );
             {% endif %}
         })(jQuery);


### PR DESCRIPTION
I met the same problem as issue [#245](https://github.com/mrjoes/flask-admin/issues/245), and I notice the fix. But the new 'filter_groups' stuff in commit [d851c420019df6212d576f31301519cfb12104dc](https://github.com/mrjoes/flask-admin/commit/d851c420019df6212d576f31301519cfb12104dc) seems did nothing to it's non-string keys for 'tojson' function in the [template/admin/model/list.html ](https://github.com/mrjoes/flask-admin/blob/master/flask_admin/templates/bootstrap3/admin/model/list.html).

this is my PR based on the previous fix, hope you can find a better way to solve this, Thanks.