### PR TITLE
fix build errors caused by pillow

### DIFF
--- a/examples/forms/requirements.txt
+++ b/examples/forms/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 Flask-SQLAlchemy
-pillow
+pillow==2.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ peewee
 wtf-peewee
 pymongo==2.8
 flask-mongoengine
-pillow
+pillow==2.9.0
 Babel<=1.3
 flask-babelex
 shapely==1.5.9

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     tests_require=[
         'nose>=1.0',
-        'pillow',
+        'pillow==2.9.0',
         'mongoengine',
         'pymongo',
         'wtf-peewee',


### PR DESCRIPTION
Locks Pillow dependency to 2.9.0 until this pull request makes it into the next version: https://github.com/python-pillow/Pillow/pull/1467