### PR TITLE
Return user to filtered list view after action

### DIFF
--- a/flask_admin/actions.py
+++ b/flask_admin/actions.py
@@ -3,6 +3,7 @@ from flask import request, redirect
 
 from flask_admin import tools
 from flask_admin._compat import text_type
+from flask_admin.helpers import get_redirect_target
 
 
 def action(name, text, confirmation=None):
@@ -100,7 +101,8 @@ class ActionsMixin(object):
 
             :param return_view:
                 Name of the view to return to after the request.
-                If not provided, will return user to the index view.
+                If not provided, will return user to the return url in the form
+                or the list view.
         """
         action = request.form.get('action')
         ids = request.form.getlist('rowid')
@@ -113,9 +115,9 @@ class ActionsMixin(object):
             if response is not None:
                 return response
 
-        if not return_view:
-            url = self.get_url('.' + self._default_view)
-        else:
+        if return_view:
             url = self.get_url('.' + return_view)
+        else:
+            url = get_redirect_target() or self.get_url('.index_view')
 
         return redirect(url)

--- a/flask_admin/templates/bootstrap2/admin/actions.html
+++ b/flask_admin/templates/bootstrap2/admin/actions.html
@@ -17,6 +17,7 @@
         {% if csrf_token %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% endif %}
+        <input type="hidden" name="url" value="{{ return_url }}">
         <input type="hidden" id="action" name="action" />
     </form>
     {% endif %}

--- a/flask_admin/templates/bootstrap3/admin/actions.html
+++ b/flask_admin/templates/bootstrap3/admin/actions.html
@@ -17,6 +17,7 @@
         {% if csrf_token %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% endif %}
+        <input type="hidden" name="url" value="{{ return_url }}">
         <input type="hidden" id="action" name="action" />
     </form>
     {% endif %}


### PR DESCRIPTION
Fixes #1022

Redirects the user back to their filtered view after they use an action. This solution uses the same logic as the delete button on the list view.