### PR TITLE
Make 'contains' the default string filter operator

### DIFF
--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -221,9 +221,9 @@ class DateTimeNotBetweenFilter(DateTimeBetweenFilter):
         return lazy_gettext('not between')
 
 
-# Base peewee filter field converter
+# Base MongoEngine filter field converter
 class FilterConverter(filters.BaseFilterConverter):
-    strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike,
+    strings = (FilterLike, FilterNotLike, FilterEqual, FilterNotEqual,
                FilterEmpty, FilterInList, FilterNotInList)
     int_filters = (IntEqualFilter, IntNotEqualFilter, IntGreaterFilter,
                    IntSmallerFilter, FilterEmpty, IntInListFilter,

--- a/flask_admin/contrib/peewee/filters.py
+++ b/flask_admin/contrib/peewee/filters.py
@@ -284,7 +284,7 @@ class TimeNotBetweenFilter(TimeBetweenFilter):
 
 # Base peewee filter field converter
 class FilterConverter(filters.BaseFilterConverter):
-    strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike,
+    strings = (FilterLike, FilterNotLike, FilterEqual, FilterNotEqual,
                FilterEmpty, FilterInList, FilterNotInList)
     int_filters = (IntEqualFilter, IntNotEqualFilter, IntGreaterFilter,
                    IntSmallerFilter, FilterEmpty, IntInListFilter,

--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -285,7 +285,7 @@ class TimeNotBetweenFilter(TimeBetweenFilter):
 
 # Base SQLA filter field converter
 class FilterConverter(filters.BaseFilterConverter):
-    strings = (FilterEqual, FilterNotEqual, FilterLike, FilterNotLike,
+    strings = (FilterLike, FilterNotLike, FilterEqual, FilterNotEqual,
                FilterEmpty, FilterInList, FilterNotInList)
     int_filters = (IntEqualFilter, IntNotEqualFilter, IntGreaterFilter,
                    IntSmallerFilter, FilterEmpty, IntInListFilter,

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -229,10 +229,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Test1']],
         [
-            (0, 'equals'),
-            (1, 'not equal'),
-            (2, 'contains'),
-            (3, 'not contains'),
+            (0, 'contains'),
+            (1, 'not contains'),
+            (2, 'equals'),
+            (3, 'not equal'),
             (4, 'empty'),
             (5, 'in list'),
             (6, 'not in list'),

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -263,10 +263,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Test1']],
         [
-            (0, 'equals'),
-            (1, 'not equal'),
-            (2, 'contains'),
-            (3, 'not contains'),
+            (0, 'contains'),
+            (1, 'not contains'),
+            (2, 'equals'),
+            (3, 'not equal'),
             (4, 'empty'),
             (5, 'in list'),
             (6, 'not in list'),

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -421,10 +421,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Test1']],
         [
-            (0, u'equals'),
-            (1, u'not equal'),
-            (2, u'contains'),
-            (3, u'not contains'),
+            (0, u'contains'),
+            (1, u'not contains'),
+            (2, u'equals'),
+            (3, u'not equal'),
             (4, u'empty'),
             (5, u'in list'),
             (6, u'not in list'),

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -436,10 +436,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Model1 / Test1']],
         [
-            (0, u'equals'),
-            (1, u'not equal'),
-            (2, u'contains'),
-            (3, u'not contains'),
+            (0, u'contains'),
+            (1, u'not contains'),
+            (2, u'equals'),
+            (3, u'not equal'),
             (4, u'empty'),
             (5, u'in list'),
             (6, u'not in list'),
@@ -447,10 +447,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Model1 / Test2']],
         [
-            (7, u'equals'),
-            (8, u'not equal'),
-            (9, u'contains'),
-            (10, u'not contains'),
+            (7, u'contains'),
+            (8, u'not contains'),
+            (9, u'equals'),
+            (10, u'not equal'),
             (11, u'empty'),
             (12, u'in list'),
             (13, u'not in list'),
@@ -458,10 +458,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Model1 / Test3']],
         [
-            (14, u'equals'),
-            (15, u'not equal'),
-            (16, u'contains'),
-            (17, u'not contains'),
+            (14, u'contains'),
+            (15, u'not contains'),
+            (16, u'equals'),
+            (17, u'not equal'),
             (18, u'empty'),
             (19, u'in list'),
             (20, u'not in list'),
@@ -469,10 +469,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Model1 / Test4']],
         [
-            (21, u'equals'),
-            (22, u'not equal'),
-            (23, u'contains'),
-            (24, u'not contains'),
+            (21, u'contains'),
+            (22, u'not contains'),
+            (23, u'equals'),
+            (24, u'not equal'),
             (25, u'empty'),
             (26, u'in list'),
             (27, u'not in list'),
@@ -538,10 +538,10 @@ def test_column_filters():
 
     eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Test1']],
         [
-            (0, 'equals'),
-            (1, 'not equal'),
-            (2, 'contains'),
-            (3, 'not contains'),
+            (0, 'contains'),
+            (1, 'not contains'),
+            (2, 'equals'),
+            (3, 'not equal'),
             (4, 'empty'),
             (5, 'in list'),
             (6, 'not in list'),


### PR DESCRIPTION
Upon adding a filter for a string field, `equals` is the default selected operator. However, the `contains` operator is more like the searches people typically do on web site and operating system search boxes. Being broader, `contains` is more generally useful for string fields than `equals`.

This change places `contains` first in the list so it is the default choice, preventing the user from having to
select it. The change applies to all three data engines (MongoEngine, Peewee, and SQLAlchemy).