### PR TITLE
swallow TypeError only if related to compatibility

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1164,12 +1164,15 @@ class BaseModelView(BaseView, ActionsMixin):
         """
         try:
             self.on_model_change(form, model, is_created)
-        except TypeError:
-            msg = ('%s.on_model_change() now accepts third ' +
-                   'parameter is_created. Please update your code') % self.model
-            warnings.warn(msg)
+        except TypeError, e:
+            if e.message == 'on_model_change() takes exactly 3 arguments (4 given)':
+                msg = ('%s.on_model_change() now accepts third ' +
+                       'parameter is_created. Please update your code') % self.model
+                warnings.warn(msg)
 
-            self.on_model_change(form, model)
+                self.on_model_change(form, model)
+            else:
+                raise
 
     def after_model_change(self, form, model, is_created):
         """

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1164,8 +1164,8 @@ class BaseModelView(BaseView, ActionsMixin):
         """
         try:
             self.on_model_change(form, model, is_created)
-        except TypeError, e:
-            if e.message == 'on_model_change() takes exactly 3 arguments (4 given)':
+        except TypeError as e:
+            if re.match(r'on_model_change\(\) takes .* 3 .* arguments .* 4 .* given .*', e.message):
                 msg = ('%s.on_model_change() now accepts third ' +
                        'parameter is_created. Please update your code') % self.model
                 warnings.warn(msg)


### PR DESCRIPTION
Handling TypeError in _on_model_change without any additional checking for the cause causes an extremely puzzling error message in case a TypeError is raised by the code in on_model_change. Checking the error's message to see if it's actually caused by incompatible on_model_change signature give more readable error message and trace when the TypeError is caused by the user's code.
