### PR TITLE
Fix nullable enums and allow blanks in editable list view select fields

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -270,8 +270,16 @@ class AdminModelConverter(ModelConverterBase):
     @converts('String', 'Unicode')
     def conv_String(self, column, field_args, **extra):
         if hasattr(column.type, 'enums'):
-            field_args['validators'].append(validators.AnyOf(column.type.enums))
+            accepted_values = list(column.type.enums)
+
             field_args['choices'] = [(f, f) for f in column.type.enums]
+
+            if column.nullable:
+                field_args['allow_blank'] = column.nullable
+                accepted_values.append(None)
+
+            field_args['validators'].append(validators.AnyOf(accepted_values))
+
             return form.Select2Field(**field_args)
 
         if column.nullable:

--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -147,4 +147,8 @@ class XEditableWidget(object):
         else:
             raise Exception('Unsupported field type: %s' % (type(subfield),))
 
+        # for Select2, QuerySelectField, and ModelSelectField
+        if getattr(subfield, 'allow_blank', False):
+            kwargs['data-source']['__None'] = ""
+
         return kwargs


### PR DESCRIPTION
Fixes the issue @boolbag found in #1003 with nullable enum fields not having a blank option.

![](https://i.imgur.com/lnI0TWx.png)

Also noticed that "allow_blank" wasn't working with the select fields in the editable list view. That's fixed too.

![](https://i.imgur.com/ybCmoqs.png)

Thanks for finding this @boolbag!
