### PR TITLE
fix validation type matches.

### DIFF
--- a/flask_admin/contrib/mongoengine/helpers.py
+++ b/flask_admin/contrib/mongoengine/helpers.py
@@ -1,4 +1,5 @@
 from mongoengine import ValidationError
+from wtforms.validators import ValidationError as wtfValidationError
 from flask_admin._compat import itervalues, as_unicode
 
 
@@ -31,6 +32,9 @@ def make_thumb_args(value):
 
 def format_error(error):
     if isinstance(error, ValidationError):
+        return as_unicode(error)
+
+    if isinstance(error, wtfValidationError):
         return '. '.join(itervalues(error.to_dict()))
 
     return as_unicode(error)


### PR DESCRIPTION
I thought this was a fix for https://github.com/flask-admin/flask-admin/issues/725#issuecomment-213361694 but it seems that was fixed previously? Or, there is some confusion perhaps, but the other issue was closed, so I'm going to document this here too...


```
Traceback (most recent call last):
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask_admin/base.py", line 68, in inner
    return self._run_view(f, *args, **kwargs)
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask_admin/base.py", line 354, in _run_view
    return fn(self, *args, **kwargs)
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask_admin/model/base.py", line 1519, in edit_view
    if self.update_model(form, model):
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask_admin/contrib/mongoengine/view.py", line 564, in update_model
    error=format_error(ex)),
  File "/Users/tinix/.virtualenvs/7g/lib/python2.7/site-packages/flask_admin/contrib/mongoengine/helpers.py", line 34, in format_error
    return '. '.join(itervalues(error.to_dict()))
TypeError: sequence item 0: expected string, dict found

```

So, let's dig in... :)

In debug mode a ValidaitonError is thrown, ex: 

```
ValidationError: ValidationError (Client:551c938013d5342d2d00f751) (6.report_templates.Field is required and cannot be empty: ['inspection_types'])
```

However, the behavior changes when debug mode is off.

In mongoengine/view.py we have this:
```python
            if not self.handle_view_exception(ex):
                flash(gettext('Failed to create record. %(error)s',
                              error=format_error(ex)),
                      'error')
                log.exception('Failed to create record.')
```

From model/base.py:
```python
    # Exception handler
    def handle_view_exception(self, exc):
        if isinstance(exc, ValidationError):
            flash(as_unicode(exc))
            return True

        if self._debug:
            raise

        return False
```

The format_error method looks like this:
```python

def format_error(error):
    if isinstance(error, ValidationError):
        return '. '.join(itervalues(error.to_dict()))

    return as_unicode(error)
```

ValidationError is thrown, in debug mode. 

But when *not* in debug mode, handle_view_exception() must be returning false, because we're calling format_error() in a conditional that says ```if not self.handle_view_exception(ex)```. 

For handle_view_exception() to return false, this must be true: ```isinstance(exc, ValidationError)```. 

So, format_error() checks if the error is a ValidationError too, and if it's not, it should be passing it through as_unicode(), but it's not, it's passing it through ```join(itervalues(error.to_dict()))```.

Thus, the only possibility is that not all ValidationErrors are the same.

In models/base.py we have the following:

```python
from wtforms.validators import ValidationError, Required
```

but in mongoengine.helpers.py we have the following:

```python
from mongoengine import ValidationError
```
