### PR TITLE
On adding a text filter, set input focus to allow immediate typing

### DIFF
--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -153,8 +153,10 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         
         var $filterField = addFilter(name, filterGroups[name], false, null);
 
-        // set focus to allow immediate typing in text filters
-        $filterField.focus();
+        // allow immediate typing in text filter box
+        if ($filterField.attr('type') === 'text') {
+            $filterField.focus();
+        }
         
         $('button', $root).show();        
     });

--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -154,9 +154,9 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         var $filterField = addFilter(name, filterGroups[name], false, null);
 
         // allow immediate typing in text filter box
-        //if ($filterField.attr('type') === 'text') {
-        //    $filterField.focus();
-        //}
+        if ($filterField.attr('type') === 'text') {
+            $filterField.focus();
+        }
         
         $('button', $root).show();        
     });

--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -154,9 +154,9 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         var $filterField = addFilter(name, filterGroups[name], false, null);
 
         // allow immediate typing in text filter box
-        if ($filterField.attr('type') === 'text') {
-            $filterField.focus();
-        }
+        //if ($filterField.attr('type') === 'text') {
+        //    $filterField.focus();
+        //}
         
         $('button', $root).show();        
     });

--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -151,7 +151,10 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
     $('a.filter', filtersElement).click(function() {
         var name = ($(this).text().trim !== undefined ? $(this).text().trim() : $(this).text().replace(/^\s+|\s+$/g,''));
         
-        addFilter(name, filterGroups[name], false, null);
+        var $filterField = addFilter(name, filterGroups[name], false, null);
+
+        // set focus to allow immediate typing in text filters
+        $filterField.focus();
         
         $('button', $root).show();        
     });


### PR DESCRIPTION
Upon choosing a text filter to add, it would be useful to be able to immediately type into the text box rather than first having to click in the box.