### PR TITLE
FileAdmin - alert user when upload fails due to file already existing

### DIFF
--- a/flask_admin/contrib/fileadmin.py
+++ b/flask_admin/contrib/fileadmin.py
@@ -597,8 +597,8 @@ class FileAdmin(BaseView, ActionsMixin):
 
         if op.exists(filename):
             secure_name = op.join(path, secure_filename(form.upload.data.filename))
-            flash(gettext('File "%(name)s" already exists.', name=secure_name),
-                  'error')
+            raise Exception(gettext('File "%(name)s" already exists.',
+                                    name=secure_name))
         else:
             self.save_file(filename, form.upload.data)
             self.on_file_upload(directory, path, filename)


### PR DESCRIPTION
Currently, the FileAdmin will say "Successfully saved file" when it fails to save a file (because the file already exists).

This pull request will throw an exception when a file already exists. The exception will be caught and displayed on the upload form.

Screenshot of new behavior:
![test](https://i.imgur.com/MZtjeh9m.png)