### PR TITLE
Added after_model_delete hook on view classes like after_model_change

### DIFF
--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -582,7 +582,6 @@ class ModelView(BaseModelView):
         try:
             self.on_model_delete(model)
             model.delete()
-            return True
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 flash(gettext('Failed to delete record. %(error)s',
@@ -591,6 +590,11 @@ class ModelView(BaseModelView):
                 log.exception('Failed to delete record.')
 
             return False
+        else:
+            self.after_model_delete(model)
+            
+        return True
+
 
     # FileField access API
     @expose('/api/file/')

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -409,13 +409,16 @@ class ModelView(BaseModelView):
         try:
             self.on_model_delete(model)
             model.delete_instance(recursive=True)
-            return True
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 flash(gettext('Failed to delete record. %(error)s', error=str(ex)), 'error')
                 log.exception('Failed to delete record.')
 
             return False
+        else:
+            self.after_model_delete(model)
+            
+        return True
 
     # Default model actions
     def is_action_allowed(self, name):

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -330,12 +330,15 @@ class ModelView(BaseModelView):
 
             self.on_model_delete(model)
             self.coll.remove({'_id': pk})
-            return True
         except Exception as ex:
             flash(gettext('Failed to delete record. %(error)s', error=str(ex)),
                   'error')
             log.exception('Failed to delete record.')
             return False
+        else:
+            self.after_model_delete(model)
+            
+        return True
 
     # Default model actions
     def is_action_allowed(self, name):

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -934,7 +934,6 @@ class ModelView(BaseModelView):
             self.session.flush()
             self.session.delete(model)
             self.session.commit()
-            return True
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 flash(gettext('Failed to delete record. %(error)s', error=str(ex)), 'error')
@@ -943,6 +942,10 @@ class ModelView(BaseModelView):
             self.session.rollback()
 
             return False
+        else:
+            self.after_model_delete(model)
+        
+        return True
 
     # Default model actions
     def is_action_allowed(self, name):

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1200,6 +1200,21 @@ class BaseModelView(BaseView, ActionsMixin):
             By default do nothing.
         """
         pass
+        
+    def after_model_delete(self, model):
+        """
+            Perform some actions after a model was deleted and
+            committed to the database.
+
+            Called from delete_model after successful database commit
+            (if it has any meaning for a store backend).
+
+            By default does nothing.
+
+            :param model:
+                Model that was deleted
+        """
+        pass        
 
     def on_form_prefill (self, form, id):
         """


### PR DESCRIPTION
Flask Admin currently has an `after_model_change` method which can be overridden in a custom view to allow for additional processing after a model has been created or changed, but no analogous `after_model_delete` method exists. This PR adds that method.