### PR TITLE
improve error message when resolve_ctx is missing

### DIFF
--- a/flask_admin/form/rules.py
+++ b/flask_admin/form/rules.py
@@ -173,7 +173,11 @@ class Macro(BaseRule):
         """
         parts = name.split('.')
 
-        field = context.resolve(parts[0])
+        try:
+            field = context.resolve(parts[0])
+        except AttributeError:
+            raise Exception('Your template is missing '
+                            '"{% set render_ctx = h.resolve_ctx() %}"')
 
         if not field:
             return None


### PR DESCRIPTION
Relates to issue #771, just provides a more detailed error message when ```{% set render_ctx = h.resolve_ctx() %}``` is missing from a template that uses form_rules.