### PR TITLE
Updated formatting for code snippets to show line break in on github

### DIFF
--- a/examples/auth-mongoengine/README.rst
+++ b/examples/auth-mongoengine/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+     git clone https://github.com/mrjoes/flask-admin.git
+     cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+     virtualenv env
+     source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/auth-mongoengine/requirements.txt'
+     pip install -r 'examples/auth-mongoengine/requirements.txt'
 
 4. Run the application::
 
-  python examples/auth-mongoengine/app.py
+     python examples/auth-mongoengine/app.py
 
 

--- a/examples/auth/README.rst
+++ b/examples/auth/README.rst
@@ -4,24 +4,24 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+     git clone https://github.com/mrjoes/flask-admin.git
+     cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+     virtualenv env
+     source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/auth/requirements.txt'
+     pip install -r 'examples/auth/requirements.txt'
 
 4. Run the application::
 
-  python examples/auth/app.py
+     python examples/auth/app.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+     if not os.path.exists(database_path):
+         build_sample_db()

--- a/examples/babel/README.rst
+++ b/examples/babel/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+     git clone https://github.com/mrjoes/flask-admin.git
+     cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+     virtualenv env
+     source env/bin/activate
 
 3. Install requirements::
-
-  pip install -r 'examples/babel/requirements.txt'
-
+     
+     pip install -r 'examples/babel/requirements.txt'
+  
 4. Run the application::
 
-  python examples/babel/app.py
+     python examples/babel/app.py
 
 

--- a/examples/file/README.rst
+++ b/examples/file/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+     git clone https://github.com/mrjoes/flask-admin.git
+     cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+     virtualenv env
+     source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/file/requirements.txt'
+     pip install -r 'examples/file/requirements.txt'
 
 4. Run the application::
 
-  python examples/file/app.py
+     python examples/file/app.py
 
 

--- a/examples/forms/README.rst
+++ b/examples/forms/README.rst
@@ -5,24 +5,24 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/forms/requirements.txt'
+    pip install -r 'examples/forms/requirements.txt'
 
 4. Run the application::
 
-  python examples/forms/app.py
+    python examples/forms/app.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+    if not os.path.exists(database_path):
+        build_sample_db()

--- a/examples/layout-bootstrap3/README.rst
+++ b/examples/layout-bootstrap3/README.rst
@@ -4,24 +4,24 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/layout-bootstrap3/requirements.txt'
+    pip install -r 'examples/layout-bootstrap3/requirements.txt'
 
 4. Run the application::
 
-  python examples/layout-bootstrap3/app.py
+    python examples/layout-bootstrap3/app.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+    if not os.path.exists(database_path):
+        build_sample_db()

--- a/examples/layout/README.rst
+++ b/examples/layout/README.rst
@@ -4,24 +4,24 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/layout/requirements.txt'
+    pip install -r 'examples/layout/requirements.txt'
 
 4. Run the application::
 
-  python examples/layout/app.py
+    python examples/layout/app.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+    if not os.path.exists(database_path):
+        build_sample_db()

--- a/examples/menu-external-links/README.rst
+++ b/examples/menu-external-links/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/menu-external-links/requirements.txt'
+    pip install -r 'examples/menu-external-links/requirements.txt'
 
 4. Run the application::
 
-  python examples/menu-external-links/app.py
+    python examples/menu-external-links/app.py
 
 

--- a/examples/methodview/README.rst
+++ b/examples/methodview/README.rst
@@ -4,18 +4,18 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
-
-  virtualenv env
-  source env/bin/activate
+  
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/methodview/requirements.txt'
+    pip install -r 'examples/methodview/requirements.txt'
 
 4. Run the application::
 
-  python examples/methodview/app.py
+    python examples/methodview/app.py

--- a/examples/mongoengine/README.rst
+++ b/examples/mongoengine/README.rst
@@ -4,19 +4,19 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/mongoengine/requirements.txt'
+    pip install -r 'examples/mongoengine/requirements.txt'
 
 4. Run the application::
 
-  python examples/mongoengine/app.py
+    python examples/mongoengine/app.py
 

--- a/examples/multi/README.rst
+++ b/examples/multi/README.rst
@@ -4,19 +4,19 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/multi/requirements.txt'
+    pip install -r 'examples/multi/requirements.txt'
 
 4. Run the application::
 
-  python examples/multi/app.py
+    python examples/multi/app.py
 

--- a/examples/peewee/README.rst
+++ b/examples/peewee/README.rst
@@ -4,19 +4,19 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/peewee/requirements.txt'
-
+    pip install -r 'examples/peewee/requirements.txt'
+  
 4. Run the application::
 
-  python examples/peewee/app.py
+    python examples/peewee/app.py
 

--- a/examples/pymongo/README.rst
+++ b/examples/pymongo/README.rst
@@ -4,19 +4,19 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/pymongo/requirements.txt'
+    pip install -r 'examples/pymongo/requirements.txt'
 
 4. Run the application::
 
-  python examples/pymongo/app.py
+    python examples/pymongo/app.py
 

--- a/examples/quickstart/README.rst
+++ b/examples/quickstart/README.rst
@@ -4,21 +4,21 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/quickstart/requirements.txt'
+    pip install -r 'examples/quickstart/requirements.txt'
 
 4. Run the application with any of the following::
 
-  python examples/quickstart/app.py
-  python examples/quickstart/app2.py
-  python examples/quickstart/app3.py
+    python examples/quickstart/app.py
+    python examples/quickstart/app2.py
+    python examples/quickstart/app3.py
 

--- a/examples/rediscli/README.rst
+++ b/examples/rediscli/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/rediscli/requirements.txt'
+    pip install -r 'examples/rediscli/requirements.txt'
 
 4. Run the application::
 
-  python examples/rediscli/app.py
+    python examples/rediscli/app.py
 
 You should now be able to access a Redis instance on your machine (if it is running) through the admin interface.

--- a/examples/simple/README.rst
+++ b/examples/simple/README.rst
@@ -5,18 +5,18 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/simple/requirements.txt'
+    pip install -r 'examples/simple/requirements.txt'
 
 4. Run the application::
 
-  python examples/simple/app.py
+    python examples/simple/app.py

--- a/examples/sqla-custom-filter/README.rst
+++ b/examples/sqla-custom-filter/README.rst
@@ -4,24 +4,24 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/sqla-custom-filter/requirements.txt'
+    pip install -r 'examples/sqla-custom-filter/requirements.txt'
 
 4. Run the application::
 
-  python examples/sqla-custom-filter/app.py
+    python examples/sqla-custom-filter/app.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+    if not os.path.exists(database_path):
+        build_sample_db()

--- a/examples/sqla-inline/README.rst
+++ b/examples/sqla-inline/README.rst
@@ -4,20 +4,20 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/sqla-inline/requirements.txt'
+    pip install -r 'examples/sqla-inline/requirements.txt'
 
 4. Run the application::
 
-  python examples/sqla-inline/app.py
+    python examples/sqla-inline/app.py
 
 

--- a/examples/sqla/README.rst
+++ b/examples/sqla/README.rst
@@ -4,25 +4,25 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/sqla/requirements.txt'
+    pip install -r 'examples/sqla/requirements.txt'
 
 4. Run either of these applications::
 
-  python examples/sqla/app.py
-  python examples/sqla/app2.py
+    python examples/sqla/app.py
+    python examples/sqla/app2.py
 
 The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
 comment the following lines in app.py:::
 
-  if not os.path.exists(database_path):
-      build_sample_db()
+    if not os.path.exists(database_path):
+        build_sample_db()

--- a/examples/wysiwyg/README.rst
+++ b/examples/wysiwyg/README.rst
@@ -4,19 +4,19 @@ To run this example:
 
 1. Clone the repository::
 
-  git clone https://github.com/mrjoes/flask-admin.git
-  cd flask-admin
+    git clone https://github.com/mrjoes/flask-admin.git
+    cd flask-admin
 
 2. Create and activate a virtual environment::
 
-  virtualenv env
-  source env/bin/activate
+    virtualenv env
+    source env/bin/activate
 
 3. Install requirements::
 
-  pip install -r 'examples/wysiwyg/requirements.txt'
+    pip install -r 'examples/wysiwyg/requirements.txt'
 
 4. Run the application::
 
-  python examples/wysiwyg/app.py
+    python examples/wysiwyg/app.py
 


### PR DESCRIPTION
Changes the formatting for the code snippets to be shown as code examples.

The will also so the line breaks that will allow for copying and pasting all the examples into a terminal.

**Example**

  from this

```
To this
```
