### PR TITLE
Fix custom field classes with Bootstrap3

### DIFF
--- a/examples/wysiwyg/app.py
+++ b/examples/wysiwyg/app.py
@@ -20,9 +20,7 @@ db = SQLAlchemy(app)
 
 # Define wtforms widget and field
 class CKTextAreaWidget(widgets.TextArea):
-    def __call__(self, field, **kwargs):
-        kwargs.setdefault('class_', 'ckeditor')
-        return super(CKTextAreaWidget, self).__call__(field, **kwargs)
+    class_ = 'ckeditor'
 
 
 class CKTextAreaField(fields.TextAreaField):
@@ -55,7 +53,7 @@ def index():
 
 if __name__ == '__main__':
     # Create admin
-    admin = admin.Admin(app, name="Example: WYSIWYG")
+    admin = admin.Admin(app, name="Example: WYSIWYG", template_mode='bootstrap3')
 
     # Add views
     admin.add_view(PageAdmin(Page, db.session))

--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -91,6 +91,11 @@
     </div>
     <div class="controls">
     <div>
+      {%- set css_class = [] -%}
+      {%- if field.widget and field.widget.class_ -%}
+        {%- set _ = css_class.append(field.widget.class_) -%}
+      {%- endif -%}
+      {%- set _ = kwargs.setdefault('class', ', '.join(css_class)) if css_class -%}
       {{ field(**kwargs)|safe }}
     </div>
     {% if field.description %}

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -86,7 +86,11 @@
         {%- endif %}
     </label>
     <div class="{{ kwargs.get('column_class', 'col-md-10') }}">
-      {% set _dummy = kwargs.setdefault('class', 'form-control') %}
+      {%- set css_class = ['form-control'] -%}
+      {%- if field.widget.class_ -%}
+          {%- set _ = css_class.append(field.widget.class_) -%}
+      {%- endif -%}
+      {%- set _ = kwargs.setdefault('class', ', '.join(css_class)) -%}
       {{ field(**kwargs)|safe }}
       {% if field.description %}
       <p class="help-block">{{ field.description }}</p>


### PR DESCRIPTION
Currently the custom class is created inside the call to `field()` so we
can't actually check in the template whether the field or widget has set
any custom classes.

With Bootstrap3, the `render_field` macro overwrites the `class` anyway,
so we have to define the widget's CSS class in the Python class level
and look it up before we actually create the object.

Fixes #894