### PR TITLE
Fix active filters when named_filter_urls=True

### DIFF
--- a/flask_admin/static/admin/js/filters-1.0.0.js
+++ b/flask_admin/static/admin/js/filters-1.0.0.js
@@ -120,7 +120,7 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         // if one of the subfilters are selected, use that subfilter to create the input field
         var filterSelection = 0;
         $.each(subfilters, function( subfilterIndex, subfilter ) {
-            if (this.arg == selectedIndex) {
+            if (this.index == selectedIndex) {
                 $select.append($('<option/>').attr('value', subfilter.arg).attr('selected', true).text(subfilter.operation));
                 filterSelection = subfilterIndex;
             } else {


### PR DESCRIPTION
There is currently an issue when named_filter_url=True and an active filter is selected. The active filter operation will always default to "equals".

This fixes the logic for matching the active filter to the correct filter in filter_groups.
