### PR TITLE
Fix regression with late-evaluation relationships no longer working with filters

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -1,3 +1,5 @@
+import types
+
 from sqlalchemy import tuple_, or_, and_, inspect
 from sqlalchemy.ext.declarative.clsregistry import _class_resolver
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -201,6 +203,8 @@ def is_hybrid_property(model, attr_name):
             last_model = attr.property.argument
             if isinstance(last_model, _class_resolver):
                 last_model = model._decl_class_registry[last_model.arg]
+            elif isinstance(last_model, types.FunctionType):
+                last_model = last_model()
         last_name = names[-1]
         return last_name in get_hybrid_properties(last_model)
     else:

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -84,7 +84,7 @@ def create_models(db):
 
         # Relation
         model1_id = db.Column(db.Integer, db.ForeignKey(Model1.id))
-        model1 = db.relationship(Model1, backref='model2')
+        model1 = db.relationship(lambda: Model1, backref='model2')
 
     db.create_all()
 


### PR DESCRIPTION
Regression was introduced in 47080ae (PR #1348) where `is_hybrid_property` was changed to support remote hybrid properties. When lambdas were encountered in the iteration they were passed as-is to the function `get_hybrid_properties`, which in turn threw the exception `sqlalchemy.exc.NoInspectionAvailable: No inspection system is available for object of type <class 'function'>`.

Test has been updated to ensure that flask-admin will continue to support lambdas as a relationship’s first argument.