### PR TITLE
Fix so that auto-created inline model form has the right base class

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -601,6 +601,7 @@ class InlineModelConverter(InlineModelConverterBase):
         if child_form is None:
             child_form = get_form(info.model,
                                   converter,
+                                  base_class=info.form_base_class or form.BaseForm,
                                   only=info.form_columns,
                                   exclude=exclude,
                                   field_args=info.form_args,


### PR DESCRIPTION
This issue was found while I was trying to localize error messages in inline forms, please see the test for example.