### PR TITLE
New ARRAY type for sqlalchemy

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -343,7 +343,8 @@ class AdminModelConverter(ModelConverterBase):
         field_args['validators'].append(validators.UUID())
         return fields.StringField(**field_args)
 
-    @converts('sqlalchemy.dialects.postgresql.base.ARRAY')
+    @converts('sqlalchemy.dialects.postgresql.base.ARRAY',
+              'sqlalchemy.sql.sqltypes.ARRAY')
     def conv_ARRAY(self, field_args, **extra):
         return form.Select2TagsField(save_as_list=True, **field_args)
 


### PR DESCRIPTION
In 1.1.0 [1] SqlAlchemy changed base type for ARRAY type.
This is causing flask-admin to skip ARRAY fields due to unknown type.
Now, the base type for ARRAY type is sqlalchemy.sql.sqltypes.ARRAY

See: http://docs.sqlalchemy.org/en/latest/changelog/changelog_11.html#change-1.1.0b1-sql