### PR TITLE
Fixing bug with using multiple URL attributes

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1688,6 +1688,24 @@ class BaseModelView(BaseView, ActionsMixin):
                         search=request.args.get('search', None),
                         filters=self._get_list_filter_args())
 
+    def _get_filters(self, filters):
+        """
+            Get active filters as dictionary of URL arguments and values
+
+            :param filters:
+                List of filters from ViewArgs object
+        """
+        kwargs = {}
+
+        if filters:
+            for i, pair in enumerate(filters):
+                idx, flt_name, value = pair
+
+                key = 'flt%d_%s' % (i, self.get_filter_arg(idx, self._filters[idx]))
+                kwargs[key] = value
+
+        return kwargs
+
     # URL generation helpers
     def _get_list_url(self, view_args):
         """
@@ -1708,12 +1726,7 @@ class BaseModelView(BaseView, ActionsMixin):
         if view_args.page_size:
             kwargs['page_size'] = view_args.page_size
 
-        if view_args.filters:
-            for i, pair in enumerate(view_args.filters):
-                idx, flt_name, value = pair
-
-                key = 'flt%d_%s' % (i, self.get_filter_arg(idx, self._filters[idx]))
-                kwargs[key] = value
+        kwargs.update(self._get_filters(view_args.filters))
 
         return self.get_url('.index_view', **kwargs)
 
@@ -1935,6 +1948,7 @@ class BaseModelView(BaseView, ActionsMixin):
             page_size_url=page_size_url,
             page=view_args.page,
             page_size=page_size,
+            default_page_size=self.page_size,
 
             # Sorting
             sort_column=view_args.sort,
@@ -1950,6 +1964,7 @@ class BaseModelView(BaseView, ActionsMixin):
             filters=self._filters,
             filter_groups=self._get_filter_groups(),
             active_filters=view_args.filters,
+            filter_args=self._get_filters(view_args.filters),
 
             # Actions
             actions=actions,

--- a/flask_admin/templates/bootstrap2/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap2/admin/model/layout.html
@@ -34,6 +34,18 @@
 
 {% macro filter_form() %}
     <form id="filter_form" method="GET" action="{{ return_url }}">
+        {% if sort_column is not none %}
+        <input type="hidden" name="sort" value="{{ sort_column }}">
+        {% endif %}
+        {% if sort_desc %}
+        <input type="hidden" name="desc" value="{{ sort_desc }}">
+        {% endif %}
+        {% if search %}
+        <input type="hidden" name="search" value="{{ search }}">
+        {% endif %}
+        {% if page_size != default_page_size %}
+        <input type="hidden" name="page_size" value="{{ page_size }}">
+        {% endif %}
         <div class="pull-right">
             <button type="submit" class="btn btn-primary" style="display: none">{{ _gettext('Apply') }}</button>
             {% if active_filters %}
@@ -48,6 +60,12 @@
 
 {% macro search_form(input_class="span2") %}
 <form method="GET" action="{{ return_url }}" class="search-form">
+    {% for flt_name, flt_value in filter_args.items() %}
+    <input type="hidden" name="{{ flt_name }}" value="{{ flt_value }}">
+    {% endfor %}
+    {% if page_size != default_page_size %}
+    <input type="hidden" name="page_size" value="{{ page_size }}">
+    {% endif %}
     {% if sort_column is not none %}
     <input type="hidden" name="sort" value="{{ sort_column }}">
     {% endif %}

--- a/flask_admin/templates/bootstrap3/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap3/admin/model/layout.html
@@ -34,6 +34,18 @@
 
 {% macro filter_form() %}
     <form id="filter_form" method="GET" action="{{ return_url }}">
+        {% if sort_column is not none %}
+        <input type="hidden" name="sort" value="{{ sort_column }}">
+        {% endif %}
+        {% if sort_desc %}
+        <input type="hidden" name="desc" value="{{ sort_desc }}">
+        {% endif %}
+        {% if search %}
+        <input type="hidden" name="search" value="{{ search }}">
+        {% endif %}
+        {% if page_size != default_page_size %}
+        <input type="hidden" name="page_size" value="{{ page_size }}">
+        {% endif %}
         <div class="pull-right">
             <button type="submit" class="btn btn-primary" style="display: none">{{ _gettext('Apply') }}</button>
             {% if active_filters %}
@@ -48,6 +60,12 @@
 
 {% macro search_form(input_class="col-md-2") %}
 <form method="GET" action="{{ return_url }}" class="navbar-form navbar-left" role="search">
+    {% for flt_name, flt_value in filter_args.items() %}
+    <input type="hidden" name="{{ flt_name }}" value="{{ flt_value }}">
+    {% endfor %}
+    {% if page_size != default_page_size %}
+    <input type="hidden" name="page_size" value="{{ page_size }}">
+    {% endif %}
     {% if sort_column is not none %}
     <input type="hidden" name="sort" value="{{ sort_column }}">
     {% endif %}


### PR DESCRIPTION
Fixed small bug with using multiple URL attributes:

- filters and page size were cleared if search was used;
- sorting, search and page size were cleared if filters were used.

Was fixed by adding hidden inputs for storing arguments.