### PR TITLE
Add on_form_prefill hook to BaseModelView

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1330,7 +1330,8 @@ class BaseModelView(BaseView, ActionsMixin):
                 else:
                     return redirect(return_url)
 
-        self.on_form_prefill(form, id)
+        if request.method == 'GET':
+            self.on_form_prefill(form, id)
         
         form_opts = FormOpts(widget_args=self.form_widget_args,
                              form_rules=self._form_edit_rules)


### PR DESCRIPTION
This is a solution for custom edit form fields that need to be pre-populated from the database in a way that Flask-Admin cannot figure out by itself. My personal use case is explained [over here](http://stackoverflow.com/questions/24808028/how-to-handle-ordered-many-to-many-relationship-association-proxy-in-flask-adm).
