### PR TITLE
Use WTForms translations for (non-custom) validation errors

### DIFF
--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -11,6 +11,13 @@ except ImportError:
     def lazy_gettext(string, **variables):
         return gettext(string, **variables)
 
+    class Translations(object):
+        ''' dummy Translations class for WTForms, no translation support '''
+        def gettext(self, string):
+            return gettext(string)
+
+        def ngettext(self, singular, plural, n):
+            return ngettext(singular, plural, n)
 else:
     from flask_admin import translations
 
@@ -33,6 +40,22 @@ else:
     gettext = domain.gettext
     ngettext = domain.ngettext
     lazy_gettext = domain.lazy_gettext
+
+    try:
+        from wtforms.i18n import messages_path
+    except ImportError:
+        from wtforms.ext.i18n.utils import messages_path
+
+    wtforms_domain = Domain(messages_path(), domain='wtforms')
+
+    class Translations(object):
+        ''' Fixes WTForms translation support and uses wtforms translations '''
+        def gettext(self, string):
+            return wtforms_domain.gettext(string)
+
+        def ngettext(self, singular, plural, n):
+            return wtforms_domain.ngettext(singular, plural, n)
+
 
 # lazy imports
 from .helpers import get_current_view

--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -6,6 +6,7 @@ except ImportError:
         return string % variables
 
     def ngettext(singular, plural, num, **variables):
+        variables.setdefault('num', num)
         return (singular if num == 1 else plural) % variables
 
     def lazy_gettext(string, **variables):

--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -58,10 +58,10 @@ class ItemsRequired(InputRequired):
         if len(field.data) < self.min:
             if self.message is None:
                 message = field.ngettext(
-                    u"At least %d item is required",
-                    u"At least %d items are required",
+                    u"At least %(num)d item is required",
+                    u"At least %(num)d items are required",
                     self.min
-                ) % (self.min,)
+                )
             else:
                 message = self.message
 

--- a/flask_admin/form/__init__.py
+++ b/flask_admin/form/__init__.py
@@ -1,5 +1,6 @@
 from wtforms import form, __version__ as wtforms_version
 from wtforms.fields.core import UnboundField
+from flask_admin.babel import Translations
 
 from .fields import *
 from .widgets import *
@@ -7,10 +8,15 @@ from .upload import *
 
 
 class BaseForm(form.Form):
+    _translations = Translations()
+
     def __init__(self, formdata=None, obj=None, prefix=u'', **kwargs):
         self._obj = obj
 
         super(BaseForm, self).__init__(formdata=formdata, obj=obj, prefix=prefix, **kwargs)
+
+    def _get_translations(self):
+        return self._translations
 
 
 class FormOpts(object):


### PR DESCRIPTION
Fixes #1042 and #1076

Fixes translations for WTForms validation errors by overriding the base form's _get_translations like in the WTForms documentation: https://github.com/wtforms/wtforms/blob/3f955152b64a75b1d8cebf35bc9761a7216f4abd/docs/i18n.rst#writing-your-own-translations-provider

Also required fixing the dummy version of ngettext (for when flask_babelex fails to import) and one of the translations. Now the dummy ngettext works like the flask-babelex ngettext.