### PR TITLE
lock flask-login to 0.2.11 until flask-security is fixed

### DIFF
--- a/examples/auth-flask-login/requirements.txt
+++ b/examples/auth-flask-login/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 Flask-SQLAlchemy
-Flask-Login
+Flask-Login==0.2.11

--- a/examples/auth-mongoengine/requirements.txt
+++ b/examples/auth-mongoengine/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 flask-mongoengine
-Flask-Login
+Flask-Login==0.2.11

--- a/examples/auth/requirements.txt
+++ b/examples/auth/requirements.txt
@@ -2,3 +2,4 @@ Flask
 Flask-Admin
 Flask-SQLAlchemy
 Flask-Security==1.7.4
+Flask-Login==0.2.11

--- a/examples/menu-external-links/requirements.txt
+++ b/examples/menu-external-links/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 Flask-Admin
-Flask-Login
+Flask-Login==0.2.11

--- a/examples/mongoengine/requirements.txt
+++ b/examples/mongoengine/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 Flask-MongoEngine
-Flask-Login
+Flask-Login==0.2.11


### PR DESCRIPTION
Fixes #1081

I tried going through the examples and changing all the ```is_authenticated()``` to ```is_authenticated```, but the flask-login change to is_authenticated (https://github.com/maxcountryman/flask-login/pull/177) still breaks flask-security.

There's a lot of discussion about the fix to flask-security here: https://github.com/mattupstate/flask-security/issues/416

Until a fix gets released, it's probably best to just lock flask-login to 0.2.11.