### PR TITLE
default datetime picker's time to current time when field is blank

### DIFF
--- a/flask_admin/static/admin/js/form-1.0.0.js
+++ b/flask_admin/static/admin/js/form-1.0.0.js
@@ -371,6 +371,13 @@
                 function(start, end) {
                     $('.filter-val').trigger("change");
                 });
+                $el.on('show.daterangepicker', function (event, data) {
+                  if ($el.val() == "") {
+                    var now = moment().seconds(0); // set seconds to 0
+                    // change datetime to current time if field is blank
+                    $el.data('daterangepicker').setCustomDates(now, now);
+                  }
+                });
                 return true;
             case 'datetimerangepicker':
                 $el.daterangepicker({


### PR DESCRIPTION
This fixes #899, by overriding the default behavior of bootstrap datetimepicker.

The fix uses the "show.daterangepicker" event (https://github.com/dangrossman/bootstrap-daterangepicker#events) and sets the time to the current time (without seconds) if the input field is blank.