### PR TITLE
Update filters.py

### DIFF
--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -266,7 +266,7 @@ def convert(*args):
         See :mod:`flask_admin.contrib.sqla.filters` for usage example.
     """
     def _inner(func):
-        func._converter_for = list(map(str.lower, args))
+        func._converter_for = list(map(lambda x: x.lower(), args))
         return func
     return _inner
 


### PR DESCRIPTION
There are some programmers using unicode strings by default in Python 2 (from __future__ import unicode_literals). In that case "str.lower" raises TypeError (str type is expected, unicode given). This propose fixed mentioned issue.