### PR TITLE
Make field description(help block) html safe and can output html tags.

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -137,7 +137,7 @@
       {{ field(**kwargs)|safe }}
     </div>
     {% if field.description %}
-    <p class="help-block">{{ field.description }}</p>
+    <p class="help-block">{{ field.description|safe }}</p>
     {% endif %}
     {% if direct_error %}
       <ul class="input-errors">

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -129,7 +129,7 @@
       {% set _dummy = kwargs.setdefault('class', 'form-control') %}
       {{ field(**kwargs)|safe }}
       {% if field.description %}
-      <p class="help-block">{{ field.description }}</p>
+      <p class="help-block">{{ field.description|safe }}</p>
       {% endif %}
       {% if direct_error %}
         <ul class="help-block input-errors">


### PR DESCRIPTION
Since content of field description is controlled by developer, so it's reasonable to assume it should be safe and output them in the UI directly, this pull request is to make including additional style in the help block possible.