### PR TITLE
Use the latest version of wtforms in testing

### DIFF
--- a/travis.txt
+++ b/travis.txt
@@ -1,5 +1,5 @@
 Flask>=0.7
-wtforms<2.0
+wtforms
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee


### PR DESCRIPTION
Some tests seem to be failing with the latest version of wtforms. I don't expect this PR to be merged until the tests are passing, but I wanted to submit the PR now to make people aware of this problem.
