### PR TITLE
prevent assuming 'id' is primary key for details view

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1927,7 +1927,6 @@ class BaseModelView(BaseView, ActionsMixin):
                            model=model,
                            details_columns=self._details_columns,
                            get_value=self.get_list_value,
-                           get_pk_value=self.get_pk_value,
                            return_url=return_url)
 
     @expose('/delete/', methods=('POST',))

--- a/flask_admin/templates/bootstrap2/admin/model/details.html
+++ b/flask_admin/templates/bootstrap2/admin/model/details.html
@@ -14,7 +14,7 @@
     {%- endif -%}
     {%- if admin_view.can_edit -%}
     <li>
-        <a href="{{ get_url('.edit_view', id=get_pk_value(model), url=return_url) }}">{{ _gettext('Edit') }}</a>
+        <a href="{{ get_url('.edit_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Edit') }}</a>
     </li>
     {%- endif -%}
     <li class="active">

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -27,7 +27,7 @@
     </li>
     {%- if admin_view.can_view_details -%}
     <li>
-        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('Details') }}</a>
+        <a href="{{ get_url('.details_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Details') }}</a>
     </li>
     {%- endif -%}
   </ul>

--- a/flask_admin/templates/bootstrap3/admin/model/details.html
+++ b/flask_admin/templates/bootstrap3/admin/model/details.html
@@ -14,7 +14,7 @@
     {%- endif -%}
     {%- if admin_view.can_edit -%}
     <li>
-        <a href="{{ get_url('.edit_view', id=get_pk_value(model), url=return_url) }}">{{ _gettext('Edit') }}</a>
+        <a href="{{ get_url('.edit_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Edit') }}</a>
     </li>
     {%- endif -%}
     <li class="active">

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -27,7 +27,7 @@
     </li>
     {%- if admin_view.can_view_details -%}
     <li>
-        <a href="{{ get_url('.details_view', id=model.id, url=return_url) }}">{{ _gettext('Details') }}</a>
+        <a href="{{ get_url('.details_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Details') }}</a>
     </li>
     {%- endif -%}
   </ul>


### PR DESCRIPTION
Fixes #1148 (edit.html assumes primary key is `model.id`)

* Use `request.args.get('id')` instead of `model.id` in edit.html
* Removes unnecessary `get_pk_value` from details view, and use `request.args.get('id')` instead of `get_pk_value(model)`