### PR TITLE
Add modals to FileAdmin, minor changes to forms

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -661,7 +661,8 @@ class FileAdmin(BaseView, ActionsMixin):
                 flash(gettext('Failed to save file: %(error)s', error=ex), 'error')
 
         return self.render(self.upload_template, form=form,
-                           header_text=gettext('Upload File'))
+                           header_text=gettext('Upload File'),
+                           modal=request.args.get('modal'))
 
     @expose('/download/<path:path>')
     def download(self, path=None):
@@ -721,7 +722,8 @@ class FileAdmin(BaseView, ActionsMixin):
             helpers.flash_errors(form, message='Failed to create directory: %(error)s')
 
         return self.render(self.mkdir_template, form=form, dir_url=dir_url,
-                           header_text=gettext('Create Directory'))
+                           header_text=gettext('Create Directory'),
+                           modal=request.args.get('modal'))
 
     @expose('/delete/', methods=('POST',))
     def delete(self):
@@ -819,7 +821,8 @@ class FileAdmin(BaseView, ActionsMixin):
                            form=form,
                            path=op.dirname(path),
                            name=op.basename(path),
-                           dir_url=return_url)
+                           dir_url=return_url,
+                           modal=request.args.get('modal'))
 
     @expose('/edit/', methods=('GET', 'POST'))
     def edit(self):
@@ -887,7 +890,8 @@ class FileAdmin(BaseView, ActionsMixin):
                     form.content.data = content
 
         return self.render(self.edit_template, dir_url=dir_url, path=path,
-                           form=form, error=error)
+                           form=form, error=error,
+                           modal=request.args.get('modal'))
 
     @expose('/action/', methods=('POST',))
     def action_view(self):

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1611,7 +1611,8 @@ class BaseModelView(BaseView, ActionsMixin):
         return self.render(self.create_template,
                            form=form,
                            form_opts=form_opts,
-                           return_url=return_url)
+                           return_url=return_url,
+                           modal=request.args.get('modal'))
 
     @expose('/edit/', methods=('GET', 'POST'))
     def edit_view(self):
@@ -1654,7 +1655,8 @@ class BaseModelView(BaseView, ActionsMixin):
                            model=model,
                            form=form,
                            form_opts=form_opts,
-                           return_url=return_url)
+                           return_url=return_url,
+                           modal=request.args.get('modal'))
 
     @expose('/delete/', methods=('POST',))
     def delete_view(self):

--- a/flask_admin/templates/bootstrap2/admin/file/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/file/edit.html
@@ -1,11 +1,40 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+  {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
-{% block body %}
-    <h3>{{ _gettext('You are editing %(path)s', path=path) }}</h3>
+{% macro check_error(error) %}
     {% if error %}
-    <span>This file cannot be edited for now.</span>
+      <span>{{ _gettext('This file cannot be edited for now.') }}</span>
     {% else %}
-    {{ lib.render_form(form, dir_url) }}
+      {{ caller() }}
     {% endif %}
+{% endmacro %}
+
+{% block body %}
+    {% call check_error(error) %}
+      {%- if request.args.get('modal') -%}
+        {# content added to modal-content #}
+        {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+      {%- else -%}
+        {% block header_text -%}
+          <h3>{{ _gettext('Editing %(path)s', path=path) }}<h3>
+        {%- endblock %}
+        {{ lib.render_form(form, dir_url) }}
+      {%- endif -%}
+    {% endcall %}
+{% endblock %}
+
+{% block tail %}
+    {%- if request.args.get('modal') -%}
+    <script>
+    // fill the header of modal dynamically
+    $('.modal-header h3').html('{{ self.header_text() }}');
+
+    // fixes "remote modal shows same content every time"
+    $('.modal').on('hidden', function() {
+        $(this).removeData('modal');
+    });
+    </script>
+    {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/file/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/file/edit.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
   {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -13,7 +13,7 @@
 
 {% block body %}
     {% call check_error(error) %}
-      {%- if request.args.get('modal') -%}
+      {%- if modal -%}
         {# content added to modal-content #}
         {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
       {%- else -%}
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
     <script>
     // fill the header of modal dynamically
     $('.modal-header h3').html('{{ self.header_text() }}');

--- a/flask_admin/templates/bootstrap2/admin/file/form.html
+++ b/flask_admin/templates/bootstrap2/admin/file/form.html
@@ -1,10 +1,10 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
     {%- else -%}
       <h3>{{ header_text }}</h3>
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
     <script>
     // fill the header of modal dynamically
     $('.modal-header h3').html('{{ header_text }}');

--- a/flask_admin/templates/bootstrap2/admin/file/form.html
+++ b/flask_admin/templates/bootstrap2/admin/file/form.html
@@ -1,6 +1,27 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+    {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    {{ lib.render_form(form, dir_url) }}
+    {%- if request.args.get('modal') -%}
+      {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+    {%- else -%}
+      <h3>{{ header_text }}</h3>
+      {{ lib.render_form(form, dir_url) }}
+    {%- endif -%}
+{% endblock %}
+
+{% block tail %}
+    {%- if request.args.get('modal') -%}
+    <script>
+    // fill the header of modal dynamically
+    $('.modal-header h3').html('{{ header_text }}');
+
+    // fixes "remote modal shows same content every time"
+    $('.modal').on('hidden', function() {
+        $(this).removeData('modal');
+    });
+    </script>
+    {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/file/list.html
+++ b/flask_admin/templates/bootstrap2/admin/file/list.html
@@ -50,9 +50,15 @@
             <td>
                 {% block list_row_actions scoped %}
                 {% if admin_view.can_rename and path and name != '..' %}
-                <a class="icon" href="{{ get_url('.rename', path=path) }}">
-                        <i class="fa fa-pencil icon-pencil"></i>
-                </a>
+                  {%- if admin_view.rename_modal -%}
+                    {{ lib.add_modal_button(url=get_url('.rename', path=path, modal=True),
+                                            title=_gettext('Rename File'),
+                                            content='<i class="fa fa-pencil icon-pencil"></i>') }}
+                  {% else %}
+                    <a class="icon" href="{{ get_url('.rename', path=path) }}" title="{{ _gettext('Rename File') }}">
+                      <i class="fa fa-pencil icon-pencil"></i>
+                    </a>
+                  {%- endif -%}
                 {% endif %}
                 {%- if admin_view.can_delete and path -%}
                     {% if is_dir %}
@@ -86,9 +92,14 @@
             {% else %}
             <td>
                 {% if admin_view.can_download %}
-                <a href="{{ get_file_url(path)|safe }}">{{ name }}</a>
+                  {%- if admin_view.edit_modal and admin_view.is_file_editable(path) -%}
+                    {{ lib.add_modal_button(url=get_file_url(path, modal=True)|safe,
+                                            btn_class='', content=name) }}
+                  {% else %}
+                    <a href="{{ get_file_url(path)|safe }}">{{ name }}</a>
+                  {%- endif -%}
                 {% else %}
-                {{ name }}
+                  {{ name }}
                 {% endif %}
             </td>
             <td>
@@ -104,12 +115,24 @@
     <div class="btn-toolbar">
         {% if admin_view.can_upload %}
         <div class="btn-group">
-            <a class="btn btn-large" href="{{ get_dir_url('.upload', path=dir_path) }}">{{ _gettext('Upload File') }}</a>
+            {%- if admin_view.upload_modal -%}
+              {{ lib.add_modal_button(url=get_dir_url('.upload', path=dir_path, modal=True),
+                                      btn_class="btn btn-large",
+                                      content=_gettext('Upload File')) }}
+            {% else %}
+              <a class="btn btn-large" href="{{ get_dir_url('.upload', path=dir_path) }}">{{ _gettext('Upload File') }}</a>
+            {%- endif -%}
         </div>
         {% endif %}
         {% if admin_view.can_mkdir %}
         <div class="btn-group">
-            <a class="btn btn-large" href="{{ get_dir_url('.mkdir', path=dir_path) }}">{{ _gettext('Create Directory') }}</a>
+            {%- if admin_view.mkdir_modal -%}
+              {{ lib.add_modal_button(url=get_dir_url('.mkdir', path=dir_path, modal=True),
+                                      btn_class="btn btn-large",
+                                      content=_gettext('Create Directory')) }}
+            {% else %}
+              <a class="btn btn-large" href="{{ get_dir_url('.mkdir', path=dir_path) }}">{{ _gettext('Create Directory') }}</a>
+            {%- endif -%}
         </div>
         {% endif %}
         {% if actions %}
@@ -119,14 +142,20 @@
         {% endif %}
     </div>
     {% endblock %}
+
     {% block actions %}
     {{ actionslib.form(actions, get_url('.action_view')) }}
     {% endblock %}
+
+    {%- if admin_view.rename_modal or admin_view.mkdir_modal
+           or admin_view.upload_modal or admin_view.edit_modal -%}
+        {{ lib.add_modal_window() }}
+    {%- endif -%}
 {% endblock %}
 
 {% block tail %}
     {{ super() }}
     {{ actionslib.script(_gettext('Please select at least one file.'),
-                      actions,
-                      actions_confirmation) }}
+                         actions,
+                         actions_confirmation) }}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/file/rename.html
+++ b/flask_admin/templates/bootstrap2/admin/file/rename.html
@@ -1,7 +1,30 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+  {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    <h3>{{ _gettext('Please provide new name for %(name)s', name=name) }}</h3>
+  {%- if request.args.get('modal') -%}
+    {# content added to modal-content #}
+    {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+  {%- else -%}
+    {% block header_text -%}
+      {{ _gettext('Rename %(name)s', name=name) }}
+    {%- endblock %}
     {{ lib.render_form(form, dir_url) }}
+  {%- endif -%}
+{% endblock %}
+
+{% block tail %}
+  {%- if request.args.get('modal') -%}
+  <script>
+  // fill the header of modal dynamically
+  $('.modal-header h3').html('{{ self.header_text() }}');
+
+  // fixes "remote modal shows same content every time"
+  $('.modal').on('hidden', function() {
+      $(this).removeData('modal');
+  });
+  </script>
+  {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/file/rename.html
+++ b/flask_admin/templates/bootstrap2/admin/file/rename.html
@@ -1,22 +1,22 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
   {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
     {# content added to modal-content #}
     {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
   {%- else -%}
-    {% block header_text -%}
+    <h3>{% block header_text -%}
       {{ _gettext('Rename %(name)s', name=name) }}
-    {%- endblock %}
+    {%- endblock %}</h3>
     {{ lib.render_form(form, dir_url) }}
   {%- endif -%}
 {% endblock %}
 
 {% block tail %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
   <script>
   // fill the header of modal dynamically
   $('.modal-header h3').html('{{ self.header_text() }}');

--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -113,8 +113,8 @@
   </div>
 {% endmacro %}
 
-{% macro add_modal_button(url='', title='', content='', modal_window_id='fa_modal_window') %}
-  <a class="icon" href="#" data-toggle="modal" title="{{ title }}" data-target="#{{ modal_window_id }}" data-remote="{{ url }}">
+{% macro add_modal_button(url='', title='', content='', modal_window_id='fa_modal_window', btn_class='icon') %}
+  <a class="{{ btn_class }}" href="#" data-toggle="modal" title="{{ title }}" data-target="#{{ modal_window_id }}" data-remote="{{ url }}">
     {{ content|safe }}
   </a>
 {% endmacro %}

--- a/flask_admin/templates/bootstrap2/admin/model/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/create.html
@@ -17,8 +17,7 @@
 {% block body %}
   {%- if request.args.get('modal') -%}
     {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                       action=url_for('.create_view', url=return_url),
-                       is_modal=request.args.get('modal')) }}
+                       action=request.url, is_modal=True) }}
   {%- else -%}
     {% block navlinks %}
       <ul class="nav nav-tabs">
@@ -31,9 +30,7 @@
 	  </ul>
     {% endblock %}
 
-    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts,
-                       action=url_for('.create_view', url=return_url),
-                       is_modal=request.args.get('modal')) }}
+    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts) }}
   {%- endif -%}
 {% endblock %}
 
@@ -41,7 +38,7 @@
   {%- if request.args.get('modal') -%}
     <script>
     // fill the header of modal dynamically
-    $('.modal-header h3').html('{% block modal_header %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}');
+    $('.modal-header h3').html('{% block header_text %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}');
 
     // fixes "remote modal shows same content every time"
     $('.modal').on('hidden', function() {

--- a/flask_admin/templates/bootstrap2/admin/model/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/create.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,14 +8,14 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not request.args.get('modal') -%}
+  {%- if not modal -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
     {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                        action=request.url, is_modal=True) }}
   {%- else -%}
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block tail %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
     <script>
     // fill the header of modal dynamically
     $('.modal-header h3').html('{% block header_text %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}');

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -18,12 +18,23 @@
     {%- if request.args.get('modal') -%}
       {# remove save and continue button for modal (it won't function properly) #}
       {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                         action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=request.args.get('modal')) }}
+                         action=request.url, is_modal=True) }}
     {%- else -%}
-      {{ lib.render_form(form, return_url, extra(), form_opts,
-                         action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=request.args.get('modal')) }}
+      {% block navlinks %}
+        <ul class="nav nav-tabs">
+          <li>
+              <a href="{{ return_url }}">{{ _gettext('List') }}</a>
+          </li>
+          <li>
+              <a href="{{ get_url('.create_view', url=return_url) }}">{{ _gettext('Create') }}</a>
+          </li>
+          <li class="active">
+              <a href="javascript:void(0)">{{ _gettext('Edit') }}</a>
+          </li>
+      </ul>
+      {% endblock %}
+
+      {{ lib.render_form(form, return_url, extra(), form_opts) }}
     {%- endif -%}
 {% endblock %}
 
@@ -31,7 +42,9 @@
     {%- if request.args.get('modal') -%}
       <script>
       // fill the header of modal dynamically
-      $('.modal-header h3').html('{% block modal_header %}<h3>{{ _gettext('Edit Record') + ' #' + request.args.get('id') }}</h3>{% endblock %}');
+      $('.modal-header h3').html('{% block header_text -%}
+        {{ _gettext('Edit Record') + ' #' + request.args.get('id') }}
+      {%- endblock %}');
 
       // fixes "remote modal shows same content every time"
       $('.modal').on('hidden', function() {

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,14 +8,14 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not request.args.get('modal') -%}
+  {%- if not modal -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {# remove save and continue button for modal (it won't function properly) #}
       {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                          action=request.url, is_modal=True) }}
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       <script>
       // fill the header of modal dynamically
       $('.modal-header h3').html('{% block header_text -%}

--- a/flask_admin/templates/bootstrap3/admin/file/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/file/edit.html
@@ -1,11 +1,45 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+  {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
-{% block body %}
-    <h3>{{ _gettext('You are editing %(path)s', path=path) }}</h3>
+{% macro check_error(error) %}
     {% if error %}
-    <span>This file cannot be edited for now.</span>
+      <span>{{ _gettext('This file cannot be edited for now.') }}</span>
     {% else %}
-    {{ lib.render_form(form, dir_url) }}
+      {{ caller() }}
     {% endif %}
+{% endmacro %}
+
+{% block body %}
+    {%- if request.args.get('modal') -%}
+      {# content added to modal-content #}
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        {% block header_text %}
+            <h3>{{ _gettext('Editing %(path)s', path=path) }}</h3>
+        {% endblock %}
+      </div>
+      <div class="modal-body">
+        {% call check_error(error) %}
+          {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+        {% endcall %}
+      </div>
+    {%- else -%}
+      {{ self.header_text() }}
+      {% call check_error(error) %}
+        {{ lib.render_form(form, dir_url) }}
+      {% endcall %}
+    {%- endif -%}
+{% endblock %}
+
+{% block tail %}
+    {%- if request.args.get('modal') -%}
+    <script>
+    // fixes "remote modal shows same content every time", avoiding the flicker
+    $('body').on('hidden.bs.modal', '.modal', function() {
+        $(this).removeData('bs.modal').find(".modal-content").empty();
+    });
+    </script>
+    {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/file/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/file/edit.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
   {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
     <script>
     // fixes "remote modal shows same content every time", avoiding the flicker
     $('body').on('hidden.bs.modal', '.modal', function() {

--- a/flask_admin/templates/bootstrap3/admin/file/form.html
+++ b/flask_admin/templates/bootstrap3/admin/file/form.html
@@ -1,10 +1,10 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
     <script>
     // fixes "remote modal shows same content every time", avoiding the flicker
     $('body').on('hidden.bs.modal', '.modal', function() {

--- a/flask_admin/templates/bootstrap3/admin/file/form.html
+++ b/flask_admin/templates/bootstrap3/admin/file/form.html
@@ -1,6 +1,32 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+    {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    {{ lib.render_form(form, dir_url) }}
+    {%- if request.args.get('modal') -%}
+      {# content added to modal-content #}
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h3>{{ header_text }}</h3>
+      </div>
+      <div class="modal-body">
+        {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+      </div>
+    {%- else -%}
+      <h3>{{ header_text }}</h3>
+      {{ lib.render_form(form, dir_url) }}
+    {%- endif -%}
+
+{% endblock %}
+
+{% block tail %}
+    {%- if request.args.get('modal') -%}
+    <script>
+    // fixes "remote modal shows same content every time", avoiding the flicker
+    $('body').on('hidden.bs.modal', '.modal', function() {
+        $(this).removeData('bs.modal').find(".modal-content").empty();
+    });
+    </script>
+    {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/file/list.html
+++ b/flask_admin/templates/bootstrap3/admin/file/list.html
@@ -50,9 +50,15 @@
             <td>
                 {% block list_row_actions scoped %}
                 {% if admin_view.can_rename and path and name != '..' %}
-                <a class="icon" href="{{ get_url('.rename', path=path) }}">
-                        <i class="fa fa-pencil glyphicon glyphicon-pencil"></i>
-                </a>
+                  {%- if admin_view.rename_modal -%}
+                    {{ lib.add_modal_button(url=get_url('.rename', path=path, modal=True),
+                                            title=_gettext('Rename File'),
+                                            content='<i class="fa fa-pencil glyphicon glyphicon-pencil"></i>') }}
+                  {% else %}
+                    <a class="icon" href="{{ get_url('.rename', path=path) }}" title="{{ _gettext('Rename File') }}">
+                      <i class="fa fa-pencil glyphicon glyphicon-pencil"></i>
+                    </a>
+                  {%- endif -%}
                 {% endif %}
                 {%- if admin_view.can_delete and path -%}
                     {% if is_dir %}
@@ -86,9 +92,14 @@
             {% else %}
             <td>
                 {% if admin_view.can_download %}
-                <a href="{{ get_file_url(path)|safe }}">{{ name }}</a>
+                  {%- if admin_view.edit_modal and admin_view.is_file_editable(path) -%}
+                    {{ lib.add_modal_button(url=get_file_url(path, modal=True)|safe,
+                                            btn_class='', content=name) }}
+                  {% else %}
+                    <a href="{{ get_file_url(path)|safe }}">{{ name }}</a>
+                  {%- endif -%}
                 {% else %}
-                {{ name }}
+                  {{ name }}
                 {% endif %}
             </td>
             <td>
@@ -104,12 +115,24 @@
     <div class="btn-toolbar">
         {% if admin_view.can_upload %}
         <div class="btn-group">
-            <a class="btn btn-default btn-large" href="{{ get_dir_url('.upload', path=dir_path) }}">{{ _gettext('Upload File') }}</a>
+            {%- if admin_view.upload_modal -%}
+              {{ lib.add_modal_button(url=get_dir_url('.upload', path=dir_path, modal=True),
+                                      btn_class="btn btn-default btn-large",
+                                      content=_gettext('Upload File')) }}
+            {% else %}
+              <a class="btn btn-default btn-large" href="{{ get_dir_url('.upload', path=dir_path) }}">{{ _gettext('Upload File') }}</a>
+            {%- endif -%}
         </div>
         {% endif %}
         {% if admin_view.can_mkdir %}
         <div class="btn-group">
-            <a class="btn btn-default btn-large" href="{{ get_dir_url('.mkdir', path=dir_path) }}">{{ _gettext('Create Directory') }}</a>
+            {%- if admin_view.mkdir_modal -%}
+              {{ lib.add_modal_button(url=get_dir_url('.mkdir', path=dir_path, modal=True),
+                                      btn_class="btn btn-default btn-large",
+                                      content=_gettext('Create Directory')) }}
+            {% else %}
+              <a class="btn btn-default btn-large" href="{{ get_dir_url('.mkdir', path=dir_path) }}">{{ _gettext('Create Directory') }}</a>
+            {%- endif -%}
         </div>
         {% endif %}
         {% if actions %}
@@ -119,14 +142,20 @@
         {% endif %}
     </div>
     {% endblock %}
+
     {% block actions %}
     {{ actionslib.form(actions, get_url('.action_view')) }}
     {% endblock %}
+
+    {%- if admin_view.rename_modal or admin_view.mkdir_modal
+           or admin_view.upload_modal or admin_view.edit_modal -%}
+        {{ lib.add_modal_window() }}
+    {%- endif -%}
 {% endblock %}
 
 {% block tail %}
     {{ super() }}
     {{ actionslib.script(_gettext('Please select at least one file.'),
-                      actions,
-                      actions_confirmation) }}
+                         actions,
+                         actions_confirmation) }}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/file/rename.html
+++ b/flask_admin/templates/bootstrap3/admin/file/rename.html
@@ -1,10 +1,10 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
     <script>
     // fixes "remote modal shows same content every time", avoiding the flicker
     $('body').on('hidden.bs.modal', '.modal', function() {

--- a/flask_admin/templates/bootstrap3/admin/file/rename.html
+++ b/flask_admin/templates/bootstrap3/admin/file/rename.html
@@ -1,7 +1,33 @@
-{% extends 'admin/master.html' %}
+{%- if not request.args.get('modal') -%}
+    {% extends 'admin/master.html' %}
+{%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-    <h3>{{ _gettext('Please provide new name for %(name)s', name=name) }}</h3>
-    {{ lib.render_form(form, dir_url) }}
+    {%- if request.args.get('modal') -%}
+      {# content added to modal-content #}
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        {% block header_text %}
+            <h3>{{ _gettext('Rename %(name)s', name=name) }}</h3>
+        {% endblock %}
+      </div>
+      <div class="modal-body">
+        {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+      </div>
+    {%- else -%}
+      <h3>{{ self.header_text() }}</h3>
+      {{ lib.render_form(form, dir_url) }}
+    {%- endif -%}
+{% endblock %}
+
+{% block tail %}
+    {%- if request.args.get('modal') -%}
+    <script>
+    // fixes "remote modal shows same content every time", avoiding the flicker
+    $('body').on('hidden.bs.modal', '.modal', function() {
+        $(this).removeData('bs.modal').find(".modal-content").empty();
+    });
+    </script>
+    {%- endif -%}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -108,8 +108,8 @@
   </div>
 {% endmacro %}
 
-{% macro add_modal_button(url='', title='', content='', modal_window_id='fa_modal_window') %}
-  <a class="icon" data-target="#{{ modal_window_id }}" title="{{ title }}" href="{{ url }}" data-toggle="modal">
+{% macro add_modal_button(url='', title='', content='', modal_window_id='fa_modal_window', btn_class='icon') %}
+  <a class="{{ btn_class }}" data-target="#{{ modal_window_id }}" title="{{ title }}" href="{{ url }}" data-toggle="modal">
     {{ content|safe }}
   </a>
 {% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/model/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/create.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,14 +8,14 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not request.args.get('modal') -%}
+  {%- if not modal -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
     <div class="modal-header">
       <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       {% block header_text %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block tail %}
-  {%- if request.args.get('modal') -%}
+  {%- if modal -%}
     <script>
     // fixes "remote modal shows same content every time", avoiding the flicker
     $('body').on('hidden.bs.modal', '.modal', function () {

--- a/flask_admin/templates/bootstrap3/admin/model/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/create.html
@@ -18,13 +18,12 @@
   {%- if request.args.get('modal') -%}
     <div class="modal-header">
       <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      {% block modal_header %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}
+      {% block header_text %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}
     </div>
     <div class="modal-body">
       {# remove save and continue button for modal (it won't function properly) #}
-      {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                         action=url_for('.create_view', url=return_url),
-                         is_modal=request.args.get('modal')) }}
+      {{ lib.render_form(form, return_url, extra(), form_opts=form_opts,
+                         action=request.url, is_modal=True) }}
     </div>
   {%- else -%}
     {% block navlinks %}
@@ -38,9 +37,7 @@
       </ul>
     {% endblock %}
 
-    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts,
-                       action=url_for('.create_view', url=return_url),
-                       is_modal=request.args.get('modal')) }}
+    {{ lib.render_form(form, return_url, extra(), form_opts=form_opts) }}
   {%- endif -%}
 {% endblock %}
 

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -1,4 +1,4 @@
-{%- if not request.args.get('modal') -%}
+{%- if not modal -%}
     {% extends 'admin/master.html' %}
 {%- endif -%}
 {% import 'admin/lib.html' as lib with context %}
@@ -8,14 +8,14 @@
 {% endmacro %}
 
 {% block head %}
-  {%- if not request.args.get('modal') -%}
+  {%- if not modal -%}
     {{ super() }}
     {{ lib.form_css() }}
   {%- endif -%}
 {% endblock %}
 
 {% block body %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -48,7 +48,7 @@
 {% endblock %}
 
 {% block tail %}
-    {%- if request.args.get('modal') -%}
+    {%- if modal -%}
       <script>
       // fixes "remote modal shows same content every time", avoiding the flicker
       $('body').on('hidden.bs.modal', '.modal', function () {

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -19,18 +19,31 @@
       {# content added to modal-content #}
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        {% block modal_header %}<h3>{{ _gettext('Edit Record') + ' #' + request.args.get('id') }}</h3>{% endblock %}
+        {% block header_text %}
+          <h3>{{ _gettext('Edit Record') + ' #' + request.args.get('id') }}</h3>
+        {% endblock %}
       </div>
       <div class="modal-body">
         {# remove save and continue button for modal (it won't function properly) #}
         {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                           action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                           is_modal=request.args.get('modal')) }}
+                           action=request.url, is_modal=True) }}
       </div>
     {%- else -%}
-      {{ lib.render_form(form, return_url, extra(), form_opts,
-                         action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                         is_modal=request.args.get('modal')) }}
+      {% block navlinks %}
+        <ul class="nav nav-tabs">
+          <li>
+              <a href="{{ return_url }}">{{ _gettext('List') }}</a>
+          </li>
+          <li>
+              <a href="{{ get_url('.create_view', url=return_url) }}">{{ _gettext('Create') }}</a>
+          </li>
+          <li class="active">
+              <a href="javascript:void(0)">{{ _gettext('Edit') }}</a>
+          </li>
+        </ul>
+      {% endblock %}
+
+      {{ lib.render_form(form, return_url, extra(), form_opts) }}
     {%- endif -%}
 {% endblock %}
 

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -168,7 +168,9 @@
     {% endblock %}
     {% endblock %}
 
+    {% block actions %}
     {{ actionlib.form(actions, get_url('.action_view')) }}
+    {% endblock %}
 
     {%- if admin_view.edit_modal or admin_view.create_modal -%}
         {{ lib.add_modal_window() }}


### PR DESCRIPTION
This pull request mainly adds modals to Fileadmin's edit, mkdir, upload, and rename views.

Minor changes:
* Add header to create directory and file upload forms.
* Add success messages when directory is created or file is uploaded.
* Added get_text to untranslated "This file cannot be edited for now." message.
* Simplifed edit_view and create_view modal button macro call by removing unnecessary parameters.
* Changed "Please provide new name for" in rename view header to simply "Rename".
* Changed "You are editing" in edit view header to simply "Editing".
* Add tabs to .edit_view for in model_view to be consistent with create view.
* Add missing "{% block actions %}" block to bootstrap3/admin/model/list.html (bootstrap2 has it).
* Changed "modal_header" block in edit_view and create_view name to "header_text" to indicate it's not just for modals.
* Now using simpler "if modal" in templates instead of "if request.args.get('modal')".