### PR TITLE
use admin url instead of # for brand link

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/base.html
+++ b/flask_admin/templates/bootstrap2/admin/base.html
@@ -32,7 +32,7 @@
       <div class="navbar">
         <div class="navbar-inner">
           {% block brand %}
-          <span class="brand">{{ admin_view.admin.name }}</span>
+          <a class="brand" href="{{ admin_view.admin.url }}">{{ admin_view.admin.name }}</a>
           {% endblock %}
           {% block main_menu %}
           <ul class="nav">

--- a/flask_admin/templates/bootstrap3/admin/base.html
+++ b/flask_admin/templates/bootstrap3/admin/base.html
@@ -39,7 +39,7 @@
             <span class="icon-bar"></span>
           </button>
           {% block brand %}
-          <a class="navbar-brand" href="#">{{ admin_view.admin.name }}</a>
+          <a class="navbar-brand" href="{{ admin_view.admin.url }}">{{ admin_view.admin.name }}</a>
           {% endblock %}
         </div>
         <!-- navbar content -->


### PR DESCRIPTION
Fixes #1317 

A lot of the time I'll do ` Admin(app, index_view=HomeView(name="Home", url='/'))` to make the index_view the root of my site. In this case, the url for the "brand" (as bootstrap calls it) would link to `/`.

I think this is a better default than `#`.