### PR TITLE
Allow markup in field help-text

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -89,7 +89,7 @@
       {% set _dummy = kwargs.setdefault('class', 'form-control') %}
       {{ field(**kwargs)|safe }}
       {% if field.description %}
-      <p class="help-block">{{ field.description }}</p>
+      <p class="help-block">{{ field.description | safe}}</p>
       {% endif %}
     </div>
     {% if direct_error %}


### PR DESCRIPTION
This is to allow help_text in the model to have HTML markup, and render in the forms.