### PR TITLE
Filters: prevent override when same target model

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -648,7 +648,7 @@ class ModelView(BaseModelView):
             # must be named with relation name (to prevent following same
             # target column to replace previous)
             if joined_column_name:
-                key_name = "{}.{}".format(joined_column_name, column)
+                key_name = "{0}.{1}".format(joined_column_name, column)
                 for f in flt:
                     f.key_name = key_name
 

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -8,7 +8,7 @@ class BaseFilter(object):
     """
         Base filter class.
     """
-    def __init__(self, name, options=None, data_type=None):
+    def __init__(self, name, options=None, data_type=None, key_name=None):
         """
             Constructor.
 
@@ -18,10 +18,13 @@ class BaseFilter(object):
                 List of fixed options. If provided, will use drop down instead of textbox.
             :param data_type:
                 Client-side widget type to use.
+            :param key_name:
+                Optional name who represent this filter.
         """
         self.name = name
         self.options = options
         self.data_type = data_type
+        self.key_name = key_name
 
     def get_options(self, view):
         """

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -640,7 +640,7 @@ def test_column_filters():
     view = CustomModelView(Model2, db.session,
                            column_filters=['model1.bool_field'])
 
-    eq_([(f['index'], f['operation']) for f in view._filter_groups[u'Model1 / Bool Field']],
+    eq_([(f['index'], f['operation']) for f in view._filter_groups[u'model1 / Model1 / Bool Field']],
         [
             (0, 'equals'),
             (1, 'not equal'),


### PR DESCRIPTION
Directly related to #1250:

> This issue is related to #909. If my admin view set column filters, but them columns are relationship on same model, last column override previous.

Before PR:
![612ba38c-fa7a-11e5-9621-bb9a805f6228](https://cloud.githubusercontent.com/assets/1104637/15117554/6ffc94ee-1608-11e6-8ba8-4a2830b3e15e.png)

After:
![a6cc9756-fb0c-11e5-9e69-437e8391be5b](https://cloud.githubusercontent.com/assets/1104637/15117560/754e8d1c-1608-11e6-8d3e-4d2813b470ed.png)
