### PR TITLE
Fix mongoengine `ListField(EmbeddedDocumentField('Model'))`

### DIFF
--- a/flask_admin/contrib/mongoengine/fields.py
+++ b/flask_admin/contrib/mongoengine/fields.py
@@ -1,3 +1,5 @@
+from mongoengine.base import get_document
+
 from werkzeug.datastructures import FileStorage
 
 from wtforms import fields
@@ -26,6 +28,9 @@ class ModelFormField(InlineFormField):
         super(ModelFormField, self).__init__(form_class, **kwargs)
 
         self.model = model
+        if isinstance(self.model, str):
+            self.model = get_document(self.model)
+
         self.view = view
         self.form_opts = form_opts
 


### PR DESCRIPTION
 not converting `'Model'` to `Model` and raising `TypeError: 'str' object is not callable`

eg. 
`users = mongoengine.ListField(mongoengine.EmbeddedDocumentField("User"))`

Full traceback:

```
Traceback (most recent call last):
  File "/env/src/flask-admin/flask_admin/contrib/mongoengine/view.py", line 532, in update_model
    form.populate_obj(model)
  File "/env/local/lib/python2.7/site-packages/wtforms/form.py", line 79, in populate_obj
    field.populate_obj(obj, name)
  File "/env/src/flask-admin/flask_admin/model/fields.py", line 86, in populate_obj
    field.populate_obj(fake_obj, 'data')
  File "/env/src/flask-admin/flask_admin/contrib/mongoengine/fields.py", line 35, in populate_obj
    candidate = self.model()
TypeError: 'str' object is not callable
```
