### PR TITLE
Prevent duplicate translations, localize "New" for inline forms

### DIFF
--- a/babel/admin.pot
+++ b/babel/admin.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Admin VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-12-11 17:54-0600\n"
+"POT-Creation-Date: 2015-12-15 07:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -528,6 +528,11 @@ msgstr ""
 msgid "Delete?"
 msgstr ""
 
+#: ../flask_admin/templates/bootstrap2/admin/model/inline_list_base.html:30
+#: ../flask_admin/templates/bootstrap3/admin/model/inline_list_base.html:33
+msgid "New"
+msgstr ""
+
 #: ../flask_admin/templates/bootstrap2/admin/model/inline_list_base.html:40
 #: ../flask_admin/templates/bootstrap3/admin/model/inline_list_base.html:43
 msgid "Add"
@@ -557,9 +562,11 @@ msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:22
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:24
+#: ../flask_admin/templates/bootstrap2/admin/model/modals/create.html:22
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:22
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:24
-msgid "Create new record"
+#: ../flask_admin/templates/bootstrap3/admin/model/modals/create.html:10
+msgid "Create New Record"
 msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:31
@@ -596,9 +603,11 @@ msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:126
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:128
+#: ../flask_admin/templates/bootstrap2/admin/model/modals/edit.html:22
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:126
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:128
-msgid "Edit record"
+#: ../flask_admin/templates/bootstrap3/admin/model/modals/edit.html:11
+msgid "Edit Record"
 msgstr ""
 
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:142
@@ -613,15 +622,5 @@ msgstr ""
 #: ../flask_admin/templates/bootstrap2/admin/model/list.html:199
 #: ../flask_admin/templates/bootstrap3/admin/model/list.html:200
 msgid "Please select at least one record."
-msgstr ""
-
-#: ../flask_admin/templates/bootstrap2/admin/model/modals/create.html:22
-#: ../flask_admin/templates/bootstrap3/admin/model/modals/create.html:10
-msgid "Create New Record"
-msgstr ""
-
-#: ../flask_admin/templates/bootstrap2/admin/model/modals/edit.html:22
-#: ../flask_admin/templates/bootstrap3/admin/model/modals/edit.html:11
-msgid "Edit Record"
 msgstr ""
 

--- a/flask_admin/templates/bootstrap2/admin/model/inline_list_base.html
+++ b/flask_admin/templates/bootstrap2/admin/model/inline_list_base.html
@@ -27,7 +27,7 @@
         {% filter forceescape %}
         <div class="inline-field well well-small">
             <legend>
-                New {{ field.label.text }}
+                {{ _gettext('New') }} {{ field.label.text }}
                 <div class="pull-right">
                     <a href="javascript:void(0)" class="inline-remove-field"><i class="fa fa-times icon-remove"></i></a>
                 </div>

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -19,9 +19,9 @@
         {% if admin_view.can_create %}
         <li>
           {%- if admin_view.create_modal -%}
-            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create new record'), content=_gettext('Create')) }}
+            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create New Record'), content=_gettext('Create')) }}
           {% else %}
-            <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create new record') }}">{{ _gettext('Create') }}</a>
+            <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create New Record') }}">{{ _gettext('Create') }}</a>
           {%- endif -%}
         </li>
         {% endif %}
@@ -123,9 +123,9 @@
                         {%- endif -%}
                         {%- if admin_view.can_edit -%}
                             {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
+                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<i class="fa fa-pencil icon-pencil"></i>') }}
                             {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
+                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
                                     <i class="fa fa-pencil icon-pencil"></i>
                                 </a>
                             {%- endif -%}

--- a/flask_admin/templates/bootstrap3/admin/model/inline_list_base.html
+++ b/flask_admin/templates/bootstrap3/admin/model/inline_list_base.html
@@ -30,7 +30,7 @@
         {% filter forceescape %}
         <div class="inline-field well well-sm">
             <legend>
-                <small>New {{ field.label.text }}</small>
+                <small>{{ _gettext('New') }} {{ field.label.text }}</small>
                 <div class="pull-right">
                     <a href="javascript:void(0)" class="inline-remove-field"><span class="fa fa-times glyphicon glyphicon-remove"></span></a>
                 </div>

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -19,9 +19,9 @@
         {% if admin_view.can_create %}
         <li>
           {%- if admin_view.create_modal -%}
-            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create new record'), content=_gettext('Create')) }}
+            {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), title=_gettext('Create New Record'), content=_gettext('Create')) }}
           {% else %}
-            <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create new record') }}">{{ _gettext('Create') }}</a>
+            <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create New Record') }}">{{ _gettext('Create') }}</a>
           {%- endif -%}
         </li>
         {% endif %}
@@ -123,9 +123,9 @@
                         {%- endif -%}
                         {%- if admin_view.can_edit -%}
                             {%- if admin_view.edit_modal -%}
-                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
+                                {{ lib.add_modal_button(url=get_url('.edit_view', id=get_pk_value(row), url=return_url, modal=True), title=_gettext('Edit Record'), content='<span class="fa fa-pencil glyphicon glyphicon-pencil"></span>') }}
                             {% else %}
-                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit record') }}">
+                                <a class="icon" href="{{ get_url('.edit_view', id=get_pk_value(row), url=return_url) }}" title="{{ _gettext('Edit Record') }}">
                                     <span class="fa fa-pencil glyphicon glyphicon-pencil"></span>
                                 </a>
                             {%- endif -%}


### PR DESCRIPTION
* Fixes capitalization for "Create new record" and "Edit record" to "Create New Record" and "Edit Record" to prevent duplicate translations
* Fixes part of #1120 by putting _gettext around "New" for inline forms