### PR TITLE
Call _on_model_change() before session.add()

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -982,8 +982,8 @@ class ModelView(BaseModelView):
         try:
             model = self.model()
             form.populate_obj(model)
-            self.session.add(model)
             self._on_model_change(form, model, True)
+            self.session.add(model)
             self.session.commit()
         except Exception as ex:
             if not self.handle_view_exception(ex):


### PR DESCRIPTION
_on_model_change() should be called before the object is added to the session, to allow things like populate a primary key before the INSERT statement is sent to the database.