### PR TITLE
Added JSON and JSONB and support for peewee postgresql backend

### DIFF
--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -3,8 +3,6 @@ from wtforms import fields
 from peewee import (CharField, DateTimeField, DateField, TimeField,
                     PrimaryKeyField, ForeignKeyField, BaseModel)
 
-from playhouse.postgres_ext import ArrayField, JSONField, BinaryJSONField
-
 from wtfpeewee.orm import ModelConverter, model_form
 
 from flask_admin import form
@@ -14,7 +12,11 @@ from flask_admin.model.fields import InlineModelFormField, InlineFieldList, Ajax
 
 from .tools import get_primary_key, get_meta_fields
 from .ajax import create_ajax_loader
-
+try:
+    from playhouse.postgres_ext import JSONField, BinaryJSONField
+    pg_ext = True
+except:
+    pg_ext = False
 
 class InlineModelFormList(InlineFieldList):
     """
@@ -100,8 +102,10 @@ class CustomModelConverter(ModelConverter):
         self.converters[DateTimeField] = self.handle_datetime
         self.converters[DateField] = self.handle_date
         self.converters[TimeField] = self.handle_time
-        self.converters[JSONField] = self.handle_json
-        self.converters[BinaryJSONField] = self.handle_json
+
+        if pg_ext:
+            self.converters[JSONField] = self.handle_json
+            self.converters[BinaryJSONField] = self.handle_json
 
         self.overrides = getattr(self.view, 'form_overrides', None) or {}
 

--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -3,6 +3,8 @@ from wtforms import fields
 from peewee import (CharField, DateTimeField, DateField, TimeField,
                     PrimaryKeyField, ForeignKeyField, BaseModel)
 
+from playhouse.postgres_ext import ArrayField, JSONField, BinaryJSONField
+
 from wtfpeewee.orm import ModelConverter, model_form
 
 from flask_admin import form
@@ -98,6 +100,8 @@ class CustomModelConverter(ModelConverter):
         self.converters[DateTimeField] = self.handle_datetime
         self.converters[DateField] = self.handle_date
         self.converters[TimeField] = self.handle_time
+        self.converters[JSONField] = self.handle_json
+        self.converters[BinaryJSONField] = self.handle_json
 
         self.overrides = getattr(self.view, 'form_overrides', None) or {}
 
@@ -126,6 +130,9 @@ class CustomModelConverter(ModelConverter):
 
     def handle_time(self, model, field, **kwargs):
         return field.name, form.TimeField(**kwargs)
+
+    def handle_json(self, model, field, **kwargs):
+        return field.name, form.JSONField(**kwargs)
 
 
 def get_form(model, converter,

--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -18,6 +18,7 @@ try:
 except:
     pg_ext = False
 
+
 class InlineModelFormList(InlineFieldList):
     """
         Customized inline model form list field.


### PR DESCRIPTION
This pull request adds the ability to edit JSON columns to the peewee backend.

I used JSONField from flask_admin/form/fields.py and wrote two converters, for JSON and BinaryJSON fields.