### PR TITLE
Change bool_formatter() to be backward compatible with bootstrap2

### DIFF
--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -30,7 +30,7 @@ def bool_formatter(view, value):
             Value to check
     """
     glyph = 'ok-circle' if value else 'minus-sign'
-    return Markup('<span class="glyphicon glyphicon-%s"></span>' % glyph)
+    return Markup('<span class="glyphicon glyphicon-%s icon-%s"></span>' % (glyph, glyph))
 
 
 def list_formatter(view, values):


### PR DESCRIPTION
Just a little fix to make icons in bootstrap2 mode show again. Well, maybe it's a good idea to write something more complex to distinguish between 2 and 3, but I don't think so.

P.S. I am quite a newbie, so please tell me if I do something wrong.
