### PR TITLE
Fix incorrect usage of NotImplemented constant

### DIFF
--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -96,7 +96,7 @@ class ModelView(BaseModelView):
         """
             Scaffold list columns
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def scaffold_sortable_columns(self):
         """
@@ -126,7 +126,7 @@ class ModelView(BaseModelView):
             :param name:
                 Either field name or field instance
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def is_valid_filter(self, filter):
         """
@@ -138,7 +138,7 @@ class ModelView(BaseModelView):
         return isinstance(filter, BasePyMongoFilter)
 
     def scaffold_form(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def _get_field_value(self, model, name):
         """

--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -25,7 +25,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
 
         primary_keys = model._sa_class_manager.mapper.primary_key
         if len(primary_keys) > 1:
-            raise NotImplemented('Flask-Admin does not support multi-pk AJAX model loading.')
+            raise NotImplementedError('Flask-Admin does not support multi-pk AJAX model loading.')
 
         self.pk = primary_keys[0].name
 

--- a/flask_admin/form/rules.py
+++ b/flask_admin/form/rules.py
@@ -36,7 +36,7 @@ class BaseRule(object):
             :param field_args:
                 Optional arguments that should be passed to template or the field
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class NestedRule(BaseRule):

--- a/flask_admin/menu.py
+++ b/flask_admin/menu.py
@@ -20,7 +20,7 @@ class BaseMenu(object):
         self._children.append(menu)
 
     def get_url(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def is_category(self):
         return False

--- a/flask_admin/model/ajax.py
+++ b/flask_admin/model/ajax.py
@@ -19,7 +19,7 @@ class AjaxModelLoader(object):
         """
             Return (id, name) tuple from the model.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def get_one(self, pk):
         """
@@ -28,7 +28,7 @@ class AjaxModelLoader(object):
             :param pk:
                 Primary key value
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def get_list(self, query, offset=0, limit=DEFAULT_PAGE_SIZE):
         """
@@ -43,4 +43,4 @@ class AjaxModelLoader(object):
             :param limit:
                 Limit
         """
-        raise NotImplemented()
+        raise NotImplementedError()

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -667,7 +667,7 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             Return PK value from a model object.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     # List view
     def scaffold_list_columns(self):
@@ -680,7 +680,7 @@ class BaseModelView(BaseView, ActionsMixin):
 
                 ['name', 'first_name', 'last_name']
         """
-        raise NotImplemented('Please implement scaffold_list_columns method')
+        raise NotImplementedError('Please implement scaffold_list_columns method')
 
     def get_column_name(self, field):
         """
@@ -719,7 +719,7 @@ class BaseModelView(BaseView, ActionsMixin):
             Expected return format is a dictionary, where keys are field names and
             values are property names.
         """
-        raise NotImplemented('Please implement scaffold_sortable_columns method')
+        raise NotImplementedError('Please implement scaffold_sortable_columns method')
 
     def get_sortable_columns(self):
         """
@@ -820,7 +820,7 @@ class BaseModelView(BaseView, ActionsMixin):
             Create `form.BaseForm` inherited class from the model. Must be
             implemented in the child class.
         """
-        raise NotImplemented('Please implement scaffold_form method')
+        raise NotImplementedError('Please implement scaffold_form method')
 
     def get_form(self):
         """
@@ -927,7 +927,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 List of filter tuples. First value in a tuple is a search
                 index, second value is a search value.
         """
-        raise NotImplemented('Please implement get_list method')
+        raise NotImplementedError('Please implement get_list method')
 
     def get_one(self, id):
         """
@@ -938,7 +938,7 @@ class BaseModelView(BaseView, ActionsMixin):
             :param id:
                 Model id
         """
-        raise NotImplemented('Please implement get_one method')
+        raise NotImplementedError('Please implement get_one method')
 
     # Exception handler
     def handle_view_exception(self, exc):
@@ -1046,7 +1046,7 @@ class BaseModelView(BaseView, ActionsMixin):
             :param form:
                 Form instance
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def update_model(self, form, model):
         """
@@ -1061,7 +1061,7 @@ class BaseModelView(BaseView, ActionsMixin):
             :param model:
                 Model instance
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def delete_model(self, model):
         """
@@ -1074,7 +1074,7 @@ class BaseModelView(BaseView, ActionsMixin):
             :param model:
                 Model instance
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     # Various helpers
     def _prettify_name(self, name):
@@ -1222,7 +1222,7 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             Model backend will override this to implement AJAX model loading.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     # Views
     @expose('/')

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -67,7 +67,7 @@ class BaseFilter(object):
             :param query:
                 Query
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def operation(self):
         """
@@ -75,7 +75,7 @@ class BaseFilter(object):
 
             For example: u'equals'
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __unicode__(self):
         return self.name

--- a/flask_admin/model/form.py
+++ b/flask_admin/model/form.py
@@ -135,7 +135,7 @@ class ModelConverterBase(object):
     def get_form(self, model, base_class=BaseForm,
                  only=None, exclude=None,
                  field_args=None):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class InlineModelConverterBase(object):


### PR DESCRIPTION
Code in the form `raise NotImplemented()` appears in several places in the code base.

[`NotImplemented`](https://docs.python.org/2/library/constants.html#NotImplemented) is a constant singleton used in rich comparison
overloading. It is not callable, and is not an exception.

[`NotImplementedError`](https://docs.python.org/2/library/exceptions.html#exceptions.NotImplementedError) is a built in exception, and is what you probably meant to use.
