### PR TITLE
fix xss vulnerability - escape html in column_editable_list values

### DIFF
--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -1,4 +1,5 @@
 from flask import json
+from jinja2 import escape
 from wtforms.widgets import HTMLString, html_params
 
 from flask_admin._compat import as_unicode
@@ -92,7 +93,8 @@ class XEditableWidget(object):
         kwargs = self.get_kwargs(subfield, kwargs)
 
         return HTMLString(
-            '<a %s>%s</a>' % (html_params(**kwargs), kwargs['data-value'])
+            '<a %s>%s</a>' % (html_params(**kwargs),
+                              escape(kwargs['data-value']))
         )
 
     def get_kwargs(self, subfield, kwargs):


### PR DESCRIPTION
Fixes the XSS vulnerability that @boolbag found in #1000 by escaping HTML before it's passed to WTForm's HTMLString. Nice catch @boolbag!

Here's a picture from after the fix is added: ![](https://i.imgur.com/5e8JiSf.png)