### PR TITLE
Change `data-role` attribute for `Select2TagsWidget`.

### DIFF
--- a/flask_admin/form/widgets.py
+++ b/flask_admin/form/widgets.py
@@ -33,8 +33,7 @@ class Select2TagsWidget(widgets.TextInput):
     You must include select2.js, form-x.x.x.js and select2 stylesheet for it to work.
     """
     def __call__(self, field, **kwargs):
-        kwargs.setdefault('data-role', u'select2')
-        kwargs.setdefault('data-tags', u'1')
+        kwargs.setdefault('data-role', u'select2-tags')
         return super(Select2TagsWidget, self).__call__(field, **kwargs)
 
 


### PR DESCRIPTION
Values from `data-tags` are picked up only when `data-role` is set to
`select2-tags` (according to `form.js`).
