### PR TITLE
fix python3 compatibility in sqla examples without future

### DIFF
--- a/examples/sqla/app.py
+++ b/examples/sqla/app.py
@@ -2,7 +2,6 @@ import os
 import os.path as op
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from future.utils import python_2_unicode_compatible
 
 from wtforms import validators
 
@@ -26,7 +25,6 @@ db = SQLAlchemy(app, session_options=session_options)
 
 
 # Create models
-@python_2_unicode_compatible
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     first_name = db.Column(db.String(100))
@@ -45,7 +43,6 @@ post_tags_table = db.Table('post_tags', db.Model.metadata,
                            )
 
 
-@python_2_unicode_compatible
 class Post(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(120))
@@ -61,7 +58,6 @@ class Post(db.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class Tag(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Unicode(64))
@@ -70,7 +66,6 @@ class Tag(db.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class UserInfo(db.Model):
     id = db.Column(db.Integer, primary_key=True)
 
@@ -84,7 +79,6 @@ class UserInfo(db.Model):
         return '%s - %s' % (self.key, self.value)
 
 
-@python_2_unicode_compatible
 class Tree(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(64))

--- a/examples/sqla/app2.py
+++ b/examples/sqla/app2.py
@@ -28,7 +28,7 @@ class Car(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     desc = db.Column(db.String(50))
 
-    def __unicode__(self):
+    def __str__(self):
         return self.desc
 
 


### PR DESCRIPTION
Fixes #1364

I tried running the examples for the first time in a while and got `ImportError: No module named 'future'`. After messing with it, I don't think this module is necessary to run the examples.

It's better to just use `__str__` in the models to be compatible with both python 2 and 3. I thought maybe `python_2_unicode_compatible` was being used to make `__unicode__` work in python 3, but it doesn't.

