### PR TITLE
Exception: Unsupported filter type (tinyint)

### DIFF
--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -104,7 +104,7 @@ class FilterConverter(filters.BaseFilterConverter):
     def conv_string(self, column, name, **kwargs):
         return [f(column, name, **kwargs) for f in self.strings]
 
-    @filters.convert('boolean')
+    @filters.convert('boolean', 'tinyint')
     def conv_bool(self, column, name, **kwargs):
         return [f(column, name, **kwargs) for f in self.bool]
 


### PR DESCRIPTION
Tinyint is one of the possibilities when sqlalchemy reflects an existing table. In mysql, it's used in place of the boolean type. When flask-admin tries to apply a filter to it, it throws the unsupported filter type error.

I tried this and the boolean converter seems to work just fine on tinyints.
