### PR TITLE
Add create_view modal, fix modal issues

### DIFF
--- a/babel/admin.pot
+++ b/babel/admin.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Admin VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-28 18:28-0500\n"
+"POT-Creation-Date: 2015-07-03 18:39-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -268,8 +268,8 @@ msgstr ""
 #: ../flask_admin/contrib/mongoengine/view.py:565
 #: ../flask_admin/contrib/peewee/view.py:399
 #: ../flask_admin/contrib/pymongo/view.py:309
-#: ../flask_admin/contrib/sqla/view.py:1011 ../flask_admin/model/base.py:1727
-#: ../flask_admin/model/base.py:1736
+#: ../flask_admin/contrib/sqla/view.py:1011 ../flask_admin/model/base.py:1734
+#: ../flask_admin/model/base.py:1743
 #, python-format
 msgid "Failed to update record. %(error)s"
 msgstr ""
@@ -292,7 +292,7 @@ msgstr ""
 #: ../flask_admin/contrib/mongoengine/view.py:640
 #: ../flask_admin/contrib/peewee/view.py:450
 #: ../flask_admin/contrib/pymongo/view.py:363
-#: ../flask_admin/contrib/sqla/view.py:1073 ../flask_admin/model/base.py:1675
+#: ../flask_admin/contrib/sqla/view.py:1073 ../flask_admin/model/base.py:1682
 #, python-format
 msgid "Record was successfully deleted."
 msgid_plural "%(count)s records were successfully deleted."
@@ -347,20 +347,20 @@ msgstr ""
 msgid "File \"%s\" already exists."
 msgstr ""
 
-#: ../flask_admin/model/base.py:1325
+#: ../flask_admin/model/base.py:1332
 msgid "There are no items in the table."
 msgstr ""
 
-#: ../flask_admin/model/base.py:1349
+#: ../flask_admin/model/base.py:1356
 #, python-format
 msgid "Invalid Filter Value: %(value)s"
 msgstr ""
 
-#: ../flask_admin/model/base.py:1590
+#: ../flask_admin/model/base.py:1597
 msgid "Record was successfully created."
 msgstr ""
 
-#: ../flask_admin/model/base.py:1634 ../flask_admin/model/base.py:1732
+#: ../flask_admin/model/base.py:1641 ../flask_admin/model/base.py:1739
 msgid "Record was successfully saved."
 msgstr ""
 
@@ -382,13 +382,13 @@ msgstr ""
 msgid "With selected"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/lib.html:181
-#: ../flask_admin/templates/bootstrap3/admin/lib.html:173
+#: ../flask_admin/templates/bootstrap2/admin/lib.html:199
+#: ../flask_admin/templates/bootstrap3/admin/lib.html:190
 msgid "Save"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/lib.html:186
-#: ../flask_admin/templates/bootstrap3/admin/lib.html:178
+#: ../flask_admin/templates/bootstrap2/admin/lib.html:204
+#: ../flask_admin/templates/bootstrap3/admin/lib.html:195
 msgid "Cancel"
 msgstr ""
 
@@ -441,28 +441,40 @@ msgstr ""
 msgid "Please provide new name for %(name)s"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/create.html:5
-#: ../flask_admin/templates/bootstrap3/admin/model/create.html:5
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:7
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:7
 msgid "Save and Add"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/create.html:16
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:26
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:16
-#: ../flask_admin/templates/bootstrap3/admin/model/create.html:17
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:33
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:16
 msgid "List"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/create.html:19
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:20
-#: ../flask_admin/templates/bootstrap3/admin/model/create.html:20
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:20
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:29
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:22
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:24
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:36
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:22
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:24
 msgid "Create"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:5
-#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:5
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:44
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:21
+msgid "Create New Record"
+msgstr ""
+
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:7
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:7
 msgid "Save and Continue"
+msgstr ""
+
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:34
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:22
+msgid "Edit Record"
 msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/inline_list_base.html:13
@@ -497,45 +509,49 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:20
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:20
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:22
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:24
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:22
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:24
 msgid "Create new record"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:56
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:56
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:61
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:61
 msgid "Select all records"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:67
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:76
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:67
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:76
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:72
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:81
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:72
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:81
 #, python-format
 msgid "Sort by %(name)s"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:98
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:98
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:103
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:103
 msgid "Select record"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:105
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:105
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:111
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:113
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:111
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:113
 msgid "Edit record"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:118
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:118
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:127
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:127
 msgid "Are you sure you want to delete this record?"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:118
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:127
 msgid "Delete record"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/list.html:171
-#: ../flask_admin/templates/bootstrap3/admin/model/list.html:170
+#: ../flask_admin/templates/bootstrap2/admin/model/list.html:184
+#: ../flask_admin/templates/bootstrap3/admin/model/list.html:183
 msgid "Please select at least one record."
 msgstr ""
 

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -103,6 +103,9 @@ class BaseModelView(BaseView, ActionsMixin):
     edit_modal = False
     """Setting this to true will display the edit_view as a modal dialog."""
 
+    create_modal = False
+    """Setting this to true will display the create_view as a modal dialog."""
+
     # Customizations
     column_list = ObsoleteAttr('column_list', 'list_columns', None)
     """

--- a/flask_admin/templates/bootstrap2/admin/model/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/create.html
@@ -1,4 +1,6 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+    {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
@@ -6,27 +8,53 @@
 {% endmacro %}
 
 {% block head %}
+  {%- if not request.args.get('modal') -%}
     {{ super() }}
     {{ lib.form_css() }}
+  {%- endif -%}
 {% endblock %}
 
 {% block body %}
-  <ul class="nav nav-tabs">
-      <li>
-          <a href="{{ return_url }}">{{ _gettext('List') }}</a>
-      </li>
-      <li class="active">
-          <a href="javascript:void(0)">{{ _gettext('Create') }}</a>
-      </li>
-	</ul>
+  {%- if request.args.get('modal') -%}
+    {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                       action=url_for('.create_view', url=return_url),
+                       is_modal=request.args.get('modal')) }}
+  {%- else -%}
+    {% block navlinks %}
+      <ul class="nav nav-tabs">
+        <li>
+            <a href="{{ return_url }}">{{ _gettext('List') }}</a>
+        </li>
+        <li class="active">
+            <a href="javascript:void(0)">{{ _gettext('Create') }}</a>
+        </li>
+	  </ul>
+    {% endblock %}
 
-  {% call lib.form_tag(form) %}
-      {{ lib.render_form_fields(form, form_opts=form_opts) }}
-      {{ lib.render_form_buttons(return_url, extra()) }}
-  {% endcall %}
+    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts,
+                       action=url_for('.create_view', url=return_url),
+                       is_modal=request.args.get('modal')) }}
+  {%- endif -%}
 {% endblock %}
 
 {% block tail %}
-  {{ super() }}
-  {{ lib.form_js() }}
+  {%- if request.args.get('modal') -%}
+    <script>
+    // fill the header of modal dynamically
+    $('.modal-header h3').html('{% block modal_header %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}');
+
+    // fixes "remote modal shows same content every time"
+    $('.modal').on('hidden', function() {
+      $(this).removeData('modal');
+    });
+
+    $(function() {
+      // Apply flask-admin global styles after the modal is loaded
+      window.faForm.applyGlobalStyles(document);
+    });
+    </script>
+  {%- else -%}
+    {{ super() }}
+    {{ lib.form_js() }}
+  {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -1,4 +1,4 @@
-{%- if not admin_view.edit_modal -%}
+{%- if not request.args.get('modal') -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,30 +8,30 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not admin_view.edit_modal -%}
+  {%- if not request.args.get('modal') -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-    {%- if admin_view.edit_modal -%}
+    {%- if request.args.get('modal') -%}
       {# remove save and continue button for modal (it won't function properly) #}
       {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                          action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=admin_view.edit_modal) }}
+                         is_modal=request.args.get('modal')) }}
     {%- else -%}
       {{ lib.render_form(form, return_url, extra(), form_opts,
                          action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=admin_view.edit_modal) }}
+                         is_modal=request.args.get('modal')) }}
     {%- endif -%}
 {% endblock %}
 
 {% block tail %}
-    {%- if admin_view.edit_modal -%}
+    {%- if request.args.get('modal') -%}
       <script>
       // fill the header of modal dynamically
-      $('.modal-header h3').html('{% block modal_header %}<h3>Edit Record #{{ request.args.get('id') }}</h3>{% endblock %}');
+      $('.modal-header h3').html('{% block modal_header %}<h3>{{ _gettext('Edit Record') + ' #' + request.args.get('id') }}</h3>{% endblock %}');
 
       // fixes "remote modal shows same content every time"
       $('.modal').on('hidden', function() {

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -15,9 +15,14 @@
         <li class="active">
             <a href="javascript:void(0)">{{ _gettext('List') }}{% if count %} ({{ count }}){% endif %}</a>
         </li>
+
         {% if admin_view.can_create %}
         <li>
+          {%- if admin_view.create_modal -%}
+            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create new record'), content=_gettext('Create')) }}
+          {% else %}
             <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create new record') }}">{{ _gettext('Create') }}</a>
+          {%- endif -%}
         </li>
         {% endif %}
 
@@ -103,7 +108,7 @@
                     {% block list_row_actions scoped %}
                         {%- if admin_view.can_edit -%}
                             {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url), title=_gettext('Edit record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
+                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
                             {% else %}
                                 <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
                                     <i class="fa fa-pencil icon-pencil"></i>
@@ -166,7 +171,7 @@
 
     {{ actionlib.form(actions, get_url('.action_view')) }}
 
-    {%- if admin_view.edit_modal -%}
+    {%- if admin_view.edit_modal or admin_view.create_modal -%}
         {{ lib.add_modal_window() }}
     {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -109,7 +109,7 @@
 {% endmacro %}
 
 {% macro add_modal_button(url='', title='', content='', modal_window_id='fa_modal_window') %}
-  <a class="icon" data-target="#{{ modal_window_id }}" title="{{ title }}" href="{{ url }}" data-backdrop="false" data-toggle="modal">
+  <a class="icon" data-target="#{{ modal_window_id }}" title="{{ title }}" href="{{ url }}" data-toggle="modal">
     {{ content|safe }}
   </a>
 {% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/model/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/create.html
@@ -1,4 +1,6 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+    {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
@@ -6,29 +8,57 @@
 {% endmacro %}
 
 {% block head %}
+  {%- if not request.args.get('modal') -%}
     {{ super() }}
     {{ lib.form_css() }}
+  {%- endif -%}
 {% endblock %}
 
 {% block body %}
-  {% block navlinks %}
-  <ul class="nav nav-tabs">
-      <li>
-          <a href="{{ return_url }}">{{ _gettext('List') }}</a>
-      </li>
-      <li class="active">
-          <a href="javascript:void(0)">{{ _gettext('Create') }}</a>
-      </li>
-	</ul>
-  {% endblock %}
+  {%- if request.args.get('modal') -%}
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      {% block modal_header %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}
+    </div>
+    <div class="modal-body">
+      {# remove save and continue button for modal (it won't function properly) #}
+      {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                         action=url_for('.create_view', url=return_url),
+                         is_modal=request.args.get('modal')) }}
+    </div>
+  {%- else -%}
+    {% block navlinks %}
+      <ul class="nav nav-tabs">
+        <li>
+            <a href="{{ return_url }}">{{ _gettext('List') }}</a>
+        </li>
+        <li class="active">
+            <a href="javascript:void(0)">{{ _gettext('Create') }}</a>
+        </li>
+      </ul>
+    {% endblock %}
 
-  {% call lib.form_tag(form) %}
-      {{ lib.render_form_fields(form, form_opts=form_opts) }}
-      {{ lib.render_form_buttons(return_url, extra()) }}
-  {% endcall %}
+    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts,
+                       action=url_for('.create_view', url=return_url),
+                       is_modal=request.args.get('modal')) }}
+  {%- endif -%}
 {% endblock %}
 
 {% block tail %}
-  {{ super() }}
-  {{ lib.form_js() }}
+  {%- if request.args.get('modal') -%}
+    <script>
+    // fixes "remote modal shows same content every time", avoiding the flicker
+    $('body').on('hidden.bs.modal', '.modal', function () {
+      $(this).removeData('bs.modal').find(".modal-content").empty();
+    });
+
+    $(function() {
+      // Apply flask-admin global styles after the modal is loaded
+      window.faForm.applyGlobalStyles(document);
+    });
+    </script>
+  {%- else -%}
+    {{ super() }}
+    {{ lib.form_js() }}
+  {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -1,4 +1,4 @@
-{%- if not admin_view.edit_modal -%}
+{%- if not request.args.get('modal') -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,34 +8,34 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not admin_view.edit_modal -%}
+  {%- if not request.args.get('modal') -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-    {%- if admin_view.edit_modal -%}
+    {%- if request.args.get('modal') -%}
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        {% block modal_header %}<h3>Edit Record #{{ request.args.get('id') }}</h3>{% endblock %}
+        {% block modal_header %}<h3>{{ _gettext('Edit Record') + ' #' + request.args.get('id') }}</h3>{% endblock %}
       </div>
       <div class="modal-body">
         {# remove save and continue button for modal (it won't function properly) #}
         {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                            action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                           is_modal=admin_view.edit_modal) }}
+                           is_modal=request.args.get('modal')) }}
       </div>
     {%- else -%}
       {{ lib.render_form(form, return_url, extra(), form_opts,
                          action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=admin_view.edit_modal) }}
+                         is_modal=request.args.get('modal')) }}
     {%- endif -%}
 {% endblock %}
 
 {% block tail %}
-    {%- if admin_view.edit_modal -%}
+    {%- if request.args.get('modal') -%}
       <script>
       // fixes "remote modal shows same content every time", avoiding the flicker
       $('body').on('hidden.bs.modal', '.modal', function () {

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -15,9 +15,14 @@
         <li class="active">
             <a href="javascript:void(0)">{{ _gettext('List') }}{% if count %} ({{ count }}){% endif %}</a>
         </li>
+
         {% if admin_view.can_create %}
         <li>
+          {%- if admin_view.create_modal -%}
+            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create new record'), content=_gettext('Create')) }}
+          {% else %}
             <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create new record') }}">{{ _gettext('Create') }}</a>
+          {%- endif -%}
         </li>
         {% endif %}
 
@@ -103,7 +108,7 @@
                     {% block list_row_actions scoped %}
                         {%- if admin_view.can_edit -%}
                             {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url), title=_gettext('Edit record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
+                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
                             {% else %}
                                 <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
                                     <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
@@ -165,7 +170,7 @@
 
     {{ actionlib.form(actions, get_url('.action_view')) }}
 
-    {%- if admin_view.edit_modal -%}
+    {%- if admin_view.edit_modal or admin_view.create_modal -%}
         {{ lib.add_modal_window() }}
     {%- endif -%}
 {% endblock %}

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -457,22 +457,41 @@ def test_modal_edit():
     app_bs2 = Flask(__name__)
     admin_bs2 = Admin(app_bs2, template_mode="bootstrap2")
 
-    modal_view = MockModelView(Model, edit_modal=True, endpoint="modal_on")
-    no_modal_view = MockModelView(Model, edit_modal=False, endpoint="modal_off")
-
-    admin_bs2.add_view(modal_view)
-    admin_bs2.add_view(no_modal_view)
+    edit_modal_on = MockModelView(Model, edit_modal=True,
+                                  endpoint="edit_modal_on")
+    edit_modal_off = MockModelView(Model, edit_modal=False,
+                                   endpoint="edit_modal_off")
+    create_modal_on = MockModelView(Model, create_modal=True,
+                                    endpoint="create_modal_on")
+    create_modal_off = MockModelView(Model, create_modal=False,
+                                     endpoint="create_modal_off")
+    admin_bs2.add_view(edit_modal_on)
+    admin_bs2.add_view(edit_modal_off)
+    admin_bs2.add_view(create_modal_on)
+    admin_bs2.add_view(create_modal_off)
 
     client_bs2 = app_bs2.test_client()
 
     # bootstrap 2 - ensure modal window is added when edit_modal is enabled
-    rv = client_bs2.get('/admin/modal_on/')
+    rv = client_bs2.get('/admin/edit_modal_on/')
     eq_(rv.status_code, 200)
     data = rv.data.decode('utf-8')
     ok_('fa_modal_window' in data)
 
-    # bootstrap 2 - test modal disabled
-    rv = client_bs2.get('/admin/modal_off/')
+    # bootstrap 2 - test edit modal disabled
+    rv = client_bs2.get('/admin/edit_modal_off/')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('fa_modal_window' not in data)
+
+    # bootstrap 2 - ensure modal window is added when create_modal is enabled
+    rv = client_bs2.get('/admin/create_modal_on/')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('fa_modal_window' in data)
+
+    # bootstrap 2 - test create modal disabled
+    rv = client_bs2.get('/admin/create_modal_off/')
     eq_(rv.status_code, 200)
     data = rv.data.decode('utf-8')
     ok_('fa_modal_window' not in data)
@@ -481,19 +500,33 @@ def test_modal_edit():
     app_bs3 = Flask(__name__)
     admin_bs3 = Admin(app_bs3, template_mode="bootstrap3")
 
-    admin_bs3.add_view(modal_view)
-    admin_bs3.add_view(no_modal_view)
+    admin_bs3.add_view(edit_modal_on)
+    admin_bs3.add_view(edit_modal_off)
+    admin_bs3.add_view(create_modal_on)
+    admin_bs3.add_view(create_modal_off)
 
     client_bs3 = app_bs3.test_client()
 
     # bootstrap 3 - ensure modal window is added when edit_modal is enabled
-    rv = client_bs3.get('/admin/modal_on/')
+    rv = client_bs3.get('/admin/edit_modal_on/')
     eq_(rv.status_code, 200)
     data = rv.data.decode('utf-8')
     ok_('fa_modal_window' in data)
 
     # bootstrap 3 - test modal disabled
-    rv = client_bs3.get('/admin/modal_off/')
+    rv = client_bs3.get('/admin/edit_modal_off/')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('fa_modal_window' not in data)
+
+    # bootstrap 3 - ensure modal window is added when edit_modal is enabled
+    rv = client_bs3.get('/admin/create_modal_on/')
+    eq_(rv.status_code, 200)
+    data = rv.data.decode('utf-8')
+    ok_('fa_modal_window' in data)
+
+    # bootstrap 3 - test modal disabled
+    rv = client_bs3.get('/admin/create_modal_off/')
     eq_(rv.status_code, 200)
     data = rv.data.decode('utf-8')
     ok_('fa_modal_window' not in data)


### PR DESCRIPTION
* Adds "create_modal" option to enable modals for create_view.
* Fixes issue: The user was getting redirected to the non-modal edit_view or create_view *without css/js* when there was an error.
* Fixes issue: The modal backdrop was missing from bootstrap 3 modals.
* Fixes issue: Wasn't using babel translations for modal headers.
* Fixes issue: Bootstrap 2 create.html didn't have {% block navlinks %} like the bootstrap 3 template does.