### PR TITLE
SQLA - allow using column objects in column_list

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -168,6 +168,15 @@ class BaseModelView(BaseView, ActionsMixin):
 
             class MyModelView(BaseModelView):
                 column_list = ('name', 'last_name', 'email')
+
+        (Added in 1.4.0) SQLAlchemy model attributes can be used instead of strings::
+
+            class MyModelView(BaseModelView):
+                column_list = ('name', User.last_name)
+
+        When using SQLAlchemy models, you can reference related columns like this::
+            class MyModelView(BaseModelView):
+                column_list = ('<relationship>.<related column name>',)
     """
 
     column_exclude_list = ObsoleteAttr('column_exclude_list',
@@ -505,6 +514,15 @@ class BaseModelView(BaseView, ActionsMixin):
 
             class MyModelView(BaseModelView):
                 form_columns = ('name', 'email')
+
+        (Added in 1.4.0) SQLAlchemy model attributes can be used instead of
+        strings::
+
+            class MyModelView(BaseModelView):
+                form_columns = ('name', User.last_name)
+
+        SQLA Note: Model attributes must be on the same model as your ModelView
+        or you will need to use `inline_models`.
     """
 
     form_excluded_columns = ObsoleteAttr('form_excluded_columns',
@@ -878,9 +896,9 @@ class BaseModelView(BaseView, ActionsMixin):
 
     def get_list_columns(self):
         """
-            Returns a list of the model field names. If `column_list` was
-            set, returns it. Otherwise calls `scaffold_list_columns`
-            to generate the list from the model.
+            Returns a list of tuples with the model field name and formatted
+            field name. If `column_list` was set, returns it. Otherwise calls
+            `scaffold_list_columns` to generate the list from the model.
         """
         columns = self.column_list
 


### PR DESCRIPTION
Fixes #1036

I didn't get it working with model attributes from related models, but I made a unit test for it (and commented it out): https://github.com/flask-admin/flask-admin/compare/master...pawl:fix_sqla_column_list?expand=1#diff-527d8cf625fb5fc58b22130d4ded2201R274