### PR TITLE
add column_display_actions option to ModelView

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -432,6 +432,20 @@ class BaseModelView(BaseView, ActionsMixin):
         Controls if the primary key should be displayed in the list view.
     """
 
+    column_display_actions = True
+    """
+        Controls the display of the row actions (edit, delete, details, etc.)
+        column in the list view.
+
+        Useful for preventing a blank column from displaying if your view does
+        not use any build-in or custom row actions.
+
+        This column is not hidden automatically due to backwards compatibility.
+
+        Note: This only affects display and does not control whether the row
+        actions endpoints are accessible.
+    """
+
     simple_list_pager = False
     """
         Enable or disable simple list pager.

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -70,7 +70,9 @@
                     </th>
                     {% endif %}
                     {% block list_row_actions_header %}
-                    <th class="span1">&nbsp;</th>
+                        {% if admin_view.column_display_actions %}
+                        <th class="span1">&nbsp;</th>
+                        {% endif %}
                     {% endblock %}
                     {% set column = 0 %}
                     {% for c, name in list_columns %}
@@ -112,42 +114,44 @@
                 </td>
                 {% endif %}
                 {% block list_row_actions_column scoped %}
-                <td class="list-buttons-column">
-                    {% block list_row_actions scoped %}
-                        {%- if admin_view.can_view_details -%}
-                            {%- if admin_view.details_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon icon-eye-open"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
-                                    <span class="fa fa-eye icon-eye-open"></span>
-                                </a>
+                    {% if admin_view.column_display_actions %}
+                    <td class="list-buttons-column">
+                        {% block list_row_actions scoped %}
+                            {%- if admin_view.can_view_details -%}
+                                {%- if admin_view.details_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon icon-eye-open"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
+                                        <span class="fa fa-eye icon-eye-open"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_edit -%}
-                            {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
-                                    <i class="fa fa-pencil icon-pencil"></i>
-                                </a>
+                            {%- if admin_view.can_edit -%}
+                                {%- if admin_view.edit_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
+                                        <i class="fa fa-pencil icon-pencil"></i>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_delete -%}
-                        <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
-                            {{ delete_form.id(value=get_pk_value(row)) }}
-                            {{ delete_form.url(value=return_url) }}
-                            {% if delete_form.csrf_token %}
-                            {{ delete_form.csrf_token }}
-                            {% elif csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                            {% endif %}
-                            <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="{{ _gettext('Delete record') }}">
-                                <i class="fa fa-trash icon-trash"></i>
-                            </button>
-                        </form>
-                        {%- endif -%}
-                    {% endblock %}
-                </td>
+                            {%- if admin_view.can_delete -%}
+                            <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
+                                {{ delete_form.id(value=get_pk_value(row)) }}
+                                {{ delete_form.url(value=return_url) }}
+                                {% if delete_form.csrf_token %}
+                                {{ delete_form.csrf_token }}
+                                {% elif csrf_token %}
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                {% endif %}
+                                <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="{{ _gettext('Delete record') }}">
+                                    <i class="fa fa-trash icon-trash"></i>
+                                </button>
+                            </form>
+                            {%- endif -%}
+                        {% endblock %}
+                    </td>
+                    {%- endif -%}
                 {% endblock %}
 
                 {% for c, name in list_columns %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -70,7 +70,9 @@
                     </th>
                     {% endif %}
                     {% block list_row_actions_header %}
-                    <th class="col-md-1">&nbsp;</th>
+                        {% if admin_view.column_display_actions %}
+                        <th class="col-md-1">&nbsp;</th>
+                        {% endif %}
                     {% endblock %}
                     {% set column = 0 %}
                     {% for c, name in list_columns %}
@@ -112,42 +114,44 @@
                 </td>
                 {% endif %}
                 {% block list_row_actions_column scoped %}
-                <td class="list-buttons-column">
-                    {% block list_row_actions scoped %}
-                        {%- if admin_view.can_view_details -%}
-                            {%- if admin_view.details_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon glyphicon-eye-open"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
-                                    <span class="fa fa-eye glyphicon glyphicon-eye-open"></span>
-                                </a>
+                    {% if admin_view.column_display_actions %}
+                    <td class="list-buttons-column">
+                        {% block list_row_actions scoped %}
+                            {%- if admin_view.can_view_details -%}
+                                {%- if admin_view.details_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.details_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('View Record'), content='<span class="fa fa-eye glyphicon glyphicon-eye-open"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.details_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('View Record') }}">
+                                        <span class="fa fa-eye glyphicon glyphicon-eye-open"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_edit -%}
-                            {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
-                            {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
-                                    <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
-                                </a>
+                            {%- if admin_view.can_edit -%}
+                                {%- if admin_view.edit_modal -%}
+                                    {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
+                                {% else %}
+                                    <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
+                                        <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
+                                    </a>
+                                {%- endif -%}
                             {%- endif -%}
-                        {%- endif -%}
-                        {%- if admin_view.can_delete -%}
-                        <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
-                            {{ delete_form.id(value=get_pk_value(row)) }}
-                            {{ delete_form.url(value=return_url) }}
-                            {% if delete_form.csrf_token %}
-                            {{ delete_form.csrf_token }}
-                            {% elif csrf_token %}
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                            {% endif %}
-                            <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
-                                <span class="fa fa-trash glyphicon glyphicon-trash"></span>
-                            </button>
-                        </form>
-                        {%- endif -%}
-                    {% endblock %}
-                </td>
+                            {%- if admin_view.can_delete -%}
+                            <form class="icon" method="POST" action="{{ get_url('.delete_view') }}">
+                                {{ delete_form.id(value=get_pk_value(row)) }}
+                                {{ delete_form.url(value=return_url) }}
+                                {% if delete_form.csrf_token %}
+                                {{ delete_form.csrf_token }}
+                                {% elif csrf_token %}
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                {% endif %}
+                                <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
+                                    <span class="fa fa-trash glyphicon glyphicon-trash"></span>
+                                </button>
+                            </form>
+                            {%- endif -%}
+                        {% endblock %}
+                    </td>
+                    {%- endif -%}
                 {% endblock %}
                 {% for c, name in list_columns %}
                     <td class="col-{{c}}">


### PR DESCRIPTION
Adds the column_display_actions option to ModelView to allow for hiding the row actions column without modifying list.html. Useful for when you don't want the blank column to appear when you have can_edit, can_delete, and can_view_details disabled.

column_display_actions=True (default): 
<img width="186" alt="true" src="https://cloud.githubusercontent.com/assets/992533/10270454/ab194434-6ab7-11e5-999e-3f05d03b6367.png">

column_display_actions=False:
<img width="186" alt="false" src="https://cloud.githubusercontent.com/assets/992533/10270457/c7174afa-6ab7-11e5-973e-53b2ece36aff.png">

This approach preserves backwards compatibility for projects that have can_edit + can_delete disabled and have custom row actions.

Discussion about this is here: #1005