### PR TITLE
remove first column from list view when it is empty anyway

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -62,7 +62,9 @@
                     </th>
                     {% endif %}
                     {% block list_row_actions_header %}
-                    <th class="span1">&nbsp;</th>
+                        {% if admin_view.can_view_details or admin_view.can_edit or admin_view.can_delete %}
+                        <th class="span1">&nbsp;</th>
+                        {% endif %}
                     {% endblock %}
                     {% set column = 0 %}
                     {% for c, name in list_columns %}
@@ -104,42 +106,44 @@
                 </td>
                 {% endif %}
                 {% block list_row_actions_column scoped %}
-                <td class="list-buttons-column">
-                    {% block list_row_actions scoped %}
-                        {%- if admin_view.can_view_details -%}
-                            {%- if admin_view.details_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon icon-eye-open"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
-                                    <span class="fa fa-eye icon-eye-open"></span>
-                                </a>
+                    {% if admin_view.can_view_details or admin_view.can_edit or admin_view.can_delete %}
+                    <td class="list-buttons-column">
+                        {% block list_row_actions scoped %}
+                            {%- if admin_view.can_view_details -%}
+                                {%- if admin_view.details_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon icon-eye-open"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
+                                        <span class="fa fa-eye icon-eye-open"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_edit -%}
-                            {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
-                                    <i class="fa fa-pencil icon-pencil"></i>
-                                </a>
+                            {%- if admin_view.can_edit -%}
+                                {%- if admin_view.edit_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
+                                        <i class="fa fa-pencil icon-pencil"></i>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_delete -%}
-                        <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
-                            {{ delete_form.id(value=get_pk_value(row)) }}
-                            {{ delete_form.url(value=return_url) }}
-                            {% if delete_form.csrf_token %}
-                            {{ delete_form.csrf_token }}
-                            {% elif csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                            {% endif %}
-                            <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="{{ _gettext('Delete record') }}">
-                                <i class="fa fa-trash icon-trash"></i>
-                            </button>
-                        </form>
-                        {%- endif -%}
-                    {% endblock %}
-                </td>
+                            {%- if admin_view.can_delete -%}
+                            <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
+                                {{ delete_form.id(value=get_pk_value(row)) }}
+                                {{ delete_form.url(value=return_url) }}
+                                {% if delete_form.csrf_token %}
+                                {{ delete_form.csrf_token }}
+                                {% elif csrf_token %}
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                {% endif %}
+                                <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="{{ _gettext('Delete record') }}">
+                                    <i class="fa fa-trash icon-trash"></i>
+                                </button>
+                            </form>
+                            {%- endif -%}
+                        {% endblock %}
+                    </td>
+                    {% endif %}
                 {% endblock %}
 
                 {% for c, name in list_columns %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -62,8 +62,10 @@
                     </th>
                     {% endif %}
                     {% block list_row_actions_header %}
-                    <th class="col-md-1">&nbsp;</th>
-                    {% endblock %}
+                        {% if admin_view.can_view_details or admin_view.can_edit or admin_view.can_delete %} 
+                        <th class="col-md-1">&nbsp;</th>
+                        {% endif %}
+                    {% endblock %}                    
                     {% set column = 0 %}
                     {% for c, name in list_columns %}
                     <th class="column-header col-{{c}}">
@@ -102,45 +104,47 @@
                 <td>
                     <input type="checkbox" name="rowid" class="action-checkbox" value="{{ get_pk_value(row) }}" title="{{ _gettext('Select record') }}" />
                 </td>
-                {% endif %}
+                {% endif %}                
                 {% block list_row_actions_column scoped %}
-                <td class="list-buttons-column">
-                    {% block list_row_actions scoped %}
-                        {%- if admin_view.can_view_details -%}
-                            {%- if admin_view.details_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon glyphicon-eye-open"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
-                                    <span class="fa fa-eye glyphicon glyphicon-eye-open"></span>
-                                </a>
+                    {% if admin_view.can_view_details or admin_view.can_edit or admin_view.can_delete %}
+                    <td class="list-buttons-column">
+                        {% block list_row_actions scoped %}
+                            {%- if admin_view.can_view_details -%}
+                                {%- if admin_view.details_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon glyphicon-eye-open"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
+                                        <span class="fa fa-eye glyphicon glyphicon-eye-open"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_edit -%}
-                            {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
-                                    <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
-                                </a>
+                            {%- if admin_view.can_edit -%}
+                                {%- if admin_view.edit_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
+                                        <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_delete -%}
-                        <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
-                            {{ delete_form.id(value=get_pk_value(row)) }}
-                            {{ delete_form.url(value=return_url) }}
-                            {% if delete_form.csrf_token %}
-                            {{ delete_form.csrf_token }}
-                            {% elif csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                            {% endif %}
-                            <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
-                                <span class="fa fa-trash glyphicon glyphicon-trash"></span>
-                            </button>
-                        </form>
-                        {%- endif -%}
-                    {% endblock %}
-                </td>
-                {% endblock %}
+                            {%- if admin_view.can_delete -%}
+                            <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
+                                {{ delete_form.id(value=get_pk_value(row)) }}
+                                {{ delete_form.url(value=return_url) }}
+                                {% if delete_form.csrf_token %}
+                                {{ delete_form.csrf_token }}
+                                {% elif csrf_token %}
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                {% endif %}
+                                <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
+                                    <span class="fa fa-trash glyphicon glyphicon-trash"></span>
+                                </button>
+                            </form>
+                            {%- endif -%}
+                        {% endblock %}
+                    </td>                    
+                    {%- endif -%}
+                {% endblock %}                
                 {% for c, name in list_columns %}
                     <td class="col-{{c}}">
                     {% if admin_view.is_editable(c) %}


### PR DESCRIPTION
In the list, when view_details, edit and delete are disabled, the first column is empty. This commit ads an extra if statement to check that case and stops further output of the th and td to remove the column completely. 

The use case: the model that I use has many fields, but I do only want N of them to be able to be edited and just inline editing via column_editable_list. In that case there is no need for the column with the view/edit/delete icons.



