### PR TITLE
Column sort follows ForeignKeys

### DIFF
--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -288,7 +288,9 @@ class ModelView(BaseModelView):
 
     def _order_by(self, query, joins, sort_field, sort_desc):
         if isinstance(sort_field, string_types):
-            field = getattr(self.model, sort_field)
+            field = self.model
+            for f in sort_field.split('.'):
+                field = getattr(field.rel_model if isinstance(field, ForeignKeyField) else field, f)
             query = query.order_by(field.desc() if sort_desc else field.asc())
         elif isinstance(sort_field, Field):
             if sort_field.model_class != self.model:

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -65,13 +65,14 @@ def create_models(db):
 
     class Model2(BaseModel):
         def __init__(self, char_field=None, int_field=None, float_field=None,
-                     bool_field=0):
+                     bool_field=0, model1=None):
             super(Model2, self).__init__()
 
             self.char_field = char_field
             self.int_field = int_field
             self.float_field = float_field
             self.bool_field = bool_field
+            self.model1 = model1
 
         char_field = peewee.CharField(max_length=20)
         int_field = peewee.IntegerField(null=True)
@@ -819,6 +820,39 @@ def test_default_sort():
     eq_(data[0].test1, 'a')
     eq_(data[1].test1, 'b')
     eq_(data[2].test1, 'c')
+
+
+def test_complex_sort():
+    app, db, admin = setup()
+    M1, M2 = create_models(db)
+
+    a = M1('a', 1)
+    b = M1('b', 2)
+    c = M1('c', 3)
+
+    a.save()
+    b.save()
+    c.save()
+
+    M2('c', model1=c).save()
+    M2('b', model1=b).save()
+    M2('a', model1=a).save()
+
+    eq_(M1.select().count(), 3)
+
+    class CustomModelView2(CustomModelView):
+        def get_query(self):
+            query = super(CustomModelView2, self).get_query()
+            return query.select(M2, M1).join(M1)
+
+    view = CustomModelView2(M2, column_default_sort='model1.test1')
+    admin.add_view(view)
+
+    _, data = view.get_list(0, None, None, None, None)
+
+    eq_(data[0].char_field, 'a')
+    eq_(data[1].char_field, 'b')
+    eq_(data[2].char_field, 'c')
 
 
 def test_extra_fields():


### PR DESCRIPTION
You have two models:

```python
from peewee import ForeignKey, PrimaryKey, CharField, Model

class Purchase(Model):
     user = ForeignKey(User)

class User(Model):
    id = PrimaryKey()
    name = CharField()
```

Before you could not write

```python
class PurchaseView(ModelView):
    column_sortable_list = (('user', 'user.name'), )
```

because it would fail saying that 'user.name' is not a field of Purchase.

I tried with:

```python
class PurchaseView(ModelView):
    column_sortable_list = (('user', User.name), )
```

but I have an exception

```
 OperationalError: (1066, "Not unique table/alias: 't2'")
```

What I do is splitting on the dot and following foreign keys.