### PR TITLE
add form blocks to modal and fileadmin templates too

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/file/form.html
+++ b/flask_admin/templates/bootstrap2/admin/file/form.html
@@ -3,5 +3,7 @@
 
 {% block body %}
   {% block header %}<h3>{{ header_text }}</h3>{% endblock %}
-  {{ lib.render_form(form, dir_url) }}
+  {% block fa_form %}
+    {{ lib.render_form(form, dir_url) }}
+  {% endblock %}
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/file/modals/form.html
+++ b/flask_admin/templates/bootstrap2/admin/file/modals/form.html
@@ -3,7 +3,9 @@
 
 {% block body %}
   {# content added to modal-content #}
-  {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+  {% block fa_form %}
+    {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+  {% endblock %}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/create.html
@@ -6,9 +6,11 @@
 
 {% block body %}
   {# "save and add" button is removed from modal (it won't function properly) #}
-  {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                     action=url_for('.create_view', url=return_url),
-                     is_modal=True) }}
+  {% block create_form %}
+    {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                       action=url_for('.create_view', url=return_url),
+                       is_modal=True) }}
+  {% endblock %}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
@@ -6,9 +6,11 @@
 
 {% block body %}
   {# "save and continue" button is removed from modal (it won't function properly) #}
-  {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                     action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                     is_modal=True) }}
+  {% block edit_form %}
+    {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                       action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
+                       is_modal=True) }}
+  {% endblock %}
 {% endblock %}
 
 {% block tail %}

--- a/flask_admin/templates/bootstrap3/admin/file/form.html
+++ b/flask_admin/templates/bootstrap3/admin/file/form.html
@@ -3,5 +3,7 @@
 
 {% block body %}
   {% block header %}<h3>{{ header_text }}</h3>{% endblock %}
-  {{ lib.render_form(form, dir_url) }}
+  {% block fa_form %}
+    {{ lib.render_form(form, dir_url) }}
+  {% endblock %}
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/file/modals/form.html
+++ b/flask_admin/templates/bootstrap3/admin/file/modals/form.html
@@ -8,7 +8,9 @@
     {% block header %}<h3>{{ header_text }}</h3>{% endblock %}
   </div>
   <div class="modal-body">
-    {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+    {% block fa_form %}
+      {{ lib.render_form(form, dir_url, action=request.url, is_modal=True) }}
+    {% endblock %}
   </div>
 {% endblock %}
 

--- a/flask_admin/templates/bootstrap3/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/create.html
@@ -11,9 +11,11 @@
   </div>
   <div class="modal-body">
     {# "save and add" button is removed from modal (it won't function properly) #}
-    {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                       action=url_for('.create_view', url=return_url),
-                       is_modal=True) }}
+    {% block create_form %}
+      {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                         action=url_for('.create_view', url=return_url),
+                         is_modal=True) }}
+    {% endblock %}
   </div>
 {% endblock %}
 

--- a/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
@@ -13,9 +13,11 @@
   </div>
   <div class="modal-body">
     {# "save and continue" button is removed from modal (it won't function properly) #}
-    {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
-                       action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
-                       is_modal=True) }}
+    {% block edit_form %}
+      {{ lib.render_form(form, return_url, extra=None, form_opts=form_opts,
+                         action=url_for('.edit_view', id=request.args.get('id'), url=return_url),
+                         is_modal=True) }}
+    {% endblock %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
Related to the pull request in #1088

Adds the same form blocks to the modal and FileAdmin templates.