### PR TITLE
Fix #672 BUG for InlineModelFormList with two primary keys

### DIFF
--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -272,11 +272,11 @@ class InlineModelFormList(InlineFieldList):
             return
 
         # Create primary key map
-        pk_map = dict((str(getattr(v, self._pk)), v) for v in values)
+        pk_map = dict((get_obj_pk(v, self._pk), v) for v in values)
 
         # Handle request data
         for field in self.entries:
-            field_id = field.get_pk()
+            field_id = get_field_id(field)
 
             is_created = field_id not in pk_map
             if not is_created:
@@ -298,3 +298,27 @@ def get_pk_from_identity(obj):
     # TODO: Remove me
     cls, key = identity_key(instance=obj)
     return u':'.join(text_type(x) for x in key)
+
+
+def get_obj_pk(obj, pk):
+    """
+    get and format pk from obj
+    :rtype: text_type
+    """
+
+    if isinstance(pk, tuple):
+        return tuple(text_type(getattr(obj, k)) for k in pk)
+
+    return text_type(getattr(obj, pk))
+
+
+def get_field_id(field):
+    """
+    get and format id from field
+    :rtype: text_type
+    """
+    field_id = field.get_pk()
+    if isinstance(field_id, tuple):
+        return tuple(text_type(_) for _ in field_id)
+
+    return text_type(field_id)

--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -118,6 +118,10 @@ class InlineModelFormField(FormField):
         self.form_opts = form_opts
 
     def get_pk(self):
+
+        if isinstance(self._pk, (tuple, list)):
+            return tuple(getattr(self.form, pk).data for pk in self._pk)
+
         return getattr(self.form, self._pk).data
 
     def populate_obj(self, obj, name):


### PR DESCRIPTION
the type of primary of model with two or more primary keys is tuple, which is different from that of models with one primary.
InlineModelFormField and InlineModelFormList can only work with str type primary key.
