### PR TITLE
Make fields without inline edit html safe by default

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -142,7 +142,7 @@
                         {{ form[c](pk=get_pk_value(row), value=get_value(row, c)) }}
                         {% endif %}
                     {% else %}
-                    {{ get_value(row, c) }}
+                    {{ get_value(row, c) | safe }}
                     {% endif %}
                     </td>
                 {% endfor %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -141,7 +141,7 @@
                         {{ form[c](pk=get_pk_value(row), value=get_value(row, c)) }}
                         {% endif %}
                     {% else %}
-                    {{ get_value(row, c) }}
+                    {{ get_value(row, c) | safe}}
                     {% endif %}
                     </td>
                 {% endfor %}


### PR DESCRIPTION
Make fields in list page html safe by default, for the ability to render field in different style, only assume it's safe if the field is configured without inline edit.