### PR TITLE
Fix editable list view - CSRF validation & widget override

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1709,11 +1709,6 @@ class BaseModelView(BaseView, ActionsMixin):
         """
             List view
         """
-        if self.column_editable_list:
-            form = self.list_form
-        else:
-            form = None
-
         if self.can_delete:
             delete_form = self.delete_form()
         else:
@@ -1730,6 +1725,11 @@ class BaseModelView(BaseView, ActionsMixin):
         # Get count and data
         count, data = self.get_list(view_args.page, sort_column, view_args.sort_desc,
                                     view_args.search, view_args.filters)
+
+        list_forms = {}
+        if self.column_editable_list:
+            for row in data:
+                list_forms[self.get_pk_value(row)] = self.list_form(obj=row)
 
         # Calculate number of pages
         if count is not None:
@@ -1767,7 +1767,7 @@ class BaseModelView(BaseView, ActionsMixin):
         return self.render(
             self.list_template,
             data=data,
-            form=form,
+            list_forms=list_forms,
             delete_form=delete_form,
 
             # List

--- a/flask_admin/model/form.py
+++ b/flask_admin/model/form.py
@@ -33,7 +33,7 @@ def create_editable_list_form(form_base_class, form_class, widget=None):
             WTForms widget class. Defaults to `XEditableWidget`.
     """
     if widget is None:
-        widget = XEditableWidget
+        widget = XEditableWidget()
 
     class ListForm(form_base_class):
         list_form_pk = HiddenField(validators=[InputRequired()])
@@ -41,7 +41,7 @@ def create_editable_list_form(form_base_class, form_class, widget=None):
     # iterate FormMeta to get unbound fields, replace widget, copy to ListForm
     for name, obj in iteritems(form_class.__dict__):
         if isinstance(obj, UnboundField):
-            obj.kwargs['widget'] = XEditableWidget()
+            obj.kwargs['widget'] = widget
             setattr(ListForm, name, obj)
 
             if name == "list_form_pk":

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -157,10 +157,11 @@
                 {% for c, name in list_columns %}
                     <td class="col-{{c}}">
                     {% if admin_view.is_editable(c) %}
+                        {% set form = list_forms[get_pk_value(row)] %}
                         {% if form.csrf_token %}
-                        {{ form(obj=row)[c](pk=get_pk_value(row), display_value=get_value(row, c), csrf=form.csrf_token._value()) }}
+                        {{ form[c](pk=get_pk_value(row), display_value=get_value(row, c), csrf=form.csrf_token._value()) }}
                         {% else %}
-                        {{ form(obj=row)[c](pk=get_pk_value(row), display_value=get_value(row, c)) }}
+                        {{ form[c](pk=get_pk_value(row), display_value=get_value(row, c)) }}
                         {% endif %}
                     {% else %}
                     {{ get_value(row, c) }}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -153,13 +153,15 @@
                     </td>
                     {%- endif -%}
                 {% endblock %}
+
                 {% for c, name in list_columns %}
                     <td class="col-{{c}}">
                     {% if admin_view.is_editable(c) %}
+                        {% set form = list_forms[get_pk_value(row)] %}
                         {% if form.csrf_token %}
-                        {{ form(obj=row)[c](pk=get_pk_value(row), display_value=get_value(row, c), csrf=form.csrf_token._value()) }}
+                        {{ form[c](pk=get_pk_value(row), display_value=get_value(row, c), csrf=form.csrf_token._value()) }}
                         {% else %}
-                        {{ form(obj=row)[c](pk=get_pk_value(row), display_value=get_value(row, c)) }}
+                        {{ form[c](pk=get_pk_value(row), display_value=get_value(row, c)) }}
                         {% endif %}
                     {% else %}
                     {{ get_value(row, c) }}


### PR DESCRIPTION
This fixes two issues caused by #1160:
* Broken CSRF validation in the editable list view. (was trying to get csrf_token from an uninitialized form)
* Overriding the default widget used by create_editable_list_form (XEditableWidget) doesn't work.