### PR TITLE
control inline model row control display (bootstrap3)

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
@@ -4,4 +4,4 @@
     {{ field }}
 {% endmacro %}
 
-{{ base.render_inline_fields(field, template, render_field) }}
+{{ base.render_inline_fields(field, template, render_field, check) }}


### PR DESCRIPTION
Currently, although the render_inline_fields macro takes an optional
check parameter, it's not passed from the default inline_field_list
templates, forcing applications to override the template just to control
the parameter.