### PR TITLE
use tox, fix mongoengine & python 2.6 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ examples/appengine/lib
 env
 *.egg
 .eggs
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - WTFORMS_VERSION=1
@@ -17,17 +18,16 @@ addons:
 services:
   - postgresql
   - mongodb
-  
+
 before_script:
   - psql -U postgres -c 'CREATE DATABASE flask_admin_test;'
   - psql -U postgres -c 'CREATE EXTENSION postgis;' flask_admin_test
   - psql -U postgres -c 'CREATE EXTENSION hstore;' flask_admin_test
 
 install:
-  - pip install "wtforms<$WTFORMS_VERSION.99"
-  - pip install -r requirements-dev.txt
+  - pip install tox
 
-script: nosetests flask_admin/tests --with-coverage --cover-erase --cover-inclusive
+script: tox -e py-WTForms$WTFORMS_VERSION
 
 after_success:
     - coveralls

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,8 @@ For all the tests to pass successfully, you'll need Postgres & MongoDB to be run
     CREATE DATABASE flask_admin_test;
     CREATE EXTENSION postgis;
 
+You can also run the tests on multiple environments using *tox*.
+
 3rd Party Stuff
 ---------------
 

--- a/flask_admin/_compat.py
+++ b/flask_admin/_compat.py
@@ -87,17 +87,4 @@ def with_metaclass(meta, *bases):
 try:
     from collections import OrderedDict
 except ImportError:
-    # Bare-bones OrderedDict implementation for Python2.6 compatibility
-    class OrderedDict(dict):
-        def __init__(self, *args, **kwargs):
-            dict.__init__(self, *args, **kwargs)
-            self.ordered_keys = []
-        def __setitem__(self, key, value):
-            self.ordered_keys.append(key)
-            dict.__setitem__(self, key, value)
-        def __iter__(self):
-            return (k for k in self.ordered_keys)
-        def iteritems(self):
-            return ((k, self[k]) for k in self.ordered_keys)
-        def items(self):
-            return list(self.iteritems())
+    from ordereddict import OrderedDict

--- a/flask_admin/tests/mongoengine/__init__.py
+++ b/flask_admin/tests/mongoengine/__init__.py
@@ -1,3 +1,14 @@
+from nose.plugins.skip import SkipTest
+from wtforms import __version__ as wtforms_version
+
+# Skip test on PY3
+from flask_admin._compat import PY2
+if not PY2:
+    raise SkipTest('MongoEngine is not Python 3 compatible')
+
+if int(wtforms_version[0]) < 2:
+    raise SkipTest('MongoEngine does not support WTForms 1.')
+
 from flask import Flask
 from flask_admin import Admin
 from flask_mongoengine import MongoEngine

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -1,19 +1,15 @@
 from nose.tools import eq_, ok_
-from nose.plugins.skip import SkipTest
-
-# Skip test on PY3
-from flask_admin._compat import PY2, as_unicode
-if not PY2:
-    raise SkipTest('MongoEngine is not Python 3 compatible')
 
 from wtforms import fields, validators
 
 from flask_admin import form
+from flask_admin._compat import as_unicode
 from flask_admin.contrib.mongoengine import ModelView
 
 from . import setup
 
 from datetime import datetime
+
 
 class CustomModelView(ModelView):
     def __init__(self, model,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 Flask>=0.7
-wtforms
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # Fix for older setuptools
 import re
 import os
+import sys
 
 from setuptools import setup, find_packages
 
@@ -30,6 +31,14 @@ def grep(attrname):
     return strval
 
 
+install_requires = [
+    'Flask>=0.7',
+    'wtforms'
+]
+
+if sys.version_info[:2] < (2, 7):
+    install_requires.append('ordereddict')
+
 setup(
     name='Flask-Admin',
     version=grep('__version__'),
@@ -43,10 +52,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'Flask>=0.7',
-        'wtforms'
-    ],
+    install_requires=install_requires,
     tests_require=[
         'nose>=1.0',
         'pillow==2.9.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py{26,27,33,34,35,36}-WTForms{1,2}
+skipsdist = true
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+deps =
+    WTForms1: WTForms==1.0.5
+    WTForms2: WTForms>=2.0
+    -r{toxinidir}/requirements-dev.txt
+commands =
+    nosetests flask_admin/tests --with-coverage --cover-erase --cover-inclusive


### PR DESCRIPTION
The MongoEngine tests were broken because MongoEngine now requires a recent version of Flask-WTF which requires WTForms 2 for its CSRF validation implementation. I fixed this by skipping WTForms 1 tests for the MongoEngine backend. 

The Python 2.6 tests were broken because the `keys` method calls the normal (unordered) `dict.keys()`. I fixed this by adding `ordereddict` as a dependency for 2.6 and removing the "Bare-bones OrderedDict implementation for Python2.6 compatibility" in case there are other problems with it. If we want to keep it, we could probably also fix this by adding a `keys` method that returns `self.ordered_keys`.

I added a tox.ini to make these sorts of issues easier to test locally. And, I made the travis.yml use tox so we can do stuff like running flake8 in the future. I also made it test Python 3.6.