### PR TITLE
Fallback to default location if it was not received from external service

### DIFF
--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -151,6 +151,8 @@
           // look up user's location by IP address
           $.getJSON("http://ip-api.com/json/?callback=?", function(data) {
             map.setView([data["lat"], data["lon"]], 12);
+          }).fail(function() {
+              map.setView([0, 0], 1)
           });
         }
 


### PR DESCRIPTION
If end-user uses adblock or other extension and access to ip-api.com is blocked map will apper gray and it will not be possible to do anything with it. 

If that happens we need to set default location and zoom out for better view.