### PR TITLE
Update conv_Boolean to support MSSQL BIT type

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -288,7 +288,7 @@ class AdminModelConverter(ModelConverterBase):
         self._string_common(field_args=field_args, **extra)
         return fields.TextAreaField(**field_args)
 
-    @converts('Boolean')
+    @converts('Boolean', 'sqlalchemy.dialects.mssql.base.BIT')
     def conv_Boolean(self, field_args, **extra):
         return fields.BooleanField(**field_args)
 


### PR DESCRIPTION
A quirk I ran into when using flask_admin with a MS SQL backend.

Updates ```contrib/sqla/form.py```'s ```AdminModelConvert.conv_Boolean``` to register as a valid converter for the MS SQL "BIT" type.

I've also run into an issue whereupon MS SQL will error if an OFFSET is provided without an explicit ORDER BY. This breaks pagination for any subclass of ```flask_admin.contrib.sqla.ModelView``` that doesn't provide a `column_default_sort`. I'd be happy to include a patch that throws a ```RuntimeError``` with a helpful message or, if you have an idea for setting default sort order, I can try and run that down and send you code.