### PR TITLE
Fix form_rules rendering in modal dialogs

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/base.html
+++ b/flask_admin/templates/bootstrap2/admin/base.html
@@ -53,6 +53,7 @@
       {{ layout.messages() }}
       {% endblock %}
 
+      {# store the jinja2 context for form_rules rendering logic #}
       {% set render_ctx = h.resolve_ctx() %}
 
       {% block body %}{% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/create.html
@@ -1,6 +1,9 @@
 {% import 'admin/static.html' as admin_static with context%}
 {% import 'admin/lib.html' as lib with context %}
 
+{# store the jinja2 context for form_rules rendering logic #}
+{% set render_ctx = h.resolve_ctx() %}
+
 {% block body %}
   {# "save and add" button is removed from modal (it won't function properly) #}
   {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,

--- a/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
@@ -1,6 +1,9 @@
 {% import 'admin/static.html' as admin_static with context%}
 {% import 'admin/lib.html' as lib with context %}
 
+{# store the jinja2 context for form_rules rendering logic #}
+{% set render_ctx = h.resolve_ctx() %}
+
 {% block body %}
   {# "save and continue" button is removed from modal (it won't function properly) #}
   {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,

--- a/flask_admin/templates/bootstrap3/admin/base.html
+++ b/flask_admin/templates/bootstrap3/admin/base.html
@@ -64,6 +64,7 @@
       {{ layout.messages() }}
       {% endblock %}
 
+      {# store the jinja2 context for form_rules rendering logic #}
       {% set render_ctx = h.resolve_ctx() %}
 
       {% block body %}{% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/base.html
+++ b/flask_admin/templates/bootstrap3/admin/base.html
@@ -5,8 +5,8 @@
   <head>
     <title>{% block title %}{% if admin_view.category %}{{ admin_view.category }} - {% endif %}{{ admin_view.name }} - {{ admin_view.admin.name }}{% endblock %}</title>
     {% block head_meta %}
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="">
         <meta name="author" content="">
@@ -30,19 +30,19 @@
     {% block page_body %}
     <div class="container">
       <nav class="navbar navbar-default" role="navigation">
-	<!-- Brand and toggle get grouped for better mobile display -->
-	<div class="navbar-header">
-	  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#admin-navbar-collapse">
-	    <span class="sr-only">Toggle navigation</span>
-	    <span class="icon-bar"></span>
-	    <span class="icon-bar"></span>
-	    <span class="icon-bar"></span>
-	  </button>
-	  {% block brand %}
-	  <a class="navbar-brand" href="#">{{ admin_view.admin.name }}</a>
-	  {% endblock %}
-	</div>
-	<!-- navbar content -->
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#admin-navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          {% block brand %}
+          <a class="navbar-brand" href="#">{{ admin_view.admin.name }}</a>
+          {% endblock %}
+        </div>
+        <!-- navbar content -->
         <div class="collapse navbar-collapse" id="admin-navbar-collapse">
           {% block main_menu %}
           <ul class="nav navbar-nav">

--- a/flask_admin/templates/bootstrap3/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/create.html
@@ -1,6 +1,9 @@
 {% import 'admin/static.html' as admin_static with context%}
 {% import 'admin/lib.html' as lib with context %}
 
+{# store the jinja2 context for form_rules rendering logic #}
+{% set render_ctx = h.resolve_ctx() %}
+
 {% block body %}
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
@@ -1,6 +1,9 @@
 {% import 'admin/static.html' as admin_static with context%}
 {% import 'admin/lib.html' as lib with context %}
 
+{# store the jinja2 context for form_rules rendering logic #}
+{% set render_ctx = h.resolve_ctx() %}
+
 {% block body %}
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>


### PR DESCRIPTION
Adds ```{% set render_ctx = h.resolve_ctx() %}``` to the modal templates to make form_rules work. Fixes #1045 

Also found some indention that needed fixing in the base.html file.