### PR TITLE
Added possibility to extend css/js assets from admin view

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -148,22 +148,11 @@ classes as follows::
         widget = CKTextAreaWidget()
 
     class MessageAdmin(ModelView):
+        extra_js = ['//cdn.ckeditor.com/4.6.0/standard/ckeditor.js']
+
         form_overrides = {
             'body': CKTextAreaField
         }
-        create_template = 'ckeditor.html'
-        edit_template = 'ckeditor.html'
-
-For this to work, you would also need to create a template that extends the default
-functionality by including the necessary CKEditor javascript on the `create` and
-`edit` pages. Save this in `templates/ckeditor.html`::
-
-    {% extends 'admin/model/edit.html' %}
-
-    {% block tail %}
-      {{ super() }}
-      <script src="//cdn.ckeditor.com/4.5.1/standard/ckeditor.js"></script>
-    {% endblock %}
 
 File & Image Fields
 *******************

--- a/flask_admin/templates/bootstrap2/admin/base.html
+++ b/flask_admin/templates/bootstrap2/admin/base.html
@@ -15,6 +15,11 @@
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap2/css/bootstrap.css', v='2.3.2') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap2/css/bootstrap-responsive.css', v='2.3.2') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='admin/css/bootstrap2/admin.css', v='1.1.1') }}" rel="stylesheet">
+        {% if admin_view.extra_css %}
+          {% for css_url in admin_view.extra_css %}
+            <link href="{{ css_url }}" rel="stylesheet">
+          {% endfor %}
+        {% endif %}
         <style>
         body {
             padding-top: 4px;
@@ -65,6 +70,11 @@
     <script src="{{ admin_static.url(filename='bootstrap/bootstrap2/js/bootstrap.min.js', v='2.3.2') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='vendor/moment.min.js', v='2.9.0') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='vendor/select2/select2.min.js', v='3.5.2') }}" type="text/javascript"></script>
+    {% if admin_view.extra_js %}
+      {% for js_url in admin_view.extra_js %}
+        <script src="{{ js_url }}" type="text/javascript"></script>
+      {% endfor %}
+    {% endif %}
     {% endblock %}
 
     {% block tail %}

--- a/flask_admin/templates/bootstrap3/admin/base.html
+++ b/flask_admin/templates/bootstrap3/admin/base.html
@@ -15,6 +15,11 @@
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap3/css/bootstrap.min.css', v='3.3.5') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='bootstrap/bootstrap3/css/bootstrap-theme.min.css', v='3.3.5') }}" rel="stylesheet">
         <link href="{{ admin_static.url(filename='admin/css/bootstrap3/admin.css', v='1.1.1') }}" rel="stylesheet">
+        {% if admin_view.extra_css %}
+          {% for css_url in admin_view.extra_css %}
+            <link href="{{ css_url }}" rel="stylesheet">
+          {% endfor %}
+        {% endif %}
         <style>
         body {
             padding-top: 4px;
@@ -76,6 +81,11 @@
     <script src="{{ admin_static.url(filename='bootstrap/bootstrap3/js/bootstrap.min.js', v='3.3.5') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='vendor/moment.min.js', v='2.9.0') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='vendor/select2/select2.min.js', v='3.5.2') }}" type="text/javascript"></script>
+    {% if admin_view.extra_js %}
+      {% for js_url in admin_view.extra_js %}
+        <script src="{{ js_url }}" type="text/javascript"></script>
+      {% endfor %}
+    {% endif %}
     {% endblock %}
 
     {% block tail %}


### PR DESCRIPTION
It's easy to extend extra js and css anyway, but I'm sure creating custom fields that required extra css/js is pretty common procedure, so it would be better to have it in flask-admin already.
Related to https://github.com/flask-admin/flask-admin/issues/1328