### PR TITLE
make flask-admin compatible with peewee 2.7.4

### DIFF
--- a/flask_admin/contrib/peewee/tools.py
+++ b/flask_admin/contrib/peewee/tools.py
@@ -1,10 +1,5 @@
-from peewee import PrimaryKeyField
-
-
 def get_primary_key(model):
-    for n, f in model._meta.get_sorted_fields():
-        if type(f) == PrimaryKeyField or f.primary_key:
-            return n
+    return model._meta.primary_key.name
 
 
 def parse_like_term(term):

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -2,7 +2,7 @@ import logging
 
 from flask import flash
 
-from flask_admin._compat import string_types
+from flask_admin._compat import string_types, iteritems
 from flask_admin.babel import gettext, ngettext, lazy_gettext
 from flask_admin.model import BaseModelView
 from flask_admin.model.form import wrap_fields_in_fieldlist
@@ -149,7 +149,7 @@ class ModelView(BaseModelView):
         if model is None:
             model = self.model
 
-        return model._meta.get_sorted_fields()
+        return iteritems(model._meta.fields)
 
     def scaffold_pk(self):
         return get_primary_key(self.model)


### PR DESCRIPTION
Fixes #1118

Similar to #1118, but keeps backwards compatibility with earlier versions of peewee.

I tested with peewee 2.6.0 and 2.7.4 (current version).

More details about the backwards incompatible changes here: https://github.com/coleifer/peewee/issues/765

Thank you for your help with this @rudyryk