### PR TITLE
add fix for issue #734, allow saving blank times

### DIFF
--- a/flask_admin/form/fields.py
+++ b/flask_admin/form/fields.py
@@ -69,24 +69,29 @@ class TimeField(fields.Field):
     def _value(self):
         if self.raw_data:
             return u' '.join(self.raw_data)
+        elif self.data is not None:
+            return self.data.strftime(self.default_format)
         else:
-            return self.data and self.data.strftime(self.default_format) or u''
+            return u''
 
     def process_formdata(self, valuelist):
         if valuelist:
             date_str = u' '.join(valuelist)
 
-            for format in self.formats:
-                try:
-                    timetuple = time.strptime(date_str, format)
-                    self.data = datetime.time(timetuple.tm_hour,
-                                              timetuple.tm_min,
-                                              timetuple.tm_sec)
-                    return
-                except ValueError:
-                    pass
+            if date_str.strip():
+                for format in self.formats:
+                    try:
+                        timetuple = time.strptime(date_str, format)
+                        self.data = datetime.time(timetuple.tm_hour,
+                                                  timetuple.tm_min,
+                                                  timetuple.tm_sec)
+                        return
+                    except ValueError:
+                        pass
 
-            raise ValueError(gettext('Invalid time format'))
+                raise ValueError(gettext('Invalid time format'))
+            else:
+                self.data = None
 
 
 class Select2Field(fields.SelectField):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -121,7 +121,9 @@ def test_model():
     eq_(rv.status_code, 200)
 
     rv = client.post('/admin/model1/new/',
-                     data=dict(test1='test1large', test2='test2'))
+                     data=dict(test1='test1large',
+                               test2='test2',
+                               time_field=time(0,0,0)))
     eq_(rv.status_code, 302)
 
     model = db.session.query(Model1).first()
@@ -137,6 +139,9 @@ def test_model():
     url = '/admin/model1/edit/?id=%s' % model.id
     rv = client.get(url)
     eq_(rv.status_code, 200)
+    
+    # verify that midnight does not show as blank
+    ok_(u'00:00:00' in rv.data.decode('utf-8'))
 
     rv = client.post(url,
                      data=dict(test1='test1small', test2='test2large'))


### PR DESCRIPTION
This resolves issue #734. 

I also found that it wasn't possible to clear out the time field by saving a blank string. This also resolves that issue by saving None when the user enters a blank string.

Also includes a test to verify that time(0,0,0) shows as 00:00:00.
