### PR TITLE
Don’t initialize index_view twice

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -664,7 +664,12 @@ class Admin(object):
         self._init_extension()
 
         # Register Index view
-        self._set_admin_index_view(index_view=index_view, endpoint=endpoint, url=url)
+        if index_view is not None:
+            self._set_admin_index_view(
+                index_view=index_view,
+                endpoint=endpoint,
+                url=url
+            )
 
         # Register views
         for view in self._views:


### PR DESCRIPTION
Since #1238 was merged, `index_view` would be initialized twice, which
caused the url of an `index_vew` passed in to `Admin.__init__()` not
being read (causing 404s for me 😢). This PR fixes that.