### PR TITLE
FIX: don't pre-populate forms for one-to-one that are not required in SQLA.

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -111,9 +111,8 @@ class AdminModelConverter(ModelConverterBase):
             else:
                 kwargs['validators'].append(validators.InputRequired())
 
-        # Contribute model-related parameters
-        if 'allow_blank' not in kwargs:
-            kwargs['allow_blank'] = column.nullable
+        # Never prepopulate relation widgets:
+        kwargs['allow_blank'] = True
 
         # Override field type if necessary
         override = self._get_field_override(prop.key)

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -105,14 +105,15 @@ class AdminModelConverter(ModelConverterBase):
 
         # determine optional/required, or respect existing
         requirement_options = (validators.Optional, validators.InputRequired)
-        if not any(isinstance(v, requirement_options) for v in kwargs['validators']):
-            if property_is_association_proxy or column.nullable or prop.direction.name != 'MANYTOONE':
+        requirement_validator_specified = any(isinstance(v, requirement_options) for v in kwargs['validators'])
+        if property_is_association_proxy or column.nullable or prop.direction.name != 'MANYTOONE':
+            kwargs['allow_blank'] = True
+            if not requirement_validator_specified:
                 kwargs['validators'].append(validators.Optional())
-            else:
+        else:
+            kwargs['allow_blank'] = False
+            if not requirement_validator_specified:
                 kwargs['validators'].append(validators.InputRequired())
-
-        # Never prepopulate relation widgets:
-        kwargs['allow_blank'] = True
 
         # Override field type if necessary
         override = self._get_field_override(prop.key)

--- a/flask_admin/tests/mongoengine/__init__.py
+++ b/flask_admin/tests/mongoengine/__init__.py
@@ -1,5 +1,19 @@
+import sys
+
 from flask import Flask
+from nose.plugins.skip import SkipTest
+
 from flask_admin import Admin
+from flask_admin._compat import PY2
+
+# Skip test on PY3
+if not PY2:
+    raise SkipTest('The MongoEngine integration is not Python 3 compatible')
+
+# Skip test on Python 2.6 since it is still supported by flask-admin:
+if sys.version_info[0] == 2 and sys.version_info[1] == 6:
+    raise SkipTest('MongoEngine is not Python 2.6 compatible as of its 0.11 version.')
+
 from flask_mongoengine import MongoEngine
 
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -5,6 +5,10 @@ from nose.plugins.skip import SkipTest
 from flask_admin._compat import PY2, as_unicode
 if not PY2:
     raise SkipTest('MongoEngine is not Python 3 compatible')
+# Skip test on Python 2.6 since it is still supported by flask-admin:
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] == 6:
+    raise SkipTest('MongoEngine is not Python 2.6 compatible as of its 0.11 version.')
 
 from wtforms import fields, validators
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -1,23 +1,12 @@
+from datetime import datetime
+
 from nose.tools import eq_, ok_
-from nose.plugins.skip import SkipTest
-
-# Skip test on PY3
-from flask_admin._compat import PY2, as_unicode
-if not PY2:
-    raise SkipTest('MongoEngine is not Python 3 compatible')
-# Skip test on Python 2.6 since it is still supported by flask-admin:
-import sys
-if sys.version_info[0] == 2 and sys.version_info[1] == 6:
-    raise SkipTest('MongoEngine is not Python 2.6 compatible as of its 0.11 version.')
-
 from wtforms import fields, validators
 
 from flask_admin import form
+from flask_admin._compat import as_unicode
 from flask_admin.contrib.mongoengine import ModelView
-
 from . import setup
-
-from datetime import datetime
 
 class CustomModelView(ModelView):
     def __init__(self, model,


### PR DESCRIPTION
There is a bug in the SQLA form rendering for relations. If the *remote* model of a one-to-many or one-to-one relation has the corresponding ForeignKey to `nullable=False`, the corresponding widget gets erroneously rendered with `allow_blank=True`. This happens because of https://github.com/flask-admin/flask-admin/blob/master/flask_admin/contrib/sqla/form.py#L115 happening after https://github.com/flask-admin/flask-admin/blob/master/flask_admin/contrib/sqla/form.py#L110. The property itself is not required, rather the foreign key of the related object is. 

This is a problem mainly for one-to-one relations because it *pre-populates* the corresponding field with an existing object that is not required - while it still doesn't pre-populate for one-to-many, it just doesn't propose you a blank choice.

I just used the existing logic from the validator to determine the allow_blank. In particular, any non-MANYTOONE relation will be allowed to have blank fields, which only make sense :-).