### PR TITLE
Add CSS classes for columns

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -61,7 +61,7 @@
                     {% endblock %}
                     {% set column = 0 %}
                     {% for c, name in list_columns %}
-                    <th class="column-header">
+                    <th class="column-{{c}}">
                         {% if admin_view.is_sortable(c) %}
                             {% if sort_column == column %}
                                 <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">
@@ -120,15 +120,17 @@
                 </td>
                 {% endblock %}
                 {% for c, name in list_columns %}
+                    <td class="column-{{c}}">
                     {% if admin_view.is_editable(c) %}
                         {% if form.csrf_token %}
-                        <td>{{ form[c](pk=get_pk_value(row), value=get_value(row, c), csrf=form.csrf_token._value()) }}</td>
+                        {{ form[c](pk=get_pk_value(row), value=get_value(row, c), csrf=form.csrf_token._value()) }}
                         {% else %}
-                        <td>{{ form[c](pk=get_pk_value(row), value=get_value(row, c)) }}</td>
+                        {{ form[c](pk=get_pk_value(row), value=get_value(row, c)) }}
                         {% endif %}
                     {% else %}
-                    <td>{{ get_value(row, c) }}</td>
+                    {{ get_value(row, c) }}
                     {% endif %}
+                    </td>
                 {% endfor %}
             {% endblock %}
         </tr>


### PR DESCRIPTION
Adds a `column-{{name}}` CSS class to columns in list view, making it easy to style columns (eg. set widths) using CSS.