### PR TITLE
SQLAlchemy: Don’t require data for text fields that have a empty string as default value

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -205,7 +205,11 @@ class AdminModelConverter(ModelConverterBase):
 
                 optional_types = getattr(self.view, 'form_optional_types', (Boolean,))
 
-                if not column.nullable and not isinstance(column.type, optional_types):
+                if (
+                    not column.nullable
+                    and not isinstance(column.type, optional_types)
+                    and not column.default
+                ):
                     kwargs['validators'].append(validators.InputRequired())
 
                 # Apply label and description if it isn't inline form field


### PR DESCRIPTION
Current behavior by Flask-Admin is to treat all fields with `nullable=False` as required even if they have `default=''` set. This PR changes this behavior so that one does not have to enter a value if both of these conditions are met.

It might not be totally clear from the formatting but the only difference is the added `and not column.default` to the if-statement.