### PR TITLE
Make QuerySelectMultipleField fields editable on the list view

### DIFF
--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -141,9 +141,11 @@ class XEditableWidget(object):
         elif subfield.type in ['FloatField', 'DecimalField']:
             kwargs['data-type'] = 'number'
             kwargs['data-step'] = 'any'
-        elif subfield.type in ['QuerySelectField', 'ModelSelectField']:
-            # QuerySelectField and ModelSelectField are for relations
+        elif subfield.type in ['QuerySelectField', 'ModelSelectField', 'QuerySelectMultipleField']:
+            # QuerySelectField, ModelSelectField and QuerySelectMultipleField are for relations
             kwargs['data-type'] = 'select'
+            if subfield.type == 'QuerySelectMultipleField':
+                kwargs['data-type'] = 'checklist'
 
             choices = []
             for choice in subfield:


### PR DESCRIPTION
For QuerySelectField and ModelSelectField, a select data-type is used.
This element does not support select multiple, but the checklist element
does. The same code for compiling the choices is used.