### PR TITLE
Support single table inheritance for inline models (sqla)

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -557,7 +557,8 @@ class InlineModelConverter(InlineModelConverterBase):
         info = self.get_info(inline_model)
 
         # Find property from target model to current model
-        target_mapper = info.model._sa_class_manager.mapper
+        # Use the base mapper to support inheritance
+        target_mapper = info.model._sa_class_manager.mapper.base_mapper
 
         reverse_prop = None
 


### PR DESCRIPTION
This enables the use of single table inheritance with inline models.

```python
class Server(db.Model):
    __tablename__ = 'servers'
    id = db.Column(db.Integer, primary_key=True)
    services = db.relationship('Service', backref='server',
                               cascade='all, delete, delete-orphan')

class Service(db.Model):
    __tablename__ = 'services'
    id = db.Column('id', db.Integer, primary_key=True)
    service_type = db.Column(db.Enum('console', 'firmware', 'power'))

    __mapper_args__ = {
        'polymorphic_on': service_type,
        'polymorphic_identity': 'service',
    }

class Console(Service):
    type = db.Column('console_type', db.String)
    port = db.Column('console_port', db.Integer)

    __mapper_args__ = {
        'polymorphic_identity': 'console',
    }

class ServerAdmin(sqla.ModelView):
    inline_models = (InlineFormAdmin(Console),)
```