### PR TITLE
Allow primary keys with special characters in editable list view

### DIFF
--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -141,11 +141,11 @@ class ListEditableFieldList(FieldList):
 
     def _extract_indices(self, prefix, formdata):
         offset = len(prefix) + 1
-        for k in formdata:
-            if k.startswith(prefix):
-                k = k[offset:].split('-', 1)[0]
-                # removed "if k.isdigit():"
-                yield k
+        for name in formdata:
+            # selects only relevant field (not CSRF, other fields, etc)
+            if name.startswith(prefix):
+                # exclude offset (prefix-), remaining text is the index
+                yield name[offset:]
 
     def _add_entry(self, formdata=None, data=unset_value, index=None):
         assert not self.max_entries or len(self.entries) < self.max_entries, \


### PR DESCRIPTION
Fixes #755

* Fixes editable list view when the primary key has a dash
* Adds a test for the fix
* Removes some unnecessary "db.create_all()" from the tests, this is already in create_models().