### PR TITLE
CSV Documentation: fix max rows attribute name

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -278,7 +278,7 @@ To **enable csv export** of the model view::
 
     can_export = True
 
-This will add a button to the model view that exports records, truncating at :attr:`~flask_admin.model.BaseModelView.max_export_rows`.
+This will add a button to the model view that exports records, truncating at :attr:`~flask_admin.model.BaseModelView.export_max_rows`.
 
 Adding Your Own Views
 =====================


### PR DESCRIPTION
The documentation for  `can_export`  refers to the attribute `max_export_rows` whereas the code in [models/base.py](https://github.com/flask-admin/flask-admin/blob/master/flask_admin/model/base.py#L1986) uses the the `export_max_rows` attribute. 

