### PR TITLE
change mongoengine extra field order test to match sqla/peewee

### DIFF
--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -729,7 +729,6 @@ def test_extra_field_order():
 
     view = CustomModelView(
         Model1,
-        form_columns=('extra_field', 'test1'),
         form_extra_fields={
             'extra_field': fields.StringField('Extra Field')
         }
@@ -743,9 +742,10 @@ def test_extra_field_order():
 
     # Check presence and order
     data = rv.data.decode('utf-8')
+    ok_('Extra Field' in data)
     pos1 = data.find('Extra Field')
     pos2 = data.find('Test1')
-    ok_(pos2 > pos1)
+    ok_(pos2 < pos1)
 
 
 def test_custom_form_base():


### PR DESCRIPTION
This test started failing after the changes in mongoengine 0.10.4, because the position of the fields changed: https://github.com/flask-admin/flask-admin/blob/29f8e0d4de9e1490989b3fc96d53765af6acb44b/flask_admin/tests/mongoengine/test_basic.py#L725

I changed the test to be the same as the Peewee and SQLAlchemy tests for the same thing, and it's passing now.