### PR TITLE
improve AdminIndexView docs, prevent breaking static files when root url='/'

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -229,10 +229,16 @@ class BaseView(with_metaclass(AdminViewMeta, BaseViewClass)):
             if not self.url.startswith('/'):
                 self.url = '%s/%s' % (self.admin.url, self.url)
 
+        
         # If we're working from the root of the site, set prefix to None
         if self.url == '/':
             self.url = None
-
+            # prevent admin static files from conflicting with flask static files
+            if not self.static_url_path:
+                self.static_folder='static'
+                self.static_url_path='/static/admin'
+            
+            
         # If name is not povided, use capitalized endpoint name
         if self.name is None:
             self.name = self._prettify_class_name(self.__class__.__name__)
@@ -383,9 +389,21 @@ class AdminIndexView(BaseView):
                 @expose('/')
                 def index(self):
                     arg1 = 'Hello'
-                    return render_template('adminhome.html', arg1=arg1)
+                    return self.render('admin/myhome.html', arg1=arg1)
 
             admin = Admin(index_view=MyHomeView())
+            
+            
+        Also, you can change the root url from /admin to / with the following::
+
+            admin = Admin(
+                app,
+                index_view=AdminIndexView(
+                    name='Home',
+                    template='admin/myhome.html',
+                    url='/'
+                )
+            )
 
         Default values for the index page are:
 

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -1,6 +1,6 @@
 from nose.tools import ok_, eq_, raises
 
-from flask import Flask, request, abort
+from flask import Flask, request, abort, url_for
 from flask.views import MethodView
 from flask.ext.admin import base
 
@@ -132,6 +132,11 @@ def test_admin_customizations():
     client = app.test_client()
     rv = client.get('/foobar/')
     eq_(rv.status_code, 200)
+    
+    # test custom static_url_path
+    with app.test_request_context('/'):
+        rv = client.get(url_for('admin.static', filename='bootstrap/bootstrap2/css/bootstrap.css'))
+    eq_(rv.status_code, 200)    
 
 
 def test_baseview_registration():
@@ -359,6 +364,11 @@ def test_root_mount():
     client = app.test_client()
     rv = client.get('/mockview/')
     eq_(rv.data, b'Success!')
+    
+    # test static files when url='/'
+    with app.test_request_context('/'):
+        rv = client.get(url_for('admin.static', filename='bootstrap/bootstrap2/css/bootstrap.css'))
+    eq_(rv.status_code, 200)
 
 
 def test_menu_links():


### PR DESCRIPTION
Setting the root url to / and the conflict it creates is a common issue for new users. This fix will change the admin blueprint's static_folder and static_url_path if the root url is '/' and a static_url_path is not provided. Also, tests and documentation are added.

Resolves these two issues:
- Issue #227 
- Issue #641 
