### PR TITLE
fix custom filter example after breaking change

### DIFF
--- a/examples/sqla-custom-filter/app.py
+++ b/examples/sqla-custom-filter/app.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 
 from flask_admin.contrib import sqla
-from flask_admin import expose, Admin
+from flask_admin import Admin
 
 # required for creating custom filters
 from flask_admin.contrib.sqla.filters import BaseSQLAFilter, FilterEqual
@@ -19,6 +19,13 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + app.config['DATABASE_FILE
 app.config['SQLALCHEMY_ECHO'] = True
 db = SQLAlchemy(app)
 
+
+# Flask views
+@app.route('/')
+def index():
+    return '<a href="/admin/">Click me to get to Admin!</a>'
+
+
 # Create model
 class User(db.Model):
     def __init__(self, first_name, last_name, username, email):
@@ -33,13 +40,14 @@ class User(db.Model):
     username = db.Column(db.String(80), unique=True)
     email = db.Column(db.String(120), unique=True)
 
-    # Required for administrative interface. For python 3 please use __str__ instead.
+    # Required for admin interface. For python 3 please use __str__ instead.
     def __unicode__(self):
         return self.username
 
+
 # Create custom filter class
 class FilterLastNameBrown(BaseSQLAFilter):
-    def apply(self, query, value):
+    def apply(self, query, value, alias=None):
         if value == '1':
             return query.filter(self.column == "Brown")
         else:
@@ -48,17 +56,22 @@ class FilterLastNameBrown(BaseSQLAFilter):
     def operation(self):
         return 'is Brown'
 
+
 # Add custom filter and standard FilterEqual to ModelView
 class UserAdmin(sqla.ModelView):
     # each filter in the list is a filter operation (equals, not equals, etc)
     # filters with the same name will appear as operations under the same filter
     column_filters = [
         FilterEqual(User.last_name, 'Last Name'),
-        FilterLastNameBrown(User.last_name, 'Last Name', options=(('1', 'Yes'),('0', 'No')))
+        FilterLastNameBrown(
+            User.last_name, 'Last Name', options=(('1', 'Yes'), ('0', 'No'))
+        )
     ]
+
 
 admin = Admin(app, template_mode="bootstrap3")
 admin.add_view(UserAdmin(User, db.session))
+
 
 def build_sample_db():
     db.drop_all()
@@ -70,6 +83,7 @@ def build_sample_db():
     db.session.add_all([user_obj1, user_obj2, user_obj3])
     db.session.commit()
 
+
 if __name__ == '__main__':
     build_sample_db()
-    app.run(port=5000)
+    app.run(port=5000, debug=True)


### PR DESCRIPTION
Fixes #1020 and makes some minor formatting improvements to the sqla-custom-filter example.

The commit message describes the change that needed to break backwards compatibility and caused this issue: https://github.com/flask-admin/flask-admin/commit/db3ee4b01944359f9839c0e3d99fdba640d4d25d