### PR TITLE
fix greater/smaller filters for pymongo

### DIFF
--- a/flask_admin/contrib/pymongo/filters.py
+++ b/flask_admin/contrib/pymongo/filters.py
@@ -69,6 +69,10 @@ class FilterNotLike(BasePyMongoFilter):
 
 class FilterGreater(BasePyMongoFilter):
     def apply(self, query, value):
+        try:
+            value = float(value)
+        except ValueError:
+            value = 0
         query.append({self.column: {'$gt': value}})
         return query
 
@@ -78,6 +82,10 @@ class FilterGreater(BasePyMongoFilter):
 
 class FilterSmaller(BasePyMongoFilter):
     def apply(self, query, value):
+        try:
+            value = float(value)
+        except ValueError:
+            value = 0
         query.append({self.column: {'$lt': value}})
         return query
 


### PR DESCRIPTION
filter never worked, because value is passed as string and mongodb returns zero documents
