### PR TITLE
Allow exceptions to always be raised on view errors

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import cast
 from sqlalchemy import Unicode
 
-from flask import flash
+from flask import current_app, flash
 
 from flask_admin._compat import string_types, text_type
 from flask_admin.babel import gettext, ngettext, lazy_gettext
@@ -996,7 +996,10 @@ class ModelView(BaseModelView):
     # Error handler
     def handle_view_exception(self, exc):
         if isinstance(exc, IntegrityError):
-            flash(gettext('Integrity error. %(message)s', message=text_type(exc)), 'error')
+            if current_app.config.get('ADMIN_RAISE_ON_VIEW_EXCEPTION'):
+                raise
+            else:
+                flash(gettext('Integrity error. %(message)s', message=text_type(exc)), 'error')
             return True
 
         return super(ModelView, self).handle_view_exception(exc)

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -7,8 +7,8 @@ from math import ceil
 
 from werkzeug import secure_filename
 
-from flask import (request, redirect, flash, abort, json, Response,
-                   get_flashed_messages, stream_with_context)
+from flask import (current_app, request, redirect, flash, abort, json,
+                   Response, get_flashed_messages, stream_with_context)
 from jinja2 import contextfunction
 try:
     import tablib
@@ -1440,6 +1440,9 @@ class BaseModelView(BaseView, ActionsMixin):
         if isinstance(exc, ValidationError):
             flash(as_unicode(exc), 'error')
             return True
+
+        if current_app.config.get('ADMIN_RAISE_ON_VIEW_EXCEPTION'):
+            raise
 
         if self._debug:
             raise

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     test_suite='nose.collector'
 )


### PR DESCRIPTION
The current behavior to swallow exceptions makes it really hard to track down bugs in the system. Especially in a production environment.

I would recommend to make this the default, but I don’t want to impose so here’s a solution which requires the config option `ADMIN_RAISE_ON_VIEW_EXCEPTION` to be set.

Also added missing trove classifier for Python 3.5.