### PR TITLE
Using sorted list field not handled (and crash) in process_ajax_references

### DIFF
--- a/flask_admin/contrib/mongoengine/ajax.py
+++ b/flask_admin/contrib/mongoengine/ajax.py
@@ -76,7 +76,7 @@ def create_ajax_loader(model, name, field_name, opts):
 
     ftype = type(prop).__name__
 
-    if ftype == 'ListField':
+    if ftype == 'ListField' or ftype == 'SortedListField':
         prop = prop.field
         ftype = type(prop).__name__
 
@@ -97,7 +97,7 @@ def process_ajax_references(references, view):
     def handle_field(field, subdoc, base):
         ftype = type(field).__name__
 
-        if ftype == 'ListField':
+        if ftype == 'ListField' or ftype == 'SortedListField':
             child_doc = getattr(subdoc, '_form_subdocuments', {}).get(None)
 
             if child_doc:


### PR DESCRIPTION
Hi,

I encountered an issue when using SortedListField that I believe was just something overlooked when it's support was added in mongoengine.
I created 2 new test cases including one that was failing before and I provided a patch that fix the issue.

Have a nice day,

Seb