### PR TITLE
fix discrepancies between edit_view and details_view navbar text

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/details.html
+++ b/flask_admin/templates/bootstrap2/admin/model/details.html
@@ -18,7 +18,7 @@
     </li>
     {%- endif -%}
     <li class="active">
-        <a href="javascript:void(0)">{{ _gettext('View Record') }}</a>
+        <a href="javascript:void(0)">{{ _gettext('Details') }}</a>
     </li>
   </ul>
   {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/details.html
+++ b/flask_admin/templates/bootstrap3/admin/model/details.html
@@ -18,7 +18,7 @@
     </li>
     {%- endif -%}
     <li class="active">
-        <a href="javascript:void(0)">{{ _gettext('View Record') }}</a>
+        <a href="javascript:void(0)">{{ _gettext('Details') }}</a>
     </li>
   </ul>
   {% endblock %}


### PR DESCRIPTION
Just changes details view navbar text from "View Record" to "Details" (same as the edit view).

1.3.0 details view navbar: 
![](https://i.imgur.com/T4rC00Zm.png)

1.3.0 edit view navbar:
![](https://i.imgur.com/ojTxYMBm.png)

Fixed details view navbar:
![](https://i.imgur.com/1BuJSL7m.png)