### PR TITLE
Fix url generation with localized named filters.

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1117,7 +1117,15 @@ class BaseModelView(BaseView, ActionsMixin):
                 Filter instance
         """
         if self.named_filter_urls:
-            name = ('%s %s' % (flt.name, as_unicode(flt.operation()))).lower()
+            operation = flt.operation()
+
+            try:
+                # get lazy string original value
+                operation = operation._args[0]
+            except AttributeError:
+                pass
+
+            name = ('%s %s' % (flt.name, as_unicode(operation))).lower()
             name = filter_char_re.sub('', name)
             name = filter_compact_re.sub('_', name)
             return name

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1834,6 +1834,28 @@ def test_modelview_localization():
     for locale in locales:
         test_locale(locale)
 
+
+def test_modelview_named_filter_localization():
+    app, db, admin = setup()
+
+    app.config['BABEL_DEFAULT_LOCALE'] = 'de'
+    Babel(app)
+
+    Model1, _ = create_models(db)
+
+    view = CustomModelView(
+        Model1, db.session,
+        named_filter_urls=True,
+        column_filters=['test1'],
+    )
+
+    filters = view.get_filters()
+    flt = filters[2]
+    with app.test_request_context():
+        flt_name = view.get_filter_arg(2, flt)
+    eq_('test1_equals', flt_name)
+
+
 def test_custom_form_base():
     app, db, admin = setup()
 


### PR DESCRIPTION
Avoid named filters localization.

This l10n generates broken urls with named filters.

Fix #1319.