### PR TITLE
Prevent black space after last filter is removed

### DIFF
--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -31,7 +31,7 @@ var AdminFilters = function(element, filtersElement, filterGroups) {
         $(this).closest('tr').remove();
         if($('.filters tr').length == 0) {
             $('button', $root).hide();
-            $('#filter_form div a').hide();
+            $('a[class=btn]', $root).hide();
             $('.filters tbody').remove();
         } else {
             $('button', $root).show();


### PR DESCRIPTION
Fixes this blank space which is left after the last filter is removed:
![filters](https://cloud.githubusercontent.com/assets/992533/3723624/3ed7b20c-1675-11e4-8883-868e503391a8.png)

The `table.filters:not(:empty)` styling does not work because tbody is left over after all the filters are removed. This fix also removes tbody when there are no filters left.
