### PR TITLE
Correct format_errors for nested dictionaries

### DIFF
--- a/flask_admin/contrib/mongoengine/helpers.py
+++ b/flask_admin/contrib/mongoengine/helpers.py
@@ -31,6 +31,11 @@ def make_thumb_args(value):
 
 def format_error(error):
     if isinstance(error, ValidationError):
-        return '. '.join(itervalues(error.to_dict()))
-
+        resp = ''
+        for v in error.to_dict().values():
+            if isinstance(v, dict):
+                resp += str(v.values())
+            else:
+                resp += str(v)
+                
     return as_unicode(error)


### PR DESCRIPTION
In the case of errors on EmbeddedDocuments, the format_errors() function had
an exception due to the error being returned as a dictionary, instead of a
string.