### PR TITLE
Allow flash message in success style

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/layout.html
+++ b/flask_admin/templates/bootstrap3/admin/layout.html
@@ -70,12 +70,13 @@
     {% if messages %}
       {% for category, m in messages %}
         {% if category %}
+        {# alert-error changed to alert-danger in bootstrap 3, mapping is for backwards compatibility #}
         {% set mapping = {'message': 'info', 'error': 'danger'} %}
-        <div class="alert alert-{{ mapping.get(category, 'warning') }} alert-dismissable">
+        <div class="alert alert-{{ mapping.get(category, category) }} alert-dismissable">
         {% else %}
         <div class="alert alert-dismissable">
         {% endif %}
-	      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+          <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
           {{ m }}
         </div>
       {% endfor %}


### PR DESCRIPTION
A different approach to https://github.com/flask-admin/flask-admin/pull/748

Changes ```mapping.get(category, 'warning')``` to ```mapping.get(category, category)``` to allow using ```flash('record successfully created!', 'success')```.