### PR TITLE
add unit test for a related table's column object

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -9,7 +9,7 @@ from flask_admin.model.form import (converts, ModelConverterBase,
 from flask_admin.model.fields import AjaxSelectField, AjaxSelectMultipleField
 from flask_admin.model.helpers import prettify_name
 from flask_admin._backwards import get_property
-from flask_admin._compat import iteritems, text_type
+from flask_admin._compat import iteritems
 
 from .validators import Unique
 from .fields import (QuerySelectField, QuerySelectMultipleField,

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -475,10 +475,15 @@ class ModelView(BaseModelView):
                     column, path = tools.get_field_with_path(self.model, c)
                     column_name = c
 
-                if path:
+                if path and hasattr(path[0], 'property'):
                     # column is in another table, use full path as column_name
                     column_name = text_type(c)
                     self._sortable_joins[column_name] = path
+                elif path:
+                    raise Exception("For sorting columns in a related table, "
+                                    "column_sortable_list requires a string "
+                                    "like '<relation name>.<column name>'. "
+                                    "Failed on: {0}".format(c))
                 else:
                     # column is in same table, use only model attribute name
                     column_name = column.key


### PR DESCRIPTION
Fixes #1192

This pull request will throw an exception if a developer tries to use a SQLA column object from a related model. It will instruct them to use the string format instead, for example: `'<relation name>.<column name>'`. I figured this behavior is preferred to it mysteriously not working.

Also:
* Removed some unnecessary tests
* Removed unnecessary `text_type` import in form.py