### PR TITLE
Change buttons on edit/create views, change redirect behavior

### DIFF
--- a/babel/admin.pot
+++ b/babel/admin.pot
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Admin VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-07-28 00:55-0500\n"
+"POT-Creation-Date: 2015-08-14 19:32-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.0\n"
 
 #: ../flask_admin/base.py:431
 msgid "Home"
@@ -197,10 +197,10 @@ msgid "File deletion is disabled."
 msgstr ""
 
 #: ../flask_admin/contrib/fileadmin.py:919
-#: ../flask_admin/templates/bootstrap2/admin/model/details.html:15
-#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:23
-#: ../flask_admin/templates/bootstrap3/admin/model/details.html:15
-#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:23
+#: ../flask_admin/templates/bootstrap2/admin/model/details.html:17
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:26
+#: ../flask_admin/templates/bootstrap3/admin/model/details.html:17
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:26
 msgid "Edit"
 msgstr ""
 
@@ -298,8 +298,8 @@ msgstr ""
 #: ../flask_admin/contrib/mongoengine/view.py:565
 #: ../flask_admin/contrib/peewee/view.py:399
 #: ../flask_admin/contrib/pymongo/view.py:309
-#: ../flask_admin/contrib/sqla/view.py:1016 ../flask_admin/model/base.py:1839
-#: ../flask_admin/model/base.py:1848
+#: ../flask_admin/contrib/sqla/view.py:1016 ../flask_admin/model/base.py:1845
+#: ../flask_admin/model/base.py:1854
 #, python-format
 msgid "Failed to update record. %(error)s"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 #: ../flask_admin/contrib/mongoengine/view.py:640
 #: ../flask_admin/contrib/peewee/view.py:450
 #: ../flask_admin/contrib/pymongo/view.py:363
-#: ../flask_admin/contrib/sqla/view.py:1078 ../flask_admin/model/base.py:1787
+#: ../flask_admin/contrib/sqla/view.py:1078 ../flask_admin/model/base.py:1793
 #, python-format
 msgid "Record was successfully deleted."
 msgid_plural "%(count)s records were successfully deleted."
@@ -390,12 +390,12 @@ msgstr ""
 msgid "Record was successfully created."
 msgstr ""
 
-#: ../flask_admin/model/base.py:1699 ../flask_admin/model/base.py:1748
-#: ../flask_admin/model/base.py:1782
+#: ../flask_admin/model/base.py:1702 ../flask_admin/model/base.py:1754
+#: ../flask_admin/model/base.py:1788
 msgid "Record does not exist."
 msgstr ""
 
-#: ../flask_admin/model/base.py:1708 ../flask_admin/model/base.py:1844
+#: ../flask_admin/model/base.py:1711 ../flask_admin/model/base.py:1850
 msgid "Record was successfully saved."
 msgstr ""
 
@@ -417,12 +417,12 @@ msgstr ""
 msgid "With selected"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/lib.html:199
+#: ../flask_admin/templates/bootstrap2/admin/lib.html:200
 #: ../flask_admin/templates/bootstrap3/admin/lib.html:190
 msgid "Save"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/lib.html:204
+#: ../flask_admin/templates/bootstrap2/admin/lib.html:205
 #: ../flask_admin/templates/bootstrap3/admin/lib.html:195
 msgid "Cancel"
 msgstr ""
@@ -479,55 +479,64 @@ msgid "Rename %(name)s"
 msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/create.html:5
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:5
 #: ../flask_admin/templates/bootstrap3/admin/model/create.html:5
-msgid "Save and Add"
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:5
+msgid "Save and Add Another"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/create.html:17
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:6
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:6
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:6
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:6
+msgid "Save and Continue Editing"
+msgstr ""
+
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:18
 #: ../flask_admin/templates/bootstrap2/admin/model/details.html:8
-#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:17
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:18
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:16
-#: ../flask_admin/templates/bootstrap3/admin/model/create.html:17
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:18
 #: ../flask_admin/templates/bootstrap3/admin/model/details.html:8
-#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:17
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:18
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:16
 msgid "List"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/create.html:20
-#: ../flask_admin/templates/bootstrap2/admin/model/details.html:11
-#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:20
+#: ../flask_admin/templates/bootstrap2/admin/model/create.html:21
+#: ../flask_admin/templates/bootstrap2/admin/model/details.html:12
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:22
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:22
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:24
-#: ../flask_admin/templates/bootstrap3/admin/model/create.html:20
-#: ../flask_admin/templates/bootstrap3/admin/model/details.html:11
-#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:20
+#: ../flask_admin/templates/bootstrap3/admin/model/create.html:21
+#: ../flask_admin/templates/bootstrap3/admin/model/details.html:12
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:22
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:22
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:24
 msgid "Create"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/details.html:19
+#: ../flask_admin/templates/bootstrap2/admin/model/details.html:21
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:111
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:113
 #: ../flask_admin/templates/bootstrap2/admin/model/modals/details.html:37
-#: ../flask_admin/templates/bootstrap3/admin/model/details.html:19
+#: ../flask_admin/templates/bootstrap3/admin/model/details.html:21
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:111
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:113
 #: ../flask_admin/templates/bootstrap3/admin/model/modals/details.html:8
 msgid "View Record"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/details.html:27
+#: ../flask_admin/templates/bootstrap2/admin/model/details.html:29
 #: ../flask_admin/templates/bootstrap2/admin/model/modals/details.html:8
-#: ../flask_admin/templates/bootstrap3/admin/model/details.html:26
+#: ../flask_admin/templates/bootstrap3/admin/model/details.html:28
 #: ../flask_admin/templates/bootstrap3/admin/model/modals/details.html:15
 msgid "Filter"
 msgstr ""
 
-#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:5
-#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:5
-msgid "Save and Continue"
+#: ../flask_admin/templates/bootstrap2/admin/model/edit.html:30
+#: ../flask_admin/templates/bootstrap3/admin/model/edit.html:30
+msgid "Details"
 msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/inline_list_base.html:13

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1658,13 +1658,16 @@ class BaseModelView(BaseView, ActionsMixin):
                 flash(gettext('Record was successfully created.'))
                 if '_add_another' in request.form:
                     return redirect(request.url)
-                else:
+                elif '_continue_editing' in request.form:
                     # if we have a valid model, try to go to the edit view
                     if model is not True:
                         url = self.get_url('.edit_view', id=self.get_pk_value(model), url=return_url)
                     else:
                         url = return_url
                     return redirect(url)
+                else:
+                    # save button
+                    return redirect(return_url)
 
         form_opts = FormOpts(widget_args=self.form_widget_args,
                              form_rules=self._form_create_rules)
@@ -1706,9 +1709,12 @@ class BaseModelView(BaseView, ActionsMixin):
         if self.validate_form(form):
             if self.update_model(form, model):
                 flash(gettext('Record was successfully saved.'))
-                if '_continue_editing' in request.form:
+                if '_add_another' in request.form:
+                    return redirect(self.get_url('.create_view', url=return_url))
+                elif '_continue_editing' in request.form:
                     return redirect(request.url)
                 else:
+                    # save button
                     return redirect(return_url)
 
         if request.method == 'GET':

--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -194,14 +194,15 @@
 {% endmacro %}
 
 {% macro render_form_buttons(cancel_url, extra=None, is_modal=False) %}
-    <div class="control-group">
+    <hr>
+    <div class="control-group pull-right">
       <div class="controls">
-        <input type="submit" class="btn btn-primary btn-large" value="{{ _gettext('Save') }}" />
+        <input type="submit" class="btn btn-primary" value="{{ _gettext('Save') }}" />
         {% if extra %}
         {{ extra }}
         {% endif %}
         {% if cancel_url %}
-          <a href="{{ cancel_url }}" class="btn btn-large btn-danger" {% if is_modal %}data-dismiss="modal"{% endif %}>{{ _gettext('Cancel') }}</a>
+          <a href="{{ cancel_url }}" class="btn btn-danger" {% if is_modal %}data-dismiss="modal"{% endif %}>{{ _gettext('Cancel') }}</a>
         {% endif %}
       </div>
     </div>

--- a/flask_admin/templates/bootstrap2/admin/model/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/create.html
@@ -2,7 +2,8 @@
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
-  <input name="_add_another" type="submit" class="btn btn-large" value="{{ _gettext('Save and Add') }}" />
+  <input name="_add_another" type="submit" class="btn" value="{{ _gettext('Save and Add Another') }}" />
+  <input name="_continue_editing" type="submit" class="btn" value="{{ _gettext('Save and Continue Editing') }}" />
 {% endmacro %}
 
 {% block head %}
@@ -22,7 +23,7 @@
   </ul>
   {% endblock %}
 
-  {{ lib.render_form(form, return_url, extra(), form_opts=form_opts) }}
+  {{ lib.render_form(form, cancel_url=None, extra=extra(), form_opts=form_opts) }}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -2,7 +2,8 @@
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
-  <input name="_continue_editing" type="submit" class="btn btn-large" value="{{ _gettext('Save and Continue') }}" />
+  <input name="_add_another" type="submit" class="btn" value="{{ _gettext('Save and Add Another') }}" />
+  <input name="_continue_editing" type="submit" class="btn" value="{{ _gettext('Save and Continue Editing') }}" />
 {% endmacro %}
 
 {% block head %}
@@ -26,13 +27,13 @@
     </li>
     {%- if admin_view.can_view_details -%}
     <li>
-        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('View Record') }}</a>
+        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('Details') }}</a>
     </li>
     {%- endif -%}
   </ul>
   {% endblock %}
 
-  {{ lib.render_form(form, return_url, extra(), form_opts) }}
+  {{ lib.render_form(form, cancel_url=None, extra=extra(), form_opts=form_opts) }}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/create.html
@@ -2,7 +2,7 @@
 {% import 'admin/lib.html' as lib with context %}
 
 {% block body %}
-  {# "save and continue" button is removed from modal (it won't function properly) #}
+  {# "save and add" button is removed from modal (it won't function properly) #}
   {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                      action=url_for('.create_view', url=return_url),
                      is_modal=True) }}

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -186,7 +186,7 @@
 {% macro render_form_buttons(cancel_url, extra=None, is_modal=False) %}
     <hr>
     <div class="form-group">
-      <div class="col-md-offset-2 col-md-10 submit-row">
+      <div class="col-md-offset-2 col-md-10 submit-row text-right">
         <input type="submit" class="btn btn-primary" value="{{ _gettext('Save') }}" />
         {% if extra %}
         {{ extra }}

--- a/flask_admin/templates/bootstrap3/admin/model/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/create.html
@@ -2,7 +2,8 @@
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
-  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add') }}" />
+  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add Another') }}" />
+  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue Editing') }}" />
 {% endmacro %}
 
 {% block head %}
@@ -22,7 +23,7 @@
   </ul>
   {% endblock %}
 
-  {{ lib.render_form(form, return_url, extra(), form_opts=form_opts) }}
+  {{ lib.render_form(form, cancel_url=None, extra=extra(), form_opts=form_opts) }}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -2,7 +2,8 @@
 {% import 'admin/lib.html' as lib with context %}
 
 {% macro extra() %}
-  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue') }}" />
+  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add Another') }}" />
+  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue Editing') }}" />
 {% endmacro %}
 
 {% block head %}
@@ -26,13 +27,13 @@
     </li>
     {%- if admin_view.can_view_details -%}
     <li>
-        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('View Record') }}</a>
+        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('Details') }}</a>
     </li>
     {%- endif -%}
   </ul>
   {% endblock %}
 
-  {{ lib.render_form(form, return_url, extra(), form_opts) }}
+  {{ lib.render_form(form, cancel_url=None, extra=extra(), form_opts=form_opts) }}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap3/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/create.html
@@ -7,7 +7,7 @@
     {% block header_text %}<h3>{{ _gettext('Create New Record') }}</h3>{% endblock %}
   </div>
   <div class="modal-body">
-    {# "save and continue" button is removed from modal (it won't function properly) #}
+    {# "save and add" button is removed from modal (it won't function properly) #}
     {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
                        action=url_for('.create_view', url=return_url),
                        is_modal=True) }}

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1824,7 +1824,8 @@ def test_safe_redirect():
     client = app.test_client()
 
     rv = client.post('/admin/model1/new/?url=http://localhost/admin/model2view/',
-                     data=dict(test1='test1large', test2='test2'))
+                     data=dict(test1='test1large', test2='test2',
+                               _continue_editing='Save and Continue Editing'))
 
     eq_(rv.status_code, 302)
     assert_true(rv.location.startswith('http://localhost/admin/model1/edit/'))
@@ -1832,7 +1833,8 @@ def test_safe_redirect():
     assert_true('id=1' in rv.location)
 
     rv = client.post('/admin/model1/new/?url=http://google.com/evil/',
-                     data=dict(test1='test1large', test2='test2'))
+                     data=dict(test1='test1large', test2='test2',
+                               _continue_editing='Save and Continue Editing'))
 
     eq_(rv.status_code, 302)
     assert_true(rv.location.startswith('http://localhost/admin/model1/edit/'))


### PR DESCRIPTION
Fixes #884 (see discussion in #831 for more background info)

Create View: ![new create view](https://i.imgur.com/obfABK7.png)

Edit View:  ![new create view](https://i.imgur.com/v2yGzL7.png)

Here's the list of changes:
* Save button now redirects back to list view. But, there is now a "Save and Continue Editing" button on the ```.create_view```.
* Both ```.edit_view``` and ```.create_view``` have the same 3 buttons now.
* Changed "Save and Add" to "Save and Add Another"
* Changed "Save and Continue" to "Save and Continue Editing"
* Aligned form buttons to the right.
* Removed the cancel button to prevent crowding (users can use the "List" button in the upper left)
* Changed bootstrap2 form buttons to be the same size as the bootstrap3 form buttons and added an ```<hr>``` between the form buttons and form.
* Changed "View Record" tab on ```.edit_view``` to say "Details". (only shown when ```can_view_details = true```)

Removing the cancel button is probably the most controversial change here. But, it looks kinda crowded with that button there: https://i.imgur.com/p1ePE7i.png