### PR TITLE
fix exception when using an unlimited page_size

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -3,6 +3,7 @@ import re
 import csv
 import mimetypes
 import time
+from math import ceil
 
 from werkzeug import secure_filename
 
@@ -1818,9 +1819,7 @@ class BaseModelView(BaseView, ActionsMixin):
 
         # Calculate number of pages
         if count is not None and self.page_size:
-            num_pages = count // self.page_size
-            if count % self.page_size != 0:
-                num_pages += 1
+            num_pages = int(ceil(count / float(self.page_size)))
         else:
             num_pages = None
 

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1817,7 +1817,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 list_forms[self.get_pk_value(row)] = self.list_form(obj=row)
 
         # Calculate number of pages
-        if count is not None:
+        if count is not None and self.page_size:
             num_pages = count // self.page_size
             if count % self.page_size != 0:
                 num_pages += 1

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1820,8 +1820,10 @@ class BaseModelView(BaseView, ActionsMixin):
         # Calculate number of pages
         if count is not None and self.page_size:
             num_pages = int(ceil(count / float(self.page_size)))
+        elif not self.page_size:
+            num_pages = 0  # hide pager for unlimited page_size
         else:
-            num_pages = None
+            num_pages = None  # use simple pager
 
         # Various URL generation helpers
         def pager_url(p):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -2027,6 +2027,28 @@ def test_simple_list_pager():
     assert_true(count is None)
 
 
+def test_unlimited_page_size():
+    app, db, admin = setup()
+    M1, _ = create_models(db)
+
+    db.session.add_all([M1('1'), M1('2'), M1('3'), M1('4'), M1('5'), M1('6'),
+                        M1('7'), M1('8'), M1('9'), M1('10'), M1('11'),
+                        M1('12'), M1('13'), M1('14'), M1('15'), M1('16'),
+                        M1('17'), M1('18'), M1('19'), M1('20'), M1('21')])
+
+    view = CustomModelView(M1, db.session)
+
+    # test 0 as page_size
+    _, data = view.get_list(0, None, None, None, None, execute=True,
+                            page_size=0)
+    eq_(len(data), 21)
+
+    # test False as page_size
+    _, data = view.get_list(0, None, None, None, None, execute=True,
+                            page_size=False)
+    eq_(len(data), 21)
+
+
 def test_advanced_joins():
     app, db, admin = setup()
 


### PR DESCRIPTION
If you use `0` or `False` as a page_size in a model view, it will throw `ZeroDivisionError: long division or modulo by zero`. This pull request fixes the issue by checking whether a `page_size` exists before trying to calculate the number of pages.