### PR TITLE
use property name rather than db column name for form_choices

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -243,7 +243,7 @@ class AdminModelConverter(ModelConverterBase):
             form_choices = getattr(self.view, 'form_choices', None)
 
             if mapper.class_ == self.view.model and form_choices:
-                choices = form_choices.get(column.key)
+                choices = form_choices.get(prop.key)
                 if choices:
                     return form.Select2Field(
                         choices=choices,
@@ -537,7 +537,7 @@ class InlineModelConverter(InlineModelConverterBase):
     def _calculate_mapping_key_pair(self, model, info):
         """
             Calculate mapping property key pair between `model` and inline model,
-                including the forward one for `model` and the reverse one for inline model. 
+                including the forward one for `model` and the reverse one for inline model.
                 Override the method to map your own inline models.
 
             :param model:


### PR DESCRIPTION
Fixes #1223 

Currently if you have a column defined like this:
```
desc = db.Column('blah', db.String(50))
```

Your form_choices would need to look like this:
```
form_choices = {'blah': [('choice1', 'choice2')]}
```

That's not really consistent with the rest of flask-admin (which uses property names), so the current behavior is pretty confusing.

This PR changes it to use the SQLAlchemy model property instead, so form_choices would become:
```
form_choices = {'desc': [('choice1', 'choice2')]}
```