### PR TITLE
remove speaklater dependency

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 import inspect
 
-from speaklater import is_lazy_string, make_lazy_string
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm import joinedload, aliased
 from sqlalchemy.sql.expression import desc
@@ -652,14 +651,11 @@ class ModelView(BaseModelView):
                 if not isinstance(name, string_types):
                     visible_name = self.get_column_name(name.property.key)
                 else:
-                    column_name = self.get_column_name(name)
-
-                    def prettify():
-                        return column_name.replace('.', ' / ')
-                    if is_lazy_string(column_name):
-                        visible_name = make_lazy_string(prettify)
+                    if self.column_labels and name in self.column_labels:
+                        visible_name = self.column_labels[name]
                     else:
-                        visible_name = prettify()
+                        visible_name = self.get_column_name(name)
+                        visible_name = visible_name.replace('.', ' / ')
 
             type_name = type(column.type).__name__
 


### PR DESCRIPTION
This PR added speaklater as a dependency: https://github.com/flask-admin/flask-admin/pull/1348

The current logic:
1. Take the replacement column label from column_labels
1. Replace any `.` in the column label with ` / `
1. Turn the replacement column label back into a lazy string (using speaklater)

This PR removes speaklater as a dependency by changing the logic to just use the lazy_gettext object from `column_labels` if it's available (and not replacing `.` with ` / `). If the user manually specified a column label, they probably don't want the `.`'s in whatever they wrote replaced with ` / ` anyway.
