### PR TITLE
Redirect to edit view after creating new model

### DIFF
--- a/flask_admin/contrib/appengine/view.py
+++ b/flask_admin/contrib/appengine/view.py
@@ -56,7 +56,7 @@ class NdbModelView(BaseModelView):
 			model = self.model()
 			form.populate_obj(model)
 			model.put()
-			return True
+			return model
 		except Exception as ex:
 			if not self.handle_view_exception(ex):
 				#flash(gettext('Failed to create record. %(error)s',
@@ -137,7 +137,7 @@ class DbModelView(BaseModelView):
 			model = self.model()
 			form.populate_obj(model)
 			model.put()
-			return True
+			return model
 		except Exception as ex:
 			if not self.handle_view_exception(ex):
 				#flash(gettext('Failed to create record. %(error)s',

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -543,7 +543,7 @@ class ModelView(BaseModelView):
         else:
             self.after_model_change(form, model, True)
 
-        return True
+        return model
 
     def update_model(self, form, model):
         """

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -384,7 +384,7 @@ class ModelView(BaseModelView):
         else:
             self.after_model_change(form, model, True)
 
-        return True
+        return model
 
     def update_model(self, form, model):
         try:

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -287,7 +287,7 @@ class ModelView(BaseModelView):
         else:
             self.after_model_change(form, model, True)
 
-        return True
+        return model
 
     def update_model(self, form, model):
         """

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -892,7 +892,7 @@ class ModelView(BaseModelView):
         else:
             self.after_model_change(form, model, True)
 
-        return True
+        return model
 
     def update_model(self, form, model):
         """

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1227,7 +1227,7 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             Create model from the form.
 
-            Returns `True` if operation succeeded.
+            Returns the model instance if operation succeeded.
 
             Must be implemented in the child class.
 
@@ -1534,12 +1534,20 @@ class BaseModelView(BaseView, ActionsMixin):
             self._validate_form_instance(ruleset=self._form_create_rules, form=form)
 
         if self.validate_form(form):
-            if self.create_model(form):
+            # in versions 1.1.0 and before, this returns a boolean
+            # in later versions, this is the model itself
+            model = self.create_model(form)
+            if model:
                 if '_add_another' in request.form:
                     flash(gettext('Record was successfully created.'))
                     return redirect(request.url)
                 else:
-                    return redirect(return_url)
+                    # if we have a valid model, try to go to the edit view
+                    if model is not True:
+                        url = self.get_url('.edit_view', id=self.get_pk_value(model), url=return_url)
+                    else:
+                        url = return_url
+                    return redirect(url)
 
         form_opts = FormOpts(widget_args=self.form_widget_args,
                              form_rules=self._form_create_rules)

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1,4 +1,4 @@
-from nose.tools import eq_, ok_, raises
+from nose.tools import eq_, ok_, raises, assert_true
 
 from wtforms import fields
 
@@ -1669,10 +1669,14 @@ def test_safe_redirect():
                      data=dict(test1='test1large', test2='test2'))
 
     eq_(rv.status_code, 302)
-    eq_(rv.location, 'http://localhost/admin/model2view/')
+    assert_true(rv.location.startswith('http://localhost/admin/model1/edit/'))
+    assert_true('url=http%3A%2F%2Flocalhost%2Fadmin%2Fmodel2view%2F' in rv.location)
+    assert_true('id=1' in rv.location)
 
     rv = client.post('/admin/model1/new/?url=http://google.com/evil/',
                      data=dict(test1='test1large', test2='test2'))
 
     eq_(rv.status_code, 302)
-    eq_(rv.location, 'http://localhost/admin/model1/')
+    assert_true(rv.location.startswith('http://localhost/admin/model1/edit/'))
+    assert_true('url=%2Fadmin%2Fmodel1%2F' in rv.location)
+    assert_true('id=2' in rv.location)


### PR DESCRIPTION
This is less confusing for the user because they don't return to a list view which may not actually include the newly created model.

Changes `view.create_model()` to return the newly created model, including for all concrete backends.