### PR TITLE
[fix] ListField validation

### DIFF
--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -1,4 +1,4 @@
-from mongoengine import ReferenceField
+from mongoengine import ReferenceField, ListField
 from mongoengine.base import BaseDocument, DocumentMetaclass, get_document
 
 from wtforms import fields, validators
@@ -72,7 +72,7 @@ class CustomModelConverter(orm.ModelConverter):
 
         if field.required:
             kwargs['validators'].append(validators.Required())
-        else:
+        elif not isinstance(field, ListField):
             kwargs['validators'].append(validators.Optional())
 
         ftype = type(field).__name__

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -87,9 +87,10 @@ def is_field_error(errors):
         :param errors:
             Errors list.
     """
-    for e in errors:
-        if isinstance(e, string_types):
-            return True
+    if isinstance(errors, (list, tuple)):
+        for e in errors:
+            if isinstance(e, string_types):
+                return True
 
     return False
 

--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -97,7 +97,7 @@
     <p class="help-block">{{ field.description }}</p>
     {% endif %}
     {% if direct_error %}
-      <ul{% if direct_error %} class="input-errors"{% endif %}>
+      <ul class="input-errors">
       {% for e in field.errors if e is string %}
         <li>{{ e }}</li>
       {% endfor %}

--- a/flask_admin/templates/bootstrap2/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/inline_field_list.html
@@ -2,6 +2,14 @@
 
 {% macro render_field(field) %}
     {{ field }}
+
+    {% if h.is_field_error(field.errors) %}
+    <ul class="input-errors">
+      {% for e in field.errors if e is string %}
+        <li>{{ e }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
 {% endmacro %}
 
 {{ base.render_inline_fields(field, template, render_field, check) }}

--- a/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/inline_field_list.html
@@ -2,6 +2,14 @@
 
 {% macro render_field(field) %}
     {{ field }}
+
+    {% if h.is_field_error(field.errors) %}
+    <ul class="help-block input-errors">
+      {% for e in field.errors if e is string %}
+        <li>{{ e }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
 {% endmacro %}
 
 {{ base.render_inline_fields(field, template, render_field, check) }}


### PR DESCRIPTION
Mongoengine converter makes `ListField` optional if it's not required, which makes it ignore validation errors of list items. Please see commit comments and added test case