### PR TITLE
update render_field macro to accept a caller if desired

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -77,7 +77,7 @@
 {%- endmacro %}
 
 {# ---------------------- Forms -------------------------- #}
-{% macro render_field(form, field, kwargs={}) %}
+{% macro render_field(form, field, kwargs={}, caller=None) %}
   {% set direct_error = h.is_field_error(field.errors) %}
   <div class="control-group{{ ' error' if direct_error else '' }}">
     <div class="control-label">
@@ -104,6 +104,9 @@
       </ul>
     {% endif %}
     </div>
+    {% if caller %}
+      {{ caller(form, field, direct_error, kwargs) }}
+    {% endif %}
   </div>
 {% endmacro %}
 

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -75,7 +75,7 @@
 {%- endmacro %}
 
 {# ---------------------- Forms -------------------------- #}
-{% macro render_field(form, field, kwargs={}) %}
+{% macro render_field(form, field, kwargs={}, caller=None) %}
   {% set direct_error = h.is_field_error(field.errors) %}
   <div class="form-group{{ ' error' if direct_error else '' }}">
     <label for="{{ field.id }}" class="col-md-2 control-label">{{ field.label.text }}
@@ -98,6 +98,9 @@
         <li>{{ e }}</li>
       {% endfor %}
       </ul>
+    {% endif %}
+    {% if caller %}
+      {{ caller(form, field, direct_error, kwargs) }}
     {% endif %}
   </div>
 {% endmacro %}


### PR DESCRIPTION
This makes it possible to create a new macro which can utilize the existing macro, but can hook in within the "form-group"/"control-group" div, e.g.

``````
{% macro render_image_field(form, field, kwargs={}) %}
  {% call(form, field, direct_error, kwargs) admin_lib.render_field(form, field, kwargs) %}
    {% if field.data and not direct_error %}
      <div class="col-md-4">
        <img src="{{ field.data }}" class="img-profile">
      </div>
    {% endif %}
  {% endcall %}
{% endmacro %}
```.
Also, by setting `caller=None` as default, it is fully backwards compatible.
``````
