### PR TITLE
Add customization options for export columns

### DIFF
--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -602,7 +602,7 @@ def test_export_csv():
                          endpoint='exportexclusion')
     admin.add_view(view)
 
-    rv = client.get('/admin/exportexclusion/import/csv/')
+    rv = client.get('/admin/exportexclusion/export/csv/')
     data = rv.data.decode('utf-8')
     eq_(rv.mimetype, 'text/csv')
     eq_(rv.status_code, 200)

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -579,6 +579,36 @@ def test_export_csv():
         "col1_2,col2_2\r\n"
         "col1_3,col2_3\r\n" == data)
 
+    # test explicit use of column_export_list
+    view = MockModelView(Model, view_data, can_export=True,
+                         column_list=['col1', 'col2'],
+                         column_export_list=['id','col1','col2'])
+    admin.add_view(view)
+
+    rv = client.get('/admin/model/export/csv/')
+    data = rv.data.decode('utf-8')
+    eq_(rv.mimetype, 'text/csv')
+    eq_(rv.status_code, 200)
+    ok_("Id,Col1,Col2\r\n"
+        "1,col1_1,col2_1\r\n"
+        "2,col1_2,col2_2\r\n"
+        "3,col1_3,col2_3\r\n" == data)
+
+    # test explicit use of column_export_exclude_list
+    view = MockModelView(Model, view_data, can_export=True,
+                         column_list=['col1', 'col2'],
+                         column_export_exclude_list=['col2'])
+    admin.add_view(view)
+
+    rv = client.get('/admin/model/export/csv/')
+    data = rv.data.decode('utf-8')
+    eq_(rv.mimetype, 'text/csv')
+    eq_(rv.status_code, 200)
+    ok_("Col1\r\n"
+        "col1_1\r\n"
+        "col1_2\r\n"
+        "col1_3\r\n" == data)
+
     # test utf8 characters in csv export
     view_data[4] = Model(1, u'\u2013ut8_1\u2013', u'\u2013utf8_2\u2013')
     view = MockModelView(Model, view_data, can_export=True,

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -586,7 +586,7 @@ def test_export_csv():
                          endpoint='exportinclusion')
     admin.add_view(view)
 
-    rv = client.get('/admin/model/export/csv/')
+    rv = client.get('/admin/model/exportinclusion/csv/')
     data = rv.data.decode('utf-8')
     eq_(rv.mimetype, 'text/csv')
     eq_(rv.status_code, 200)
@@ -602,7 +602,7 @@ def test_export_csv():
                          endpoint='exportexclusion')
     admin.add_view(view)
 
-    rv = client.get('/admin/model/export/csv/')
+    rv = client.get('/admin/model/exportexclusion/csv/')
     data = rv.data.decode('utf-8')
     eq_(rv.mimetype, 'text/csv')
     eq_(rv.status_code, 200)

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -586,7 +586,7 @@ def test_export_csv():
                          endpoint='exportinclusion')
     admin.add_view(view)
 
-    rv = client.get('/admin/model/exportinclusion/csv/')
+    rv = client.get('/admin/exportinclusion/export/csv/')
     data = rv.data.decode('utf-8')
     eq_(rv.mimetype, 'text/csv')
     eq_(rv.status_code, 200)
@@ -602,7 +602,7 @@ def test_export_csv():
                          endpoint='exportexclusion')
     admin.add_view(view)
 
-    rv = client.get('/admin/model/exportexclusion/csv/')
+    rv = client.get('/admin/exportexclusion/import/csv/')
     data = rv.data.decode('utf-8')
     eq_(rv.mimetype, 'text/csv')
     eq_(rv.status_code, 200)

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -582,7 +582,8 @@ def test_export_csv():
     # test explicit use of column_export_list
     view = MockModelView(Model, view_data, can_export=True,
                          column_list=['col1', 'col2'],
-                         column_export_list=['id','col1','col2'])
+                         column_export_list=['id','col1','col2'],
+                         endpoint='exportinclusion')
     admin.add_view(view)
 
     rv = client.get('/admin/model/export/csv/')
@@ -597,7 +598,8 @@ def test_export_csv():
     # test explicit use of column_export_exclude_list
     view = MockModelView(Model, view_data, can_export=True,
                          column_list=['col1', 'col2'],
-                         column_export_exclude_list=['col2'])
+                         column_export_exclude_list=['col2'],
+                         endpoint='exportexclusion')
     admin.add_view(view)
 
     rv = client.get('/admin/model/export/csv/')


### PR DESCRIPTION
This is based on what is used for the details view (`get_details_columns`/`column_details_list`/`column_details_exclude_list`) with the added complication that `get_export_columns` also checks
`column_list` before attempting to invoke `scaffold_list_columns`.

The internal `_export_columns` collection is only used at the time of generation so that filters, sorting options, and so on will still use the standard column indices expected for these operations.