### PR TITLE
add json support to SQLA backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - WTFORMS_VERSION=1
   - WTFORMS_VERSION=2
 
+addons:
+  postgresql: "9.4"
+
 services:
   - postgresql
   - mongodb

--- a/flask_admin/contrib/geoa/fields.py
+++ b/flask_admin/contrib/geoa/fields.py
@@ -1,46 +1,20 @@
-import json
 import warnings
 
 import geoalchemy2
 from flask import current_app
 from shapely.geometry import shape
 from sqlalchemy import func
-from wtforms.fields import TextAreaField
+
+from flask_admin.form import JSONField
 
 from .widgets import LeafletWidget
-
-
-class JSONField(TextAreaField):
-    def _value(self):
-        if self.raw_data:
-            return self.raw_data[0]
-        if self.data:
-            return self.data
-        return ""
-
-    def process_formdata(self, valuelist):
-        if valuelist:
-            value = valuelist[0]
-            if not value:
-                self.data = None
-                return
-            try:
-                self.data = self.from_json(value)
-            except ValueError:
-                self.data = None
-                raise ValueError(self.gettext('Invalid JSON'))
-
-    def to_json(self, obj):
-        return json.dumps(obj)
-
-    def from_json(self, data):
-        return json.loads(data)
 
 
 class GeoJSONField(JSONField):
     widget = LeafletWidget()
 
-    def __init__(self, label=None, validators=None, geometry_type="GEOMETRY", srid='-1', session=None, **kwargs):
+    def __init__(self, label=None, validators=None, geometry_type="GEOMETRY",
+                 srid='-1', session=None, **kwargs):
         super(GeoJSONField, self).__init__(label, validators, **kwargs)
         self.web_srid = 4326
         self.srid = srid

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -350,6 +350,10 @@ class AdminModelConverter(ModelConverterBase):
         inner_form = field_args.pop('form', HstoreForm)
         return InlineHstoreList(InlineFormField(inner_form), **field_args)
 
+    @converts('JSON')
+    def convert_JSON(self, field_args, **extra):
+        return form.JSONField(**field_args)
+
 
 def _resolve_prop(prop):
     """

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -1,3 +1,5 @@
+import json
+
 from jinja2 import Markup
 from flask_admin._compat import text_type
 try:
@@ -58,15 +60,28 @@ def enum_formatter(view, value):
     return value.name
 
 
+def dict_formatter(view, value):
+    """
+        Removes unicode entities when displaying dict as string. Also unescapes
+        non-ASCII characters stored in the JSON.
+
+        :param value:
+            Dict to convert to string
+    """
+    return json.dumps(value, ensure_ascii=False)
+
+
 BASE_FORMATTERS = {
     type(None): empty_formatter,
     bool: bool_formatter,
     list: list_formatter,
+    dict: dict_formatter,
 }
 
 EXPORT_FORMATTERS = {
     type(None): empty_formatter,
     list: list_formatter,
+    dict: dict_formatter,
 }
 
 if Enum is not None:


### PR DESCRIPTION
This pull request adds the ability to edit JSON columns to the SQLA backend.

It accomplishes this by moving the GeoAlchemy backend's JSONField into `flask_admin/form/fields.py` to be shared between the two backends. Also, some improvements were made to the JSONField's ability to handle non-ascii characters.

Editing:
![screenshot1](https://i.imgur.com/Icld6hD.png)

List View:
![screenshot2](https://i.imgur.com/zzzqK9n.png)

Invalid JSON:
![screenshot3](https://i.imgur.com/RhM8bYZ.png)