### PR TITLE
add trove classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules'
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
     test_suite='nose.collector'
 )


### PR DESCRIPTION
will make it so https://caniusepython3.com stops showing this as a blocker

based on the versions currently tested in Travis