### PR TITLE
fixed loop counter

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -82,8 +82,8 @@
                         <th class="span1">&nbsp;</th>
                         {% endif %}
                     {% endblock %}
-                    {% set column = 0 %}
                     {% for c, name in list_columns %}
+                    {% set column = loop.index0 %}
                     <th class="column-header col-{{c}}">
                         {% if admin_view.is_sortable(c) %}
                             {% if sort_column == column %}
@@ -108,7 +108,6 @@
                             ></a>
                         {% endif %}
                     </th>
-                    {% set column = column + 1 %}
                     {% endfor %}
                 {% endblock %}
             </tr>

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -81,8 +81,8 @@
                         <th class="col-md-1">&nbsp;</th>
                         {% endif %}
                     {% endblock %}
-                    {% set column = 0 %}
                     {% for c, name in list_columns %}
+                    {% set column = loop.index0 %}
                     <th class="column-header col-{{c}}">
                         {% if admin_view.is_sortable(c) %}
                             {% if sort_column == column %}
@@ -107,7 +107,6 @@
                             ></a>
                         {% endif %}
                     </th>
-                    {% set column = column + 1 %}
                     {% endfor %}
                 {% endblock %}
             </tr>


### PR DESCRIPTION
I found sort function does not work correctly in the latest setup. (python3.6, flask 0.12, jinja2 2.9.4)
According to [this article](http://stackoverflow.com/questions/7537439/how-to-increment-a-variable-on-a-for-loop-in-jinja-template#comment16308022_7537466), I fixed this problem by using loop index instead of explicit increment of column

