### PR TITLE
Fix & test for #988: column_filters in not compatible with babel.

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -18,7 +18,7 @@ from flask_admin.helpers import (get_form_data, validate_form_on_submit,
                                  get_redirect_target, flash_errors)
 from flask_admin.tools import rec_getattr
 from flask_admin._backwards import ObsoleteAttr
-from flask_admin._compat import iteritems, OrderedDict, as_unicode
+from flask_admin._compat import iteritems, itervalues, OrderedDict, as_unicode
 from .helpers import prettify_name, get_mdict_item_or_list
 from .ajax import AjaxModelLoader
 from .fields import ListEditableFieldList
@@ -59,6 +59,26 @@ class ViewArgs(object):
         kwargs.setdefault('extra_args', dict(self.extra_args))
 
         return ViewArgs(**kwargs)
+
+
+class FilterGroup:
+    def __init__(self, label):
+        self.label = label
+        self.filters = []
+
+    def append(self, filter):
+        self.filters.append(filter)
+
+    def non_lazy(self):
+        filters = []
+        for item in self.filters:
+            copy = dict(item)
+            copy['operation'] = as_unicode(copy['operation'])
+            filters.append(copy)
+        return as_unicode(self.label), filters
+
+    def __iter__(self):
+        return iter(self.filters)
 
 
 class BaseModelView(BaseView, ActionsMixin):
@@ -665,10 +685,11 @@ class BaseModelView(BaseView, ActionsMixin):
             self._filter_args = {}
 
             for i, flt in enumerate(self._filters):
-                if flt.name not in self._filter_groups:
-                    self._filter_groups[flt.name] = []
+                key = as_unicode(flt.name)
+                if key not in self._filter_groups:
+                    self._filter_groups[key] = FilterGroup(flt.name)
 
-                self._filter_groups[flt.name].append({
+                self._filter_groups[key].append({
                     'index': i,
                     'arg': self.get_filter_arg(i, flt),
                     'operation': flt.operation(),
@@ -935,14 +956,8 @@ class BaseModelView(BaseView, ActionsMixin):
         if self._filter_groups:
             results = OrderedDict()
 
-            for key, value in iteritems(self._filter_groups):
-                items = []
-
-                for item in value:
-                    copy = dict(item)
-                    copy['operation'] = as_unicode(copy['operation'])
-                    items.append(copy)
-
+            for group in itervalues(self._filter_groups):
+                key, items = group.non_lazy()
                 results[key] = items
 
             return results

--- a/flask_admin/tests/sqla/test_translation.py
+++ b/flask_admin/tests/sqla/test_translation.py
@@ -1,0 +1,34 @@
+import json
+
+from nose.tools import eq_, ok_, raises, assert_true
+from speaklater import make_lazy_string
+
+from . import setup
+from .test_basic import CustomModelView, create_models
+
+class Translator:
+    translate = False
+
+    def __call__(self, string):
+        if self.translate:
+            return 'Translated: "{}"'.format(string)
+        else:
+            return string
+
+def test_column_label_translation():
+    app, db, admin = setup()
+
+    Model1, _ = create_models(db)
+
+    translated = Translator()
+    label = make_lazy_string(translated, 'Column1')
+
+    view = CustomModelView(Model1, db.session,
+                           column_list=['test1', 'test3'],
+                           column_labels=dict(test1=label),
+                           column_filters=('test1',))
+
+    translated.translate = True
+    non_lazy_groups = view._get_filter_groups()
+    json.dumps(non_lazy_groups)  # Filter dict is JSON serializable.
+    ok_(translated('Column1') in non_lazy_groups)  # Label was translated.


### PR DESCRIPTION
Filters currently have two issues with translatable column labels:

 1. _LazyString is not hashable and can't be used as a dict key.
 2. It can't be JSON serialized.

This patch creates an explicit FieldGroup class to store the label of the FieldGroup and it's filters. Now we can use the untranslated FieldGroup label as dict-key while not losing the translatability of the label.