### PR TITLE
change focus to newlly added filter input

### DIFF
--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -141,7 +141,7 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         var filter = subfilters[filterSelection];
         var $inputContainer = $('<td/>').appendTo($el);
          
-        var $newFilterField = createFilterInput($inputContainer, filterValue, filter);
+        var $newFilterField = createFilterInput($inputContainer, filterValue, filter).focus();
         var $styledFilterField = styleFilterInput(filter, $newFilterField);
         
         return $styledFilterField;


### PR DESCRIPTION
i think it is nicer to get the focus to the right element just after adding a new filter. 

it might be better to put it on the filter type combo, but for me the default "contains" is good enough (mostly what i need)  so i am going with the value as the right element to focus on 