### PR TITLE
add csrf token validation to actions

### DIFF
--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -413,6 +413,19 @@ class BaseFileAdmin(BaseView, ActionsMixin):
 
         return DeleteForm
 
+    def get_action_form(self):
+        """
+            Create form class for model action.
+
+            Override to implement customized behavior.
+        """
+        class ActionForm(self.form_base_class):
+            action = fields.HiddenField()
+            url = fields.HiddenField()
+            # rowid is retrieved using getlist, for backward compatibility
+
+        return ActionForm
+
     def upload_form(self):
         """
             Instantiate file upload form and return it.
@@ -470,6 +483,18 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             return delete_form_class(request.form)
         else:
             return delete_form_class()
+
+    def action_form(self):
+        """
+            Instantiate action form and return it.
+
+            Override to implement custom behavior.
+        """
+        action_form_class = self.get_action_form()
+        if request.form:
+            return action_form_class(request.form)
+        else:
+            return action_form_class()
 
     def is_file_allowed(self, filename):
         """
@@ -812,6 +837,10 @@ class BaseFileAdmin(BaseView, ActionsMixin):
 
         # Actions
         actions, actions_confirmation = self.get_actions_list()
+        if actions:
+            action_form = self.action_form()
+        else:
+            action_form = None
 
         def sort_url(column, invert=False):
             desc = None
@@ -829,6 +858,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
                            items=items,
                            actions=actions,
                            actions_confirmation=actions_confirmation,
+                           action_form=action_form,
                            delete_form=delete_form,
                            sort_column=sort_column,
                            sort_desc=sort_desc,

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -795,6 +795,7 @@ class BaseModelView(BaseView, ActionsMixin):
         self._create_form_class = self.get_create_form()
         self._edit_form_class = self.get_edit_form()
         self._delete_form_class = self.get_delete_form()
+        self._action_form_class = self.get_action_form()
 
         # List View In-Line Editing
         if self.column_editable_list:
@@ -1254,6 +1255,19 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return DeleteForm
 
+    def get_action_form(self):
+        """
+            Create form class for a model action.
+
+            Override to implement customized behavior.
+        """
+        class ActionForm(self.form_base_class):
+            action = HiddenField()
+            url = HiddenField()
+            # rowid is retrieved using getlist, for backward compatibility
+
+        return ActionForm
+
     def create_form(self, obj=None):
         """
             Instantiate model creation form and return it.
@@ -1294,6 +1308,14 @@ class BaseModelView(BaseView, ActionsMixin):
             Override to implement custom behavior.
         """
         return self._list_form_class(get_form_data(), obj=obj)
+
+    def action_form(self, obj=None):
+        """
+            Instantiate model action form and return it.
+
+            Override to implement custom behavior.
+        """
+        return self._action_form_class(get_form_data(), obj=obj)
 
     def validate_form(self, form):
         """
@@ -1540,7 +1562,7 @@ class BaseModelView(BaseView, ActionsMixin):
         """
         pass
 
-    def on_form_prefill (self, form, id):
+    def on_form_prefill(self, form, id):
         """
             Perform additional actions to pre-fill the edit form.
 
@@ -1874,6 +1896,10 @@ class BaseModelView(BaseView, ActionsMixin):
 
         # Actions
         actions, actions_confirmation = self.get_actions_list()
+        if actions:
+            action_form = self.action_form()
+        else:
+            action_form = None
 
         clear_search_url = self._get_list_url(view_args.clone(page=0,
                                                               sort=view_args.sort,
@@ -1886,6 +1912,7 @@ class BaseModelView(BaseView, ActionsMixin):
             data=data,
             list_forms=list_forms,
             delete_form=delete_form,
+            action_form=action_form,
 
             # List
             list_columns=self._list_columns,

--- a/flask_admin/templates/bootstrap2/admin/actions.html
+++ b/flask_admin/templates/bootstrap2/admin/actions.html
@@ -14,11 +14,13 @@
 {% macro form(actions, url) %}
     {% if actions %}
     <form id="action_form" action="{{ url }}" method="POST" style="display: none">
-        {% if csrf_token %}
+        {% if action_form.csrf_token %}
+        {{ action_form.csrf_token }}
+        {% elif csrf_token %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% endif %}
-        <input type="hidden" name="url" value="{{ return_url }}">
-        <input type="hidden" id="action" name="action" />
+        {{ action_form.url(value=return_url) }}
+        {{ action_form.action() }}
     </form>
     {% endif %}
 {% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/actions.html
+++ b/flask_admin/templates/bootstrap3/admin/actions.html
@@ -14,11 +14,13 @@
 {% macro form(actions, url) %}
     {% if actions %}
     <form id="action_form" action="{{ url }}" method="POST" style="display: none">
-        {% if csrf_token %}
+        {% if action_form.csrf_token %}
+        {{ action_form.csrf_token }}
+        {% elif csrf_token %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% endif %}
-        <input type="hidden" name="url" value="{{ return_url }}">
-        <input type="hidden" id="action" name="action" />
+        {{ action_form.url(value=return_url) }}
+        {{ action_form.action() }}
     </form>
     {% endif %}
 {% endmacro %}

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -379,7 +379,7 @@ def test_csrf():
 
     # Create with CSRF token
     rv = client.post('/admin/secure/new/', data=dict(name='test1',
-                                                   csrf_token=csrf_token))
+                                                     csrf_token=csrf_token))
     eq_(rv.status_code, 302)
 
     ###############
@@ -423,6 +423,23 @@ def test_csrf():
                      follow_redirects=True)
     eq_(rv.status_code, 200)
     ok_(u'Record was successfully deleted.' in rv.data.decode('utf-8'))
+
+    ################
+    # actions
+    ################
+    rv = client.get('/admin/secure/')
+    eq_(rv.status_code, 200)
+    ok_(u'name="csrf_token"' in rv.data.decode('utf-8'))
+
+    csrf_token = get_csrf_token(rv.data.decode('utf-8'))
+
+    # Delete without CSRF token, test validation errors
+    rv = client.post('/admin/secure/action/',
+                     data=dict(rowid='1', url='/admin/secure/', action='delete'),
+                     follow_redirects=True)
+    eq_(rv.status_code, 200)
+    ok_(u'Record was successfully deleted.' not in rv.data.decode('utf-8'))
+    ok_(u'Failed to perform action.' in rv.data.decode('utf-8'))
 
 
 def test_custom_form():


### PR DESCRIPTION
Fixes #1390 by adding csrf token validation when using actions. This is only enabled when the developer enables csrf production.

This code has a lot in common with the DeleteForm and how it's used in the list view.
