### PR TITLE
Prevent showing 'save and ~' buttons when actions disabled

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/lib.html
+++ b/flask_admin/templates/bootstrap2/admin/lib.html
@@ -251,3 +251,12 @@
   {% endif %}
   <script src="{{ admin_static.url(filename='admin/js/form.js', v='1.0.1') }}"></script>
 {% endmacro %}
+
+{% macro extra() %}
+  {% if admin_view.can_create %}
+  <input name="_add_another" type="submit" class="btn" value="{{ _gettext('Save and Add Another') }}" />
+  {% endif %}
+  {% if admin_view.can_edit %}
+  <input name="_continue_editing" type="submit" class="btn" value="{{ _gettext('Save and Continue Editing') }}" />
+  {% endif %}
+{% endmacro %}

--- a/flask_admin/templates/bootstrap2/admin/model/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/create.html
@@ -1,10 +1,6 @@
 {% extends 'admin/master.html' %}
 {% import 'admin/lib.html' as lib with context %}
-
-{% macro extra() %}
-  <input name="_add_another" type="submit" class="btn" value="{{ _gettext('Save and Add Another') }}" />
-  <input name="_continue_editing" type="submit" class="btn" value="{{ _gettext('Save and Continue Editing') }}" />
-{% endmacro %}
+{% from 'admin/lib.html' import extra with context %} {# backward compatible #}
 
 {% block head %}
   {{ super() }}

--- a/flask_admin/templates/bootstrap2/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/edit.html
@@ -1,10 +1,6 @@
 {% extends 'admin/master.html' %}
 {% import 'admin/lib.html' as lib with context %}
-
-{% macro extra() %}
-  <input name="_add_another" type="submit" class="btn" value="{{ _gettext('Save and Add Another') }}" />
-  <input name="_continue_editing" type="submit" class="btn" value="{{ _gettext('Save and Continue Editing') }}" />
-{% endmacro %}
+{% from 'admin/lib.html' import extra with context %} {# backward compatible #}
 
 {% block head %}
   {{ super() }}

--- a/flask_admin/templates/bootstrap3/admin/lib.html
+++ b/flask_admin/templates/bootstrap3/admin/lib.html
@@ -235,3 +235,12 @@
   {% endif %}
   <script src="{{ admin_static.url(filename='admin/js/form.js', v='1.0.1') }}"></script>
 {% endmacro %}
+
+{% macro extra() %}
+  {% if admin_view.can_create %}
+  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add Another') }}" />
+  {% endif %}
+  {% if admin_view.can_edit %}
+  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue Editing') }}" />
+  {% endif %}
+{% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/model/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/create.html
@@ -1,10 +1,6 @@
 {% extends 'admin/master.html' %}
 {% import 'admin/lib.html' as lib with context %}
-
-{% macro extra() %}
-  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add Another') }}" />
-  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue Editing') }}" />
-{% endmacro %}
+{% from 'admin/lib.html' import extra with context %} {# backward compatible #}
 
 {% block head %}
   {{ super() }}

--- a/flask_admin/templates/bootstrap3/admin/model/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/edit.html
@@ -1,10 +1,6 @@
 {% extends 'admin/master.html' %}
 {% import 'admin/lib.html' as lib with context %}
-
-{% macro extra() %}
-  <input name="_add_another" type="submit" class="btn btn-default" value="{{ _gettext('Save and Add Another') }}" />
-  <input name="_continue_editing" type="submit" class="btn btn-default" value="{{ _gettext('Save and Continue Editing') }}" />
-{% endmacro %}
+{% from 'admin/lib.html' import extra with context %} {# backward compatible #}
 
 {% block head %}
   {{ super() }}


### PR DESCRIPTION
Fixes #1163

Will prevent showing "Save and Add Another" and "Save and Continue Editing" when their respective actions are disabled.

Also moves `extra()` to lib.html while keeping backward compatibility.

@billmccord Good catch!