### PR TITLE
Fix #1101 form.js addInlineField for new nested elements

### DIFF
--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -484,7 +484,10 @@
         var $parentForm = $el.parent().closest('.inline-field');
 
         if ($parentForm.hasClass('fresh')) {
-          id = $parentForm.attr('id') + '-' + elID;
+          id = $parentForm.attr('id');
+          if (elID) {
+            id += '-' + elID;
+          }
         }
 
         var $fieldList = $el.find('> .inline-field-list');


### PR DESCRIPTION
The problem appears with rendering new nested elements for MongoEngine.
When you create a new nested element for another new element (not yet saved) form.js puts an extra "-" in the id and this results in the parent element saved empty (the nested elements fail).

For example I use mapping for some elements with a Mongo field like this:
ListField(ListField(StringField())).

I solved this problem by adding additional check that elID exists (it doesn't exist yet for the new parent element)