### PR TITLE
add a way to add multiple views or links with a single line of code

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -540,6 +540,22 @@ class Admin(object):
 
         self._add_view_to_menu(view)
 
+    def add_views(self, *args):
+        """
+            Add one or more views to the collection.
+
+            Examples::
+
+            admin.add_views(view1)
+            admin.add_views(view1, view2, view3, view4)
+            admin.add_views(*my_list)
+
+            :param args:
+                Argument list including the views to add.
+        """
+        for view in args:
+            self.add_view(view)
+
     def add_link(self, link):
         """
             Add link to menu links collection.
@@ -551,6 +567,22 @@ class Admin(object):
             self._add_menu_item(link, link.category)
         else:
             self._menu_links.append(link)
+
+    def add_links(self, *args):
+        """
+            Add one or more links to the menu links collection.
+
+            Examples::
+
+            admin.add_links(link1)
+            admin.add_links(link1, link2, link3, link4)
+            admin.add_links(*my_list)
+
+            :param args:
+                Argument list including the links to add.
+        """
+        for link in args:
+            self.add_link(link)
 
     def _add_menu_item(self, menu_item, target_category):
         if target_category:

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -195,6 +195,15 @@ def test_baseview_urls():
     eq_(len(view._urls), 2)
 
 
+def test_add_views():
+    app = Flask(__name__)
+    admin = base.Admin(app)
+
+    admin.add_views(MockView(endpoint='test1'), MockView(endpoint='test2'))
+
+    eq_(len(admin.menu()), 3)
+
+
 @raises(Exception)
 def test_no_default():
     app = Flask(__name__)
@@ -376,6 +385,20 @@ def test_menu_links():
     admin = base.Admin(app)
     admin.add_link(base.MenuLink('TestMenuLink1', endpoint='.index'))
     admin.add_link(base.MenuLink('TestMenuLink2', url='http://python.org/'))
+
+    client = app.test_client()
+    rv = client.get('/admin/')
+
+    data = rv.data.decode('utf-8')
+    ok_('TestMenuLink1' in data)
+    ok_('TestMenuLink2' in data)
+
+
+def test_add_links():
+    app = Flask(__name__)
+    admin = base.Admin(app)
+    admin.add_links(base.MenuLink('TestMenuLink1', endpoint='.index'),
+                    base.MenuLink('TestMenuLink2', url='http://python.org/'))
 
     client = app.test_client()
     rv = client.get('/admin/')


### PR DESCRIPTION
This pull request adds the ability to add multiple views at once, like this:
```
admin.add_views([view1, view2, view3, view4])
```

Here's the old way:
```
admin.add_view(view1)
admin.add_view(view2)
admin.add_view(view3)
admin.add_view(view4)
```

Also does the same for ```add_link``` by adding an ```add_links```.
