### PR TITLE
use lazy_gettext with pymongo filters

### DIFF
--- a/flask_admin/contrib/pymongo/filters.py
+++ b/flask_admin/contrib/pymongo/filters.py
@@ -1,6 +1,6 @@
 import re
 
-from flask_admin.babel import gettext
+from flask_admin.babel import lazy_gettext
 from flask_admin.model import filters
 
 from .tools import parse_like_term
@@ -35,7 +35,7 @@ class FilterEqual(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('equals')
+        return lazy_gettext('equals')
 
 
 class FilterNotEqual(BasePyMongoFilter):
@@ -44,7 +44,7 @@ class FilterNotEqual(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('not equal')
+        return lazy_gettext('not equal')
 
 
 class FilterLike(BasePyMongoFilter):
@@ -54,7 +54,7 @@ class FilterLike(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('contains')
+        return lazy_gettext('contains')
 
 
 class FilterNotLike(BasePyMongoFilter):
@@ -64,7 +64,7 @@ class FilterNotLike(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('not contains')
+        return lazy_gettext('not contains')
 
 
 class FilterGreater(BasePyMongoFilter):
@@ -77,7 +77,7 @@ class FilterGreater(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('greater than')
+        return lazy_gettext('greater than')
 
 
 class FilterSmaller(BasePyMongoFilter):
@@ -90,7 +90,7 @@ class FilterSmaller(BasePyMongoFilter):
         return query
 
     def operation(self):
-        return gettext('smaller than')
+        return lazy_gettext('smaller than')
 
 
 # Customized type filters


### PR DESCRIPTION
Finishes adding lazy_gettext to all the filters to fix the issue @tahajahangir mentioned in #514: "Filters are cached at import time, so their language will stick on default language. This prevents localizitation of filters."

