### PR TITLE
fix pymongo example ImportError

### DIFF
--- a/examples/pymongo/requirements.txt
+++ b/examples/pymongo/requirements.txt
@@ -1,4 +1,3 @@
 Flask
 Flask-Admin
 pymongo==2.4.1
-bson


### PR DESCRIPTION
I'm getting this error when I try to run the pymongo example:
```
  File "/Users/paulbrown/Envs/fix_1381/lib/python2.7/site-packages/pymongo/cursor.py", line 19, in <module>
    from bson import RE_TYPE
ImportError: cannot import name RE_TYPE
```

The `bson` module is part of pymongo and it's not necessary to have it in requirements.txt. Removing it from requirements.txt fixes the issue.
