### PR TITLE
SQLA get_count_query uses get_query() instead of model

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -749,8 +749,6 @@ class ModelView(BaseModelView):
         """
             Return a query for the model type.
 
-            If you override this method, don't forget to override `get_count_query` as well.
-
             This method can be used to set a "persistent filter" on an index_view.
 
             Example::
@@ -770,7 +768,7 @@ class ModelView(BaseModelView):
 
             See commit ``#45a2723`` for details.
         """
-        return self.session.query(func.count('*')).select_from(self.model)
+        return self.session.query(func.count('*')).select_from(self.get_query().subquery())
 
     def _order_by(self, query, joins, sort_joins, sort_field, sort_desc):
         """


### PR DESCRIPTION
Instead of override the get_count_query method every time by default it gets the model query. I use soft delete in my models and this was definitely useful.

I can write some test if you want.