### PR TITLE
fix mongoengine and peewee exceptions when filtering for non-integer values

### DIFF
--- a/flask_admin/contrib/peewee/filters.py
+++ b/flask_admin/contrib/peewee/filters.py
@@ -123,6 +123,54 @@ class BooleanNotEqualFilter(FilterNotEqual, filters.BaseBooleanFilter):
     pass
     
 
+class IntEqualFilter(FilterEqual, filters.BaseIntFilter):
+    pass
+    
+
+class IntNotEqualFilter(FilterNotEqual, filters.BaseIntFilter):
+    pass
+    
+
+class IntGreaterFilter(FilterGreater, filters.BaseIntFilter):
+    pass
+    
+
+class IntSmallerFilter(FilterSmaller, filters.BaseIntFilter):
+    pass
+    
+
+class IntInListFilter(FilterInList, filters.BaseIntListFilter):
+    pass
+    
+
+class IntNotInListFilter(FilterNotInList, filters.BaseIntListFilter):
+    pass
+    
+
+class FloatEqualFilter(FilterEqual, filters.BaseFloatFilter):
+    pass
+    
+
+class FloatNotEqualFilter(FilterNotEqual, filters.BaseFloatFilter):
+    pass
+    
+
+class FloatGreaterFilter(FilterGreater, filters.BaseFloatFilter):
+    pass
+    
+
+class FloatSmallerFilter(FilterSmaller, filters.BaseFloatFilter):
+    pass
+    
+
+class FloatInListFilter(FilterInList, filters.BaseFloatListFilter):
+    pass
+    
+
+class FloatNotInListFilter(FilterNotInList, filters.BaseFloatListFilter):
+    pass
+    
+
 class DateEqualFilter(FilterEqual, filters.BaseDateFilter):
     pass
     
@@ -139,31 +187,16 @@ class DateSmallerFilter(FilterSmaller, filters.BaseDateFilter):
     pass
     
 
-class DateBetweenFilter(BasePeeweeFilter):
+class DateBetweenFilter(BasePeeweeFilter, filters.BaseDateBetweenFilter):
     def __init__(self, column, name, options=None, data_type=None):
-        super(DateBetweenFilter, self).__init__(column, name, options, data_type='daterangepicker')
-        
-    def clean(self, value):
-        return [datetime.datetime.strptime(range, '%Y-%m-%d') for range in value.split(' to ')]
-
+        super(DateBetweenFilter, self).__init__(column,
+                                                name, 
+                                                options,
+                                                data_type='daterangepicker')
+                                                
     def apply(self, query, value):
         start, end = value
-        return query.filter(self.column.between(start, end))
-
-    def operation(self):
-        return lazy_gettext('between')
-
-    def validate(self, value):
-        try:
-            value = [datetime.datetime.strptime(range, '%Y-%m-%d') for range in value.split(' to ')]
-            # if " to " is missing, fail validation
-            # if end date is before start date, fail validation
-            if (len(value) == 2) and (value[0] <= value[1]):
-                return True
-            else:
-                return False
-        except ValueError:
-            return False        
+        return query.filter(self.column.between(start, end))   
         
 
 class DateNotBetweenFilter(DateBetweenFilter):
@@ -191,29 +224,16 @@ class DateTimeSmallerFilter(FilterSmaller, filters.BaseDateTimeFilter):
     pass
         
 
-class DateTimeBetweenFilter(BasePeeweeFilter):
+class DateTimeBetweenFilter(BasePeeweeFilter, filters.BaseDateTimeBetweenFilter):
     def __init__(self, column, name, options=None, data_type=None):
-        super(DateTimeBetweenFilter, self).__init__(column, name, options, data_type='datetimerangepicker')
-        
-    def clean(self, value):
-        return [datetime.datetime.strptime(range, '%Y-%m-%d %H:%M:%S') for range in value.split(' to ')]
-        
+        super(DateTimeBetweenFilter, self).__init__(column,
+                                                    name, 
+                                                    options,
+                                                    data_type='datetimerangepicker')
+                                                    
     def apply(self, query, value):
         start, end = value
         return query.filter(self.column.between(start, end))
-    
-    def operation(self):
-        return lazy_gettext('between')
-        
-    def validate(self, value):
-        try:
-            value = [datetime.datetime.strptime(range, '%Y-%m-%d %H:%M:%S') for range in value.split(' to ')]
-            if (len(value) == 2) and (value[0] <= value[1]):
-                return True
-            else:
-                return False
-        except ValueError:
-            return False
             
 
 class DateTimeNotBetweenFilter(DateTimeBetweenFilter):
@@ -241,36 +261,16 @@ class TimeSmallerFilter(FilterSmaller, filters.BaseTimeFilter):
     pass
     
 
-class TimeBetweenFilter(BasePeeweeFilter):
+class TimeBetweenFilter(BasePeeweeFilter, filters.BaseTimeBetweenFilter):
     def __init__(self, column, name, options=None, data_type=None):
-        super(TimeBetweenFilter, self).__init__(column, name, options, data_type='timerangepicker')
-        
-    def clean(self, value):
-        timetuples = [time.strptime(range, '%H:%M:%S') 
-                      for range in value.split(' to ')]
-        return [datetime.time(timetuple.tm_hour,
-                              timetuple.tm_min,
-                              timetuple.tm_sec)
-                              for timetuple in timetuples]
-                              
+        super(TimeBetweenFilter, self).__init__(column,
+                                                name, 
+                                                options,
+                                                data_type='timerangepicker')
+                                                
     def apply(self, query, value):
         start, end = value
         return query.filter(self.column.between(start, end))
-
-    def operation(self):
-        return lazy_gettext('between')
-
-    def validate(self, value):
-        try:
-            timetuples = [time.strptime(range, '%H:%M:%S') 
-                          for range in value.split(' to ')]
-            if (len(timetuples) == 2) and (timetuples[0] <= timetuples[1]):
-                return True
-            else:
-                return False
-        except ValueError:
-            raise
-            return False
         
 
 class TimeNotBetweenFilter(TimeBetweenFilter):
@@ -284,16 +284,25 @@ class TimeNotBetweenFilter(TimeBetweenFilter):
         
 # Base peewee filter field converter
 class FilterConverter(filters.BaseFilterConverter):
-    strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike, FilterEmpty, FilterInList, FilterNotInList)
-    numeric = (FilterEqual, FilterNotEqual, FilterGreater, FilterSmaller, FilterEmpty, FilterInList, FilterNotInList)
-    bool = (BooleanEqualFilter, BooleanNotEqualFilter)
-    date_filters = (DateEqualFilter, DateNotEqualFilter, DateGreaterFilter, DateSmallerFilter, 
-            DateBetweenFilter, DateNotBetweenFilter, FilterEmpty)
-    datetime_filters = (DateTimeEqualFilter, DateTimeNotEqualFilter, DateTimeGreaterFilter, 
-                DateTimeSmallerFilter, DateTimeBetweenFilter, DateTimeNotBetweenFilter, 
-                FilterEmpty)
-    time_filters = (TimeEqualFilter, TimeNotEqualFilter, TimeGreaterFilter, TimeSmallerFilter, 
-            TimeBetweenFilter, TimeNotBetweenFilter, FilterEmpty)
+    strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike,
+               FilterEmpty, FilterInList, FilterNotInList)
+    int_filters = (IntEqualFilter, IntNotEqualFilter, IntGreaterFilter,
+                   IntSmallerFilter, FilterEmpty, IntInListFilter,
+                   IntNotInListFilter)
+    float_filters = (FloatEqualFilter, FloatNotEqualFilter, FloatGreaterFilter,
+                     FloatSmallerFilter, FilterEmpty, FloatInListFilter, 
+                     FloatNotInListFilter)
+    bool_filters = (BooleanEqualFilter, BooleanNotEqualFilter)
+    date_filters = (DateEqualFilter, DateNotEqualFilter, DateGreaterFilter,
+                    DateSmallerFilter, DateBetweenFilter, DateNotBetweenFilter,
+                    FilterEmpty)
+    datetime_filters = (DateTimeEqualFilter, DateTimeNotEqualFilter,
+                        DateTimeGreaterFilter, DateTimeSmallerFilter, 
+                        DateTimeBetweenFilter, DateTimeNotBetweenFilter, 
+                        FilterEmpty)
+    time_filters = (TimeEqualFilter, TimeNotEqualFilter, TimeGreaterFilter,
+                    TimeSmallerFilter, TimeBetweenFilter, TimeNotBetweenFilter,
+                    FilterEmpty)
 
     def convert(self, type_name, column, name):
         if type_name in self.converters:
@@ -307,13 +316,16 @@ class FilterConverter(filters.BaseFilterConverter):
 
     @filters.convert('BooleanField')
     def conv_bool(self, column, name):
-        return [f(column, name) for f in self.bool]
+        return [f(column, name) for f in self.bool_filters]
 
-    @filters.convert('IntegerField', 'DecimalField', 'FloatField',
-                     'DoubleField', 'BigIntegerField')
+    @filters.convert('IntegerField', 'BigIntegerField')
     def conv_int(self, column, name):
-        return [f(column, name) for f in self.numeric]
-
+        return [f(column, name) for f in self.int_filters]
+        
+    @filters.convert('DecimalField', 'FloatField', 'DoubleField')
+    def conv_float(self, column, name):
+        return [f(column, name) for f in self.float_filters]
+        
     @filters.convert('DateField')
     def conv_date(self, column, name):
         return [f(column, name) for f in self.date_filters]

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -41,6 +41,7 @@ def create_models(db):
     class Model2(db.Document):
         string_field = db.StringField()
         int_field = db.IntField()
+        float_field = db.FloatField()
         bool_field = db.BooleanField()
         
         model1 = db.ReferenceField(Model1)
@@ -135,10 +136,10 @@ def test_column_filters():
     Model1('test1_val_4', 'test2_val_4').save()
     Model1(None, 'empty_obj').save()
     
-    Model2('string_field_val_1', None).save()
-    Model2('string_field_val_2', None).save()
-    Model2('string_field_val_3', 5000).save()
-    Model2('string_field_val_4', 9000).save()
+    Model2('string_field_val_1', None, None).save()
+    Model2('string_field_val_2', None, None).save()
+    Model2('string_field_val_3', 5000, 25.9).save()
+    Model2('string_field_val_4', 9000, 75.5).save()
     
     Model1('datetime_obj1', datetime_field=datetime(2014,4,3,1,9,0)).save()
     Model1('datetime_obj2', datetime_field=datetime(2013,3,2,0,8,0)).save()
@@ -297,6 +298,86 @@ def test_column_filters():
     
     # integer - not in list
     rv = client.get('/admin/model2/?flt0_6=5000%2C9000')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_1' in data)
+    ok_('string_field_val_2' in data)
+    ok_('string_field_val_3' not in data)
+    ok_('string_field_val_4' not in data)
+    
+    # Test float filter
+    view = CustomModelView(Model2, column_filters=['float_field'], 
+                           endpoint="_float")
+    admin.add_view(view)
+    
+    eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Float Field']],
+        [
+            (0, 'equals'),
+            (1, 'not equal'),
+            (2, 'greater than'),
+            (3, 'smaller than'),
+            (4, 'empty'),
+            (5, 'in list'),
+            (6, 'not in list'),
+        ])
+    
+    # float - equals
+    rv = client.get('/admin/_float/?flt0_0=25.9')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_3' in data)
+    ok_('string_field_val_4' not in data)
+    
+    # float - not equal
+    rv = client.get('/admin/_float/?flt0_1=25.9')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_3' not in data)
+    ok_('string_field_val_4' in data)
+    
+    # float - greater
+    rv = client.get('/admin/_float/?flt0_2=60.5')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_3' not in data)
+    ok_('string_field_val_4' in data)
+    
+    # float - smaller
+    rv = client.get('/admin/_float/?flt0_3=60.5')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_3' in data)
+    ok_('string_field_val_4' not in data)
+    
+    # float - empty
+    rv = client.get('/admin/_float/?flt0_4=1')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_1' in data)
+    ok_('string_field_val_2' in data)
+    ok_('string_field_val_3' not in data)
+    ok_('string_field_val_4' not in data)
+    
+    # float - not empty
+    rv = client.get('/admin/_float/?flt0_4=0')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_1' not in data)
+    ok_('string_field_val_2' not in data)
+    ok_('string_field_val_3' in data)
+    ok_('string_field_val_4' in data)
+    
+    # float - in list
+    rv = client.get('/admin/_float/?flt0_5=25.9%2C75.5')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('string_field_val_1' not in data)
+    ok_('string_field_val_2' not in data)
+    ok_('string_field_val_3' in data)
+    ok_('string_field_val_4' in data)
+    
+    # float - not in list
+    rv = client.get('/admin/_float/?flt0_6=25.9%2C75.5')
     eq_(rv.status_code, 200)
     data = rv.data.decode('utf-8')
     ok_('string_field_val_1' in data)


### PR DESCRIPTION
Currently, peewee and mongoengine will throw an exception when you enter anything that isn't an integer into an Integer Filter. This pull request fixes the issue by adding a new converter for float types and validation to both integer and float types. Tests are also added for the new float type.

This commit also consolidates most logic for date, datetime, and time BETWEEN filters into model/filters.py.
