### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ To run the examples on your local environment, one at a time, do something like:
 
 Documentation
 -------------
-Flask-Admin is extensively documented, you can find all of the documentation at `http://flask-admin.readthedocs.org/en/latest/ <http://flask-admin.readthedocs.org/en/latest/>`_.
+Flask-Admin is extensively documented, you can find all of the documentation at `https://flask-admin.readthedocs.io/en/latest/ <https://flask-admin.readthedocs.io/en/latest/>`_.
 
 The docs are auto-generated from the *.rst* files in the */doc* folder. So if you come across any errors, or
 if you think of anything else that should be included, then please make the changes and submit them as a *pull-request*.
@@ -75,7 +75,7 @@ Or alternatively, you can download the repository and install manually by doing:
 
 Tests
 -----
-Test are run with *nose*. If you are not familiar with this package you can get some more info from `their website <http://nose.readthedocs.org/>`_.
+Test are run with *nose*. If you are not familiar with this package you can get some more info from `their website <https://nose.readthedocs.io/>`_.
 
 To run the tests, from the project directory, simply::
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -189,7 +189,7 @@ Managing Geographical Models
 
 If you want to store spatial information in a GIS database, Flask-Admin has
 you covered. The GeoAlchemy backend extends the SQLAlchemy backend (just as
-`GeoAlchemy <http://geoalchemy-2.readthedocs.org/>`_  extends SQLAlchemy) to give you a pretty and functional map-based
+`GeoAlchemy <https://geoalchemy-2.readthedocs.io/>`_  extends SQLAlchemy) to give you a pretty and functional map-based
 editor for your admin pages.
 
 Some notable features include:
@@ -200,7 +200,7 @@ Some notable features include:
    interactively using `Leaflet.Draw <https://github.com/Leaflet/Leaflet.draw>`_.
  - Graceful fallback: `GeoJSON <http://geojson.org/>`_ data can be edited in a ``<textarea>``, if the
    user has turned off Javascript.
- - Works with a `Geometry <http://geoalchemy-2.readthedocs.org/en/latest/types.html#geoalchemy2.types.Geometry>`_ SQL field that is integrated with `Shapely <http://toblerity.org/shapely/>`_ objects.
+ - Works with a `Geometry <https://geoalchemy-2.readthedocs.io/en/latest/types.html#geoalchemy2.types.Geometry>`_ SQL field that is integrated with `Shapely <http://toblerity.org/shapely/>`_ objects.
 
 To get started, define some fields on your model using GeoAlchemy's *Geometry*
 field. Next, add model views to your interface using the ModelView class
@@ -387,7 +387,7 @@ Features:
  - GridFS support for file and image uploads
 
 In order to use MongoEngine integration, install the
-`Flask-MongoEngine <https://flask-mongoengine.readthedocs.org>`_ package.
+`Flask-MongoEngine <https://flask-mongoengine.readthedocs.io>`_ package.
 Flask-Admin uses form scaffolding from it.
 
 Known issues:
@@ -407,7 +407,7 @@ Features:
  - Inline editing of related models;
 
 In order to use peewee integration, you need to install two additional Python
-packages: `peewee <https://peewee.readthedocs.org/>`_ and `wtf-peewee <https://github.com/coleifer/wtf-peewee/>`_.
+packages: `peewee <http://docs.peewee-orm.com/>`_ and `wtf-peewee <https://github.com/coleifer/wtf-peewee/>`_.
 
 Known issues:
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -85,7 +85,7 @@ with your database models, and it doesn't require you to write any new view logi
 template code. So it's great for when you're deploying something that's still
 under development, before you want the whole world to see it.
 
-Have a look at `Flask-BasicAuth <http://flask-basicauth.readthedocs.org/>`_ to see just how
+Have a look at `Flask-BasicAuth <https://flask-basicauth.readthedocs.io/>`_ to see just how
 easy it is to put your whole application behind HTTP Basic Auth.
 
 Unfortunately, there is no easy way of applying HTTP Basic Auth just to your admin
@@ -96,7 +96,7 @@ Rolling Your Own
 For a more flexible solution, Flask-Admin lets you define access control rules
 on each of your admin view classes by simply overriding the `is_accessible` method.
 How you implement the logic is up to you, but if you were to use a low-level library like
-`Flask-Login <https://flask-login.readthedocs.org/>`_, then restricting access
+`Flask-Login <https://flask-login.readthedocs.io/>`_, then restricting access
 could be as simple as::
 
     class MicroBlogModelView(sqla.ModelView):

--- a/examples/wysiwyg/app.py
+++ b/examples/wysiwyg/app.py
@@ -21,7 +21,7 @@ db = SQLAlchemy(app)
 ''' Define a wtforms widget and field.
 
     WTForms documentation on custom widgets:
-    http://wtforms.readthedocs.org/en/latest/widgets.html#custom-widgets
+    https://wtforms.readthedocs.io/en/latest/widgets.html#custom-widgets
 '''
 class CKTextAreaWidget(widgets.TextArea):
     def __call__(self, field, **kwargs):


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.