### PR TITLE
prevent AjaxSelectField autoflush while populating model

### DIFF
--- a/examples/sqla/app.py
+++ b/examples/sqla/app.py
@@ -20,8 +20,7 @@ app.config['SECRET_KEY'] = '123456790'
 app.config['DATABASE_FILE'] = 'sample_db.sqlite'
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + app.config['DATABASE_FILE']
 app.config['SQLALCHEMY_ECHO'] = True
-session_options = dict(autoflush=False)
-db = SQLAlchemy(app, session_options=session_options)
+db = SQLAlchemy(app)
 
 
 # Create models

--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -55,7 +55,9 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         return (getattr(model, self.pk), as_unicode(model))
 
     def get_one(self, pk):
-        return self.session.query(self.model).get(pk)
+        # prevent autoflush from occuring during populate_obj
+        with self.session.no_autoflush:
+            return self.session.query(self.model).get(pk)
 
     def get_list(self, term, offset=0, limit=DEFAULT_PAGE_SIZE):
         query = self.session.query(self.model)


### PR DESCRIPTION
Autoflush=False was added to the SQLA app.py example to fix this issue: https://github.com/flask-admin/flask-admin/issues/1339

But, that doesn't fix the issue for people who want to have autoflush turned on.

The problem is that the AjaxSelectField runs queries during `form.populate_obj(model)` and if you have autoflush turned on, it will autoflush changes to your model before it's completely populated. This PR adds `with self.session.no_autoflush:` to the AjaxSelectField's query to fix the problem.
