### PR TITLE
SQLA: Don’t require fields that have a default or server_default value

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -209,6 +209,7 @@ class AdminModelConverter(ModelConverterBase):
                     not column.nullable
                     and not isinstance(column.type, optional_types)
                     and not column.default
+                    and not column.server_default
                 ):
                     kwargs['validators'].append(validators.InputRequired())
 

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -205,7 +205,11 @@ class AdminModelConverter(ModelConverterBase):
 
                 optional_types = getattr(self.view, 'form_optional_types', (Boolean,))
 
-                if not column.nullable and not isinstance(column.type, optional_types):
+                if (
+                    not column.nullable
+                    and not isinstance(column.type, optional_types)
+                    and not column.default
+                ):
                     kwargs['validators'].append(validators.InputRequired())
 
                 # Apply label and description if it isn't inline form field

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -61,15 +61,22 @@ def create_models(db):
 
     class Model2(db.Model):
         def __init__(self, string_field=None, int_field=None, bool_field=None,
-                     model1=None, float_field=None):
+                     model1=None, float_field=None, string_field_default=None,
+                     string_field_empty_default=None):
             self.string_field = string_field
             self.int_field = int_field
             self.bool_field = bool_field
             self.model1 = model1
             self.float_field = float_field
+            self.string_field_default = string_field_default
+            self.string_field_empty_default = string_field_empty_default
 
         id = db.Column(db.Integer, primary_key=True)
         string_field = db.Column(db.String)
+        string_field_default = db.Column(db.Text, nullable=False,
+                                         default='')
+        string_field_empty_default = db.Column(db.Text, nullable=False,
+                                               default='')
         int_field = db.Column(db.Integer)
         bool_field = db.Column(db.Boolean)
         enum_field = db.Column(db.Enum('model2_v1', 'model2_v2'), nullable=True)
@@ -1959,3 +1966,18 @@ def test_multipath_joins():
 
     rv = client.get('/admin/model2/')
     eq_(rv.status_code, 200)
+
+
+def test_model_default():
+    app, db, admin = setup()
+    _, Model2 = create_models(db)
+
+    class ModelView(CustomModelView):
+        pass
+
+    view = ModelView(Model2, db.session)
+    admin.add_view(view)
+
+    client = app.test_client()
+    rv = client.post('/admin/model2/new/', data=dict())
+    assert_true(b'This field is required' not in rv.data)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ flask-mongoengine
 pillow
 Babel<=1.3
 flask-babelex
-shapely
+shapely==1.5.9
 geoalchemy2
 psycopg2
 nose


### PR DESCRIPTION
This adds a minor fix to @jmagnusson's #964 to support server_default as well as default.

Fixes #1011 

Also, the new version of shapely (1.5.10) was causing build errors: https://github.com/Toblerity/Shapely/issues/305 Had to lock the previous version to make builds pass.