### PR TITLE
Replace list_columns with columns_list in examples/sqla-hybrid_property

### DIFF
--- a/examples/sqla-hybrid_property/app.py
+++ b/examples/sqla-hybrid_property/app.py
@@ -37,7 +37,7 @@ class Screen(db.Model):
 class ScreenAdmin(sqla.ModelView):
     """ Flask-admin can not automatically find a hybrid_property yet. You will
         need to manually define the column in list_view/filters/sorting/etc."""
-    list_columns = ['id', 'width', 'height', 'number_of_pixels']
+    column_list = ['id', 'width', 'height', 'number_of_pixels']
     column_sortable_list = ['id', 'width', 'height', 'number_of_pixels']
 
     # Flask-admin can automatically detect the relevant filters for hybrid properties.


### PR DESCRIPTION
This pull request removes the deprecated `list_columns` attribute for `ModelViews` in the `sqla-hybrid_property` example  and replaces it with `column_list`