### PR TITLE
added a dependency which made it hard to import ModelView

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.7',
-        'wtforms<2.0'
+        'wtforms<2.0',
+	'python-dateutil'
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
When I tried to do `from flask.ext.admin.contrib.sqla import ModelView`, it inevitably lead to a traceback. Found out all that had to be done was to install python-dateutil.

Never done a pull request on github before so not quite sure what else to say.
