### PR TITLE
Fix regex validators when using form_args

### DIFF
--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from mongoengine import ReferenceField, ListField
 from mongoengine.base import BaseDocument, DocumentMetaclass, get_document
 
@@ -70,8 +68,11 @@ class CustomModelConverter(orm.ModelConverter):
         }
 
         if field_args:
-            # prevent modification of self.form_args
-            kwargs.update(deepcopy(field_args))
+            kwargs.update(field_args)
+
+        if kwargs['validators']:
+            # Create a copy of the list since we will be modifying it.
+            kwargs['validators'] = list(kwargs['validators'])
 
         if field.required:
             kwargs['validators'].append(validators.InputRequired())

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -1,7 +1,5 @@
 import warnings
 
-from copy import deepcopy
-
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
 
@@ -143,8 +141,11 @@ class AdminModelConverter(ModelConverterBase):
         }
 
         if field_args:
-            # prevent modification of self.form_args
-            kwargs.update(deepcopy(field_args))
+            kwargs.update(field_args)
+
+        if kwargs['validators']:
+            # Create a copy of the list since we will be modifying it.
+            kwargs['validators'] = list(kwargs['validators'])
 
         # Check if it is relation or property
         if hasattr(prop, 'direction'):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1,6 +1,6 @@
 from nose.tools import eq_, ok_, raises, assert_true
 
-from wtforms import fields
+from wtforms import fields, validators
 
 from flask_admin import form
 from flask_admin._compat import as_unicode
@@ -1441,7 +1441,27 @@ def test_form_columns():
 
     ok_(type(form3.model).__name__ == 'QuerySelectField')
 
-    # TODO: form_args
+
+def test_form_args():
+    app, db, admin = setup()
+
+    class Model(db.Model):
+        id = db.Column(db.String, primary_key=True)
+        test = db.Column(db.String, nullable=False)
+
+    db.create_all()
+
+    shared_form_args = {'test': {'validators': [validators.Regexp('test')]}}
+
+    view = CustomModelView(Model, db.session, form_args=shared_form_args)
+    admin.add_view(view)
+
+    create_form = view.create_form()
+    eq_(len(create_form.test.validators), 2)
+
+    # ensure shared field_args don't create duplicate validators
+    edit_form = view.edit_form()
+    eq_(len(edit_form.test.validators), 2)
 
 
 def test_form_override():


### PR DESCRIPTION
This change broke wtforms regex validators in form_args: https://github.com/flask-admin/flask-admin/pull/1099

@ak04nv found the issue and explained it here: https://github.com/coleifer/wtf-peewee/pull/30#issuecomment-160880686

For additional info, the description on this pull request explains the whole issue better than #1099: https://github.com/MongoEngine/flask-mongoengine/pull/188

Credit for the real fix goes to the awesome @coleifer.