### PR TITLE
Fixes #908. Ensure optional field (list of references) can be empty on form.

### DIFF
--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -114,7 +114,7 @@ class CustomModelConverter(orm.ModelConverter):
                 return AjaxSelectMultipleField(loader, **kwargs)
 
             kwargs['widget'] = form.Select2Widget(multiple=True)
-            kwargs.setdefault('validators', [validators.Optional()])
+            kwargs.setdefault('validators', []).append(validators.Optional())
 
             # TODO: Support AJAX multi-select
             doc_type = field.field.document_type


### PR DESCRIPTION
Issue #908 is not completely fixed for form validations that leave the field blank, where such field is a list of references that is not required (optional). 

This fixes it by always adding the validators.Optional() to the validators kwargs, as opposed to just when 'validators' is a missing key in kwargs.
