### PR TITLE
control inline model row control display

### DIFF
--- a/examples/sqla-inline/app.py
+++ b/examples/sqla-inline/app.py
@@ -62,9 +62,12 @@ class CustomInlineFieldListWidget(RenderTemplateWidget):
         super(CustomInlineFieldListWidget, self).__init__('field_list.html')
 
 
-# This InlineModelFormList will use our custom widget
+# This InlineModelFormList will use our custom widget and hide row controls
 class CustomInlineModelFormList(InlineModelFormList):
     widget = CustomInlineFieldListWidget()
+
+    def display_row_controls(self, field):
+        return False
 
 
 # Create custom InlineModelConverter and tell it to use our InlineModelFormList

--- a/flask_admin/templates/bootstrap2/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/inline_field_list.html
@@ -4,4 +4,4 @@
     {{ field }}
 {% endmacro %}
 
-{{ base.render_inline_fields(field, template, render_field) }}
+{{ base.render_inline_fields(field, template, render_field, check) }}

--- a/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
@@ -4,4 +4,4 @@
     {{ field }}
 {% endmacro %}
 
-{{ base.render_inline_fields(field, template, render_field) }}
+{{ base.render_inline_fields(field, template, render_field, check) }}


### PR DESCRIPTION
Currently, although the render_inline_fields macro takes an optional
check parameter, it's not passed from the default inline_field_list
templates, forcing applications to override the template just to control
the parameter.