### PR TITLE
Add nowrap to action icons table cell

### DIFF
--- a/flask_admin/static/admin/css/bootstrap3/admin.css
+++ b/flask_admin/static/admin/css/bootstrap3/admin.css
@@ -38,6 +38,11 @@
     margin: 1px 0 0 0;
 }
 
+/* List View - prevent word wrap on buttons column, to keep it on one line */
+.list-buttons-column {
+    white-space: nowrap;
+}
+
 /* Filters */
 table.filters {
     border-collapse: collapse;


### PR DESCRIPTION
This was added in the past to the bootstrap2 css but not to the bootstrap3 css.