### PR TITLE
A proposal to fix https://github.com/mrjoes/flask-admin/issues/532

### DIFF
--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -392,7 +392,7 @@ class ImageUploadField(FileUploadField):
             self._save_image(image, self._get_path(filename), format)
         else:
             data.seek(0)
-            data.save(path)
+            data.save( self._get_path(filename) )
 
         self._save_thumbnail(data, filename, format)
 


### PR DESCRIPTION
From the issue:

If an image extension is 'jpeg' (not 'jpg'), then inside
ImageUploadField._save_file() the call to self._get_save_format() enters
the if-statement where the filename is changed to ${name}.jpg. The
format stays unchanged, though, because it's the same 'JPEG'. As a
result, the original filename is preserved on disk, which is
${name}.jpeg, but _save_file() returns ${name}.jpg.

self._save_thumbnail(data, filename, format) saves the thumbnail file
under ${name}_thumb.jpg

At the time when ImageUploadField._save_file() is finished, two files
are created:

${name}.jpeg
${name}_thumb.jpg
Would you consider changing

def _save_file(self, data, filename):
...
data.save(path)

to
data.save( self._get_path(filename) )

In that case the original image will be saved with the updated filename
after self._get_save_format(filename, self.image)
