### PR TITLE
image upload field: fixed for change form if file was already uploaded

### DIFF
--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -83,6 +83,7 @@ class ImageUploadInput(object):
     data_template = ('<div class="image-thumbnail">'
                      ' <img %(image)s>'
                      ' <input type="checkbox" name="%(marker)s">Delete</input>'
+                     ' <input %(text)s>'
                      '</div>'
                      '<input %(file)s>')
 
@@ -91,6 +92,9 @@ class ImageUploadInput(object):
         kwargs.setdefault('name', field.name)
 
         args = {
+            'text': html_params(type='hidden',
+                                value=field.data,
+                                name=field.name),
             'file': html_params(type='file',
                                 **kwargs),
             'marker': '_%s-delete' % field.name


### PR DESCRIPTION
In change form, If file was already uploaded we didn't have filename with ImageUploadField, because it wasn't rendered in ImageUploadInput, so change form validation required error occured.
Fixed to render hidden filename.