### PR TITLE
prevent NotImplementedError in get_details_columns

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -987,9 +987,12 @@ class BaseModelView(BaseView, ActionsMixin):
             Uses `get_column_names` to get a list of tuples with the model
             field name and formatted name for the columns in `column_details_list`
             and not in `column_details_exclude_list`. If `column_details_list`
-            is not set, the columns from `scaffold_list_columns` will be used.
+            is not set, it will attempt to use the columns from `column_list`
+            or finally the columns from `scaffold_list_columns` will be used.
         """
-        only_columns = self.column_details_list or self.scaffold_list_columns()
+        only_columns = (self.column_details_list or self.column_list or
+                        self.scaffold_list_columns())
+
         return self.get_column_names(
             only_columns=only_columns,
             excluded_columns=self.column_details_exclude_list,


### PR DESCRIPTION
Looks like there's one more error causing tests to fail for #1264

Pymongo doesn't implement `scaffold_list_columns`, but `get_details_columns` is trying to use it if `column_details_list` is not set.

This pull request changes it to use `column_list` (which should always be set in pymongo) before using `scaffold_list_columns`.