### PR TITLE
prevent validators from getting inserted twice

### DIFF
--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from mongoengine import ReferenceField, ListField
 from mongoengine.base import BaseDocument, DocumentMetaclass, get_document
 
@@ -68,7 +70,8 @@ class CustomModelConverter(orm.ModelConverter):
         }
 
         if field_args:
-            kwargs.update(field_args)
+            # prevent modification of self.form_args
+            kwargs.update(deepcopy(field_args))
 
         if field.required:
             kwargs['validators'].append(validators.InputRequired())

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -1,5 +1,7 @@
 import warnings
 
+from copy import deepcopy
+
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
 
@@ -147,7 +149,8 @@ class AdminModelConverter(ModelConverterBase):
         }
 
         if field_args:
-            kwargs.update(field_args)
+            # prevent modification of self.form_args
+            kwargs.update(deepcopy(field_args))
 
         # Check if it is relation or property
         if hasattr(prop, 'direction'):


### PR DESCRIPTION
Fixes #1094 

When ```kwargs``` in ```convert()``` is updated with ```field_args``` (really ```self.form_args```), only a referenced to mutable objects in ```self.form_args``` are copied. So, modifying ```kwargs``` can also modify mutable objects in the overridden ```self.form_args```. Validators like ```Unique``` will be added to self.form_args once when the edit form is created, then duplicated when the create form is created.

The solution is to create a deepcopy of ```field_args``` to prevent the rest of that code from modifying ```self.form_args```.

Also submitted a pull request to wtf-peewee here: https://github.com/coleifer/wtf-peewee/pull/30