### PR TITLE
fix inet types converter, search by non-text fields

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -334,13 +334,15 @@ class AdminModelConverter(ModelConverterBase):
         field_args['validators'].append(validators.NumberRange(min=1901, max=2155))
         return fields.StringField(**field_args)
 
-    @converts('databases.postgres.PGInet', 'dialects.postgresql.base.INET')
+    @converts('sqlalchemy.dialects.postgresql.base.INET',
+              'databases.postgres.PGInet', 'dialects.postgresql.base.INET')
     def conv_PGInet(self, field_args, **extra):
         field_args.setdefault('label', u'IP Address')
         field_args['validators'].append(validators.IPAddress())
         return fields.StringField(**field_args)
 
-    @converts('dialects.postgresql.base.MACADDR')
+    @converts('sqlalchemy.dialects.postgresql.base.MACADDR',
+              'dialects.postgresql.base.MACADDR')
     def conv_PGMacaddr(self, field_args, **extra):
         field_args.setdefault('label', u'MAC Address')
         field_args['validators'].append(validators.MacAddress())

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import joinedload, aliased
 from sqlalchemy.sql.expression import desc, ColumnElement
 from sqlalchemy import Boolean, Table, func, or_
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import cast
+from sqlalchemy import Unicode
 
 from flask import flash
 
@@ -828,11 +830,11 @@ class ModelView(BaseModelView):
                                                                                    inner_join=False)
 
                 column = field if alias is None else getattr(alias, field.key)
-                filter_stmt.append(column.ilike(stmt))
+                filter_stmt.append(cast(column, Unicode).ilike(stmt))
 
                 if count_filter_stmt is not None:
                     column = field if count_alias is None else getattr(count_alias, field.key)
-                    count_filter_stmt.append(column.ilike(stmt))
+                    count_filter_stmt.append(cast(column, Unicode).ilike(stmt))
 
             query = query.filter(or_(*filter_stmt))
 


### PR DESCRIPTION
Hello, i've added 2 features
1) Fix AdminModelConverter for some postgresql types. If don't do it then fields with type Mac, Inet will not be shown in edit form view.
2) Added cast any type of column to unicode. I think it would be nice to search by any non-text field.