### PR TITLE
Prevent <escape> key from confirming deletions

### DIFF
--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -202,5 +202,22 @@
                 );
             {% endif %}
         })(jQuery);
+
+        // Catch exception when closing dialog with <esc> key
+        // and prevent accidental deletions.
+        function safeConfirm(msg) {
+          try {
+            var isconfirmed = confirm(msg);
+            if (isconfirmed == true) {
+              return true;
+            }
+            else {
+              return false;
+            }
+          }
+          catch(err) {
+            return false;
+          }
+        }
     </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/row_actions.html
+++ b/flask_admin/templates/bootstrap3/admin/model/row_actions.html
@@ -31,7 +31,7 @@
   {% elif csrf_token %}
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   {% endif %}
-  <button onclick="return confirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
+  <button onclick="return safeConfirm('{{ _gettext('Are you sure you want to delete this record?') }}');" title="Delete record">
     <span class="fa fa-trash glyphicon glyphicon-trash"></span>
   </button>
 </form>


### PR DESCRIPTION
The `Delete record` button in the `delete_row` macro calls the [`window.confirm()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) function, which fires up a dialogue box with `Ok` and `Cancel` as options.
When dismissing this modal with <kbd>Escape</kbd>, an error is thrown:

    uncaught exception: unknown (can't convert to string)

This somehow causes the `delete_row` form to be submitted, deleting the record. I expect <kbd>Escape</kbd> to cancel an action, not confirm it.

I've had this happen to me one too many times; this patch fixes that behaviour by catching the exception and returning `false` instead,

(*Not sure why the build is broken, I only changed pure HTML & CSS*)