### PR TITLE
Support association proxies in path when determining hybrid property

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -618,7 +618,8 @@ class ModelView(BaseModelView):
             is_hybrid_property = tools.is_hybrid_property(self.model, name)
             if is_hybrid_property:
                 column = attr
-                column.key = name.split('.')[-1]
+                if isinstance(name, string_types):
+                    column.key = name.split('.')[-1]
             else:
                 columns = tools.get_columns_for_field(attr)
 


### PR DESCRIPTION
1) Added support for dealing with association proxies when determining if field path is a hybrid property.
2) Restored support for filters using column values (not just their names).