### PR TITLE
On adding a text filter, set input focus to allow immediate typing

### DIFF
--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -151,7 +151,10 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
     $('a.filter', filtersElement).click(function() {
         var name = ($(this).text().trim !== undefined ? $(this).text().trim() : $(this).text().replace(/^\s+|\s+$/g,''));
         
-        addFilter(name, filterGroups[name], false, null);
+        // allow immediate typing in text filter box
+        if ($filterField.attr('type') === 'text') {
+            $filterField.focus();
+        }
         
         $('button', $root).show();        
     });

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -194,7 +194,7 @@
 {% block tail %}
     {{ super() }}
     {{ lib.form_js() }}
-    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
+    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.1') }}"></script>
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -194,7 +194,7 @@
 
 {% block tail %}
     {{ super() }}
-    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
+    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.1') }}"></script>
     {{ lib.form_js() }}
 
     {{ actionlib.script(_gettext('Please select at least one record.'),


### PR DESCRIPTION
Upon choosing a text filter to add, it would be useful to be able to immediately type into the text box rather than first having to click in it.