### PR TITLE
Added support for remote hybrid properties filters

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -190,7 +190,12 @@ def get_hybrid_properties(model):
 
 
 def is_hybrid_property(model, attr_name):
-    return attr_name in get_hybrid_properties(model)
+    names = attr_name.split('.')
+    last_model = model
+    for i in range(len(names)-1):
+        last_model = getattr(last_model, names[i]).property.argument
+    last_name = names[-1]
+    return last_name in get_hybrid_properties(last_model)
 
 
 def is_relationship(attr):
@@ -199,9 +204,3 @@ def is_relationship(attr):
 
 def is_association_proxy(attr):
     return hasattr(attr, 'extension_type') and attr.extension_type == ASSOCIATION_PROXY
-
-
-def get_association_proxy_column_name(attr):
-    # TODO find a better way to get the name
-    name, = [key for key, value in inspect(attr.owning_class).all_orm_descriptors.items() if value is attr]
-    return name

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -638,14 +638,14 @@ class ModelView(BaseModelView):
                 if not isinstance(name, string_types):
                     visible_name = self.get_column_name(name.property.key)
                 else:
-                    names = [self.get_column_name(name_item) for name_item in name.split('.')]
+                    column_name = self.get_column_name(name)
 
-                    def concat_func():
-                        return ' / '.join([str(names_item) for names_item in names])
-                    if any(map(is_lazy_string, names)):
-                        visible_name = make_lazy_string(concat_func)
+                    def prettify():
+                        return column_name.replace('.', ' / ')
+                    if is_lazy_string(column_name):
+                        visible_name = make_lazy_string(prettify)
                     else:
-                        visible_name = concat_func()
+                        visible_name = prettify()
 
             type_name = type(column.type).__name__
 

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 import inspect
 
+from speaklater import is_lazy_string, make_lazy_string
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm import joinedload, aliased
 from sqlalchemy.sql.expression import desc
@@ -637,8 +638,14 @@ class ModelView(BaseModelView):
                 if not isinstance(name, string_types):
                     visible_name = self.get_column_name(name.property.key)
                 else:
-                    names = name.split('.')
-                    visible_name = ' / '.join([self.get_column_name(names_item) for names_item in names])
+                    names = [self.get_column_name(name_item) for name_item in name.split('.')]
+
+                    def concat_func():
+                        return ' / '.join([str(names_item) for names_item in names])
+                    if any(map(is_lazy_string, names)):
+                        visible_name = make_lazy_string(concat_func)
+                    else:
+                        visible_name = concat_func()
 
             type_name = type(column.type).__name__
 

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -617,6 +617,7 @@ class ModelView(BaseModelView):
             is_hybrid_property = tools.is_hybrid_property(self.model, name)
             if is_hybrid_property:
                 column = attr
+                column.key = name.split('.')[-1]
             else:
                 columns = tools.get_columns_for_field(attr)
 
@@ -636,7 +637,8 @@ class ModelView(BaseModelView):
                 if not isinstance(name, string_types):
                     visible_name = self.get_column_name(name.property.key)
                 else:
-                    visible_name = self.get_column_name(name)
+                    names = name.split('.')
+                    visible_name = ' / '.join([self.get_column_name(names_item) for names_item in names])
 
             type_name = type(column.type).__name__
 


### PR DESCRIPTION
Fixes #1345 

Changes:
1) Updated hybrid property detection: added support for period-delimited column name - what it does is figure out if the last attribute on the last model is a hybrid property.
2) Added the `key` attribute to hybrid properties (this field is not automatically populated by sqlalchemy for hybrid properties, for some reason), which is used by flask-admin to determine the column name.
3) Prettifying the filter name for nested properties.
4) Removed unused method `get_association_proxy_column_name` I added in a previous PR (sorry!)