### PR TITLE
Page size changeable by user

### DIFF
--- a/doc/api/mod_model.rst
+++ b/doc/api/mod_model.rst
@@ -17,7 +17,7 @@
                           form_widget_args, form_extra_fields,
                           form_ajax_refs, form_create_rules,
                           form_edit_rules,
-                          page_size
+                          page_size, can_set_page_size
 
         .. autoattribute:: can_create
         .. autoattribute:: can_edit
@@ -58,3 +58,4 @@
         .. autoattribute:: action_disallowed_list
 
         .. autoattribute:: page_size
+        .. autoattribute:: can_set_page_size

--- a/flask_admin/templates/bootstrap2/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap2/admin/model/layout.html
@@ -68,3 +68,14 @@
     {% endif %}
 </form>
 {% endmacro %}
+
+{% macro page_size_form(generator, btn_class='dropdown-toggle') %}
+    <a class="{{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">
+        {{ page_size }} {{ _gettext('items') }}<b class="caret"></b>
+    </a>
+    <ul class="dropdown-menu">
+        <li><a href="{{ generator(20) }}">20 {{ _gettext('items') }}</a></li>
+        <li><a href="{{ generator(50) }}">50 {{ _gettext('items') }}</a></li>
+        <li><a href="{{ generator(100) }}">100 {{ _gettext('items') }}</a></li>
+    </ul>
+{% endmacro %}

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -39,6 +39,12 @@
         </li>
         {% endif %}
 
+        {% if can_set_page_size %}
+        <li class="dropdown">
+            {{ model_layout.page_size_form(page_size_url) }}
+        </li>
+        {% endif %}
+
         {% if actions %}
         <li class="dropdown">
             {{ actionlib.dropdown(actions) }}

--- a/flask_admin/templates/bootstrap3/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap3/admin/model/layout.html
@@ -66,3 +66,14 @@
     {% endif %}
 </form>
 {% endmacro %}
+
+{% macro page_size_form(generator, btn_class='dropdown-toggle') %}
+    <a class="{{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">
+        {{ page_size }} {{ _gettext('items') }}<b class="caret"></b>
+    </a>
+    <ul class="dropdown-menu">
+        <li><a href="{{ generator(20) }}">20 {{ _gettext('items') }}</a></li>
+        <li><a href="{{ generator(50) }}">50 {{ _gettext('items') }}</a></li>
+        <li><a href="{{ generator(100) }}">100 {{ _gettext('items') }}</a></li>
+    </ul>
+{% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -39,6 +39,12 @@
         </li>
         {% endif %}
 
+        {% if can_set_page_size %}
+        <li class="dropdown">
+            {{ model_layout.page_size_form(page_size_url) }}
+        </li>
+        {% endif %}
+
         {% if actions %}
         <li class="dropdown">
             {{ actionlib.dropdown(actions) }}


### PR DESCRIPTION
I have found that `page_size` attribute cannot be changed by user at the moment. Some developers mentioned in the issues that they implemented this feature in their projects. I thought it may be more logical to implement it on library level. Have someone already made this feature? Could it be merged if it passes all tests?

Another question: I would like to continue this work and implement customizable column sets (in a dropdown list with checkboxes). Will it be useful to code it on library level too?

Many thanks!