### PR TITLE
SQLA - fix column names error for export and details view

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -494,43 +494,42 @@ class ModelView(BaseModelView):
 
             return result
 
-    def get_list_columns(self):
+    def get_column_names(self, only_columns, excluded_columns):
         """
             Returns a list of tuples with the model field name and formatted
-            field name. If `column_list` was set, returns it. Otherwise calls
-            `scaffold_list_columns` to generate the list from the model.
+            field name.
+
+            Overridden to handle special columns like InstrumentedAttribute.
+
+            :param only_columns:
+                List of columns to include in the results. If not set,
+                `scaffold_list_columns` will generate the list from the model.
+            :param excluded_columns:
+                List of columns to exclude from the results.
         """
-        if self.column_list is None:
-            columns = self.scaffold_list_columns()
+        if excluded_columns:
+            only_columns = [c for c in only_columns if c not in excluded_columns]
 
-            # Filter excluded columns
-            if self.column_exclude_list:
-                columns = [c for c in columns
-                           if c not in self.column_exclude_list]
+        formatted_columns = []
+        for c in only_columns:
+            column, path = tools.get_field_with_path(self.model, c)
 
-            return [(c, self.get_column_name(c)) for c in columns]
-        else:
-            columns = []
-
-            for c in self.column_list:
-                column, path = tools.get_field_with_path(self.model, c)
-
-                if path:
-                    # column is in another table, use full path
-                    column_name = text_type(c)
+            if path:
+                # column is a relation (InstrumentedAttribute), use full path
+                column_name = text_type(c)
+            else:
+                # column is in same table, use only model attribute name
+                if getattr(column, 'key', None) is not None:
+                    column_name = column.key
                 else:
-                    # column is in same table, use only model attribute name
-                    if getattr(column, 'key', None) is not None:
-                        column_name = column.key
-                    else:
-                        column_name = text_type(c)
+                    column_name = text_type(c)
 
-                visible_name = self.get_column_name(column_name)
+            visible_name = self.get_column_name(column_name)
 
-                # column_name must match column_name in `get_sortable_columns`
-                columns.append((column_name, visible_name))
+            # column_name must match column_name in `get_sortable_columns`
+            formatted_columns.append((column_name, visible_name))
 
-            return columns
+        return formatted_columns
 
     def init_search(self):
         """


### PR DESCRIPTION
The SQLA backend has some special logic for determining column names for relations. But, that logic wasn't getting applied to the list of columns in the export and details view. It's what's causing tests to fail on @xqliu in: https://github.com/flask-admin/flask-admin/issues/1263

This pull request fixes the issue, and I was also able to refactor duplicate code in `get_list_columns`, `get_details_columns`, and `get_export_columns` into the new `get_column_names`.

This changes some behavior in two edge cases:
* If `column_list`, `column_export_list`, or `column_details_list` evaluate to false (instead of just `None`), flask-admin will get columns from the model (scaffold_list_columns). I'm not sure why anyone would want to use an empty list for these.
* Columns in `column_exclude_list`, `column_details_exclude_list`, or `column_export_exclude_list` will never be shown on their respective views. Before, these were only excluded if `column_list`, `column_export_list`, or `column_details_list` were `None`. I'm not sure why anyone would have the same column in both the exclude_list and include list.