### PR TITLE
SQLA - fix hybrid property support after column object support changes

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -484,7 +484,10 @@ class ModelView(BaseModelView):
                                     "Failed on: {0}".format(c))
                 else:
                     # column is in same table, use only model attribute name
-                    column_name = column.key
+                    if getattr(column, 'key') is not None:
+                        column_name = column.key
+                    else:
+                        column_name = text_type(c)
 
                 # column_name must match column_name used in `get_list_columns`
                 result[column_name] = column
@@ -517,7 +520,10 @@ class ModelView(BaseModelView):
                     column_name = text_type(c)
                 else:
                     # column is in same table, use only model attribute name
-                    column_name = column.key
+                    if getattr(column, 'key') is not None:
+                        column_name = column.key
+                    else:
+                        column_name = text_type(c)
 
                 visible_name = self.get_column_name(column_name)
 


### PR DESCRIPTION
Fixes #1206

`column.key` is `None` for hybrid properties and the change in #1174 wasn't expecting that.

This pull request changes it to fail over to the column name in column_list (and column_sortable_list) if `column.key` is `None`.