### PR TITLE
Coerce MultiPolygon to Regular polygon to enable leaflet.draw editing

### DIFF
--- a/flask_admin/static/admin/js/form-1.0.0.js
+++ b/flask_admin/static/admin/js/form-1.0.0.js
@@ -72,26 +72,19 @@
       // this function fixes the lack of support for multipolygon in Leaflet.draw
       function splitMultiPolygonIntoPolygonFeatures(geojson) {
         var splitFeatures = [];
-        if (!geojson.features) {
-          return geojson;
-        }
-        geojson.features.forEach(function (feature) {
-          if (feature.geometry.type === 'MultiPolygon') {
-            geometry.coordinates.forEach(function (polygon) {
-              splitFeatures.push({
-                type: "Feature",
-                geometry: {
-                  type: "Polygon",
-                  coordinates: polygon
-                }
-              });
-            });
-          } else {
-            splitFeatures.push(feature);
-          }
+        geojson.coordinates.forEach(function (polygon) {
+          splitFeatures.push({
+            type: "Feature",
+            geometry: {
+              type: "Polygon",
+              coordinates: polygon
+            }
+          });
         });
-        geojson.features = splitFeatures;
-        return geojson;
+        return {
+          type: "FeatureCollection",
+          features: splitFeatures
+        };
       }
       /**
        * Process Leaflet (map) widget

--- a/flask_admin/static/admin/js/form-1.0.0.js
+++ b/flask_admin/static/admin/js/form-1.0.0.js
@@ -69,6 +69,30 @@
         $el.select2(opts);
       }
 
+      // this function fixes the lack of support for multipolygon in Leaflet.draw
+      function splitMultiPolygonIntoPolygonFeatures(geojson) {
+        var splitFeatures = [];
+        if (!geojson.features) {
+          return geojson;
+        }
+        geojson.features.forEach(function (feature) {
+          if (feature.geometry.type === 'MultiPolygon') {
+            geometry.coordinates.forEach(function (polygon) {
+              splitFeatures.push({
+                type: "Feature",
+                geometry: {
+                  type: "Polygon",
+                  coordinates: polygon
+                }
+              });
+            });
+          } else {
+            splitFeatures.push(feature);
+          }
+        });
+        geojson.features = splitFeatures;
+        return geojson;
+      }
       /**
        * Process Leaflet (map) widget
        */
@@ -107,7 +131,7 @@
 
         var editableLayers;
         if ($el.val()) {
-          editableLayers = new L.geoJson(JSON.parse($el.val()));
+          editableLayers = new L.geoJson(splitMultiPolygonIntoPolygonFeatures(JSON.parse($el.val())));
           center = center || editableLayers.getBounds().getCenter();
         } else {
           editableLayers = new L.geoJson();
@@ -203,7 +227,11 @@
           }
           if (multiple) {
             var coords = $.map(geo.features, function(feature) {
-              return [feature.geometry.coordinates];
+              if (feature.geometry.type === 'MultiPolygon') {
+                return feature.geometry.coordinates;
+              } else if (feature.geometry.type === 'Polygon') {
+                return [feature.geometry.coordinates];
+              }
             })
             geo = {
               "type": geometryType,


### PR DESCRIPTION
```
Coerce MultiPolygon to Regular polygon to enable leaflet.draw editing

Leaflet.draw does not currently support multipolygon features.
This coerces a MultiPolygon to be a collection of individual Polygon
features so that they can be edited successfully.
```
