### PR TITLE
Allow specifying a primary key field in column_filters (of a peewee ModelView)

### DIFF
--- a/flask_admin/contrib/peewee/filters.py
+++ b/flask_admin/contrib/peewee/filters.py
@@ -319,7 +319,7 @@ class FilterConverter(filters.BaseFilterConverter):
     def conv_bool(self, column, name):
         return [f(column, name) for f in self.bool_filters]
 
-    @filters.convert('IntegerField', 'BigIntegerField')
+    @filters.convert('IntegerField', 'BigIntegerField', 'PrimaryKeyField')
     def conv_int(self, column, name):
         return [f(column, name) for f in self.int_filters]
 


### PR DESCRIPTION
Currently if you try to specify a primary key field in the `column_filters` list of your `peewee.ModelView` subclass, flask-admin raises an exception on startup, like this:

    Exception: Unsupported filter type id

Or if you specify a primary key of another table for a join, like `OtherTable.id`, you get:

    Exception: Unsupported filter type <peewee.PrimaryKeyField object at 0x12345678>

This pull request adds `PrimaryKeyField` to the list of integer filter types to enable the above.