### PR TITLE
Bugfix - Non pk ObjectFields were ignored

### DIFF
--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -297,15 +297,12 @@ class ModelView(BaseModelView):
             # Verify type
             field_class = type(f)
 
-            if (field_class == mongoengine.ListField and
-                isinstance(f.field, mongoengine.EmbeddedDocumentField)):
+            if (field_class == mongoengine.ListField and isinstance(f.field, mongoengine.EmbeddedDocumentField) or
+                    (field_class == mongoengine.EmbeddedDocumentField) or
+                    (n == self.scaffold_pk() and not self.column_display_pk)):
                 continue
 
-            if field_class == mongoengine.EmbeddedDocumentField:
-                continue
-
-            if self.column_display_pk or field_class != mongoengine.ObjectIdField:
-                columns.append(n)
+            columns.append(n)
 
         return columns
 

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -297,9 +297,13 @@ class ModelView(BaseModelView):
             # Verify type
             field_class = type(f)
 
-            if (field_class == mongoengine.ListField and isinstance(f.field, mongoengine.EmbeddedDocumentField) or
-                    (field_class == mongoengine.EmbeddedDocumentField) or
-                    (n == self.scaffold_pk() and not self.column_display_pk)):
+            is_ignored_field = (
+                field_class == mongoengine.ListField and isinstance(f.field, mongoengine.EmbeddedDocumentField) or
+                (field_class == mongoengine.EmbeddedDocumentField) or
+                (n == self.scaffold_pk() and not self.column_display_pk)
+            )
+
+            if is_ignored_field:
                 continue
 
             columns.append(n)


### PR DESCRIPTION
Now, only the pk field is ignored if `column_display_pk` is not True. The rest of the `ObjectField`s are shown.
