### PR TITLE
add varchar to is_text_column_type

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -427,12 +427,12 @@ class ModelView(BaseModelView):
             Verify if the provided column type is text-based.
 
             :returns:
-                ``True`` for ``String``, ``Unicode``, ``Text``, ``UnicodeText``
+                ``True`` for ``String``, ``Unicode``, ``Text``, ``UnicodeText``, ``varchar``
         """
         if name:
             name = name.lower()
 
-        return name in ('string', 'unicode', 'text', 'unicodetext')
+        return name in ('string', 'unicode', 'text', 'unicodetext', 'varchar')
 
     def scaffold_filters(self, name):
         """


### PR DESCRIPTION
This resolves an issue I was having with Flask-Admin not detecting a varchar column as a text column. 

Resulting in the following error:

```
Exception: Can only search on text columns. Failed to setup search for "Site"
```
