### PR TITLE
More Flexible Exports Without Exceptions

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -2015,7 +2015,30 @@ class BaseModelView(BaseView, ActionsMixin):
         # Macros in column_formatters are not supported.
         # Macros will have a function name 'inner'
         # This causes non-macro functions named 'inner' not work.
+
+        # Skip this check when the field with the macro is excluded...
+        skip_checks = []
+
+        if self.column_export_exclude_list:
+            skip_checks.extend(self.column_export_exclude_list)
+
+        # or there is a macro-less column_formatters_export available.
+        for col, func in iteritems(self.column_formatters_export):
+            # we can skip checking columns not being exported
+            # when the export list is explicitly defined
+            if self.column_export_list and \
+                    col not in self.column_export_list:
+                skip_checks.append(col)
+                continue
+
+            if func.__name__ != 'inner':
+                skip_checks.append(col)
+
+        # main macro check loop, skipping the above "safe" skip list
         for col, func in iteritems(self.column_formatters):
+            if col in skip_checks:
+                continue
+
             if func.__name__ == 'inner':
                 raise NotImplementedError(
                     'Macros not implemented. Override with '


### PR DESCRIPTION
I had a few macro column_formatters defined on a table I wanted to export. I noticed that I was getting exceptions when:

- I had defined a column_export_list excluding the column with the macro
- I had a formatter in column_formatters_export defined to override the macro
- I had excluded the column with the macro in column_export_exclude_list

I wrote a quick fix to this...basically I created a skip_checks list and appended to it columns with valid export formatters (not macros) and columns based on the exclude and include formatters list. I then just skip those columns in the main validation loop. I wrote matching tests against this that cover these cases.

Hopefully this is clear/straight forward and makes sense as a change. I'd be happy to improve based on feedback, there's almost always a more straight forward way of doing things lurking somewhere around the corner, and I'm certainly no Flask-Admin expert.

If you want this in another branch or anything let me know. Love the Flask-Admin framework, thanks so much for everything! :clap: