### PR TITLE
Added TinyDB - TinyMongo Example.

### DIFF
--- a/examples/tinymongo/README.rst
+++ b/examples/tinymongo/README.rst
@@ -1,0 +1,22 @@
+PyMongo model backend integration example.
+
+To run this example:
+
+1. Clone the repository::
+
+    git clone https://github.com/flask-admin/flask-admin.git
+    cd flask-admin
+
+2. Create and activate a virtual environment::
+
+    virtualenv env
+    source env/bin/activate
+
+3. Install requirements::
+
+    pip install -r 'examples/pymongo/requirements.txt'
+
+4. Run the application::
+
+    python examples/pymongo/app.py
+

--- a/examples/tinymongo/README.rst
+++ b/examples/tinymongo/README.rst
@@ -1,4 +1,6 @@
-PyMongo model backend integration example.
+TinyMongo model backend integration example.
+
+TinyMongo is the Pymongo for TinyDB and it stores data in JSON files.
 
 To run this example:
 
@@ -14,9 +16,9 @@ To run this example:
 
 3. Install requirements::
 
-    pip install -r 'examples/pymongo/requirements.txt'
+    pip install -r 'examples/tinymongo/requirements.txt'
 
 4. Run the application::
 
-    python examples/pymongo/app.py
+    python examples/tinymongo/app.py
 

--- a/examples/tinymongo/app.py
+++ b/examples/tinymongo/app.py
@@ -24,6 +24,7 @@ db = conn.test
 # for i in range(30):
 #     db.user.insert({'name': 'Mike %s' % i})
 
+
 # User admin
 class InnerForm(form.Form):
     name = fields.StringField('Name')
@@ -51,6 +52,7 @@ class UserView(ModelView):
 
     page_size = 20
     can_set_page_size = True
+
 
 # Tweet view
 class TweetForm(form.Form):

--- a/examples/tinymongo/app.py
+++ b/examples/tinymongo/app.py
@@ -1,0 +1,125 @@
+from tinymongo import TinyMongoClient
+from bson.objectid import ObjectId
+
+from flask import Flask
+import flask_admin as admin
+
+from wtforms import form, fields
+
+from flask_admin.form import Select2Widget
+from flask_admin.contrib.pymongo import ModelView, filters
+from flask_admin.model.fields import InlineFormField, InlineFieldList
+
+# Create application
+app = Flask(__name__)
+
+# Create dummy secrey key so we can use sessions
+app.config['SECRET_KEY'] = '123456790'
+
+# Create models
+conn = TinyMongoClient('/tmp/flask_admin_test')
+db = conn.test
+
+
+# User admin
+class InnerForm(form.Form):
+    name = fields.StringField('Name')
+    test = fields.StringField('Test')
+
+
+class UserForm(form.Form):
+    foo = fields.StringField('foo')
+    name = fields.StringField('Name')
+    email = fields.StringField('Email')
+    password = fields.StringField('Password')
+
+    # Inner form
+    inner = InlineFormField(InnerForm)
+
+    # Form list
+    form_list = InlineFieldList(InlineFormField(InnerForm))
+
+
+class UserView(ModelView):
+    column_list = ('name', 'email', 'password', 'foo')
+    column_sortable_list = ('name', 'email', 'password')
+
+    form = UserForm
+
+
+# Tweet view
+class TweetForm(form.Form):
+    name = fields.StringField('Name')
+    user_id = fields.SelectField('User', widget=Select2Widget())
+    text = fields.StringField('Text')
+
+    testie = fields.BooleanField('Test')
+
+
+class TweetView(ModelView):
+    column_list = ('name', 'user_name', 'text')
+    column_sortable_list = ('name', 'text')
+
+    column_filters = (filters.FilterEqual('name', 'Name'),
+                      filters.FilterNotEqual('name', 'Name'),
+                      filters.FilterLike('name', 'Name'),
+                      filters.FilterNotLike('name', 'Name'),
+                      filters.BooleanEqualFilter('testie', 'Testie'))
+
+    column_searchable_list = ('name', 'text')
+
+    form = TweetForm
+
+    def get_list(self, *args, **kwargs):
+        count, data = super(TweetView, self).get_list(*args, **kwargs)
+
+        # Grab user names
+        query = {'_id': {'$in': [x['user_id'] for x in data]}}
+        users = db.user.find(query, fields=('name',))
+
+        # Contribute user names to the models
+        users_map = dict((x['_id'], x['name']) for x in users)
+
+        for item in data:
+            item['user_name'] = users_map.get(item['user_id'])
+
+        return count, data
+
+    # Contribute list of user choices to the forms
+    def _feed_user_choices(self, form):
+        users = db.user.find(fields=('name',))
+        form.user_id.choices = [(str(x['_id']), x['name']) for x in users]
+        return form
+
+    def create_form(self):
+        form = super(TweetView, self).create_form()
+        return self._feed_user_choices(form)
+
+    def edit_form(self, obj):
+        form = super(TweetView, self).edit_form(obj)
+        return self._feed_user_choices(form)
+
+    # Correct user_id reference before saving
+    def on_model_change(self, form, model):
+        user_id = model.get('user_id')
+        model['user_id'] = user_id
+
+        return model
+
+
+# Flask views
+@app.route('/')
+def index():
+    return '<a href="/admin/">Click me to get to Admin!</a>'
+
+
+if __name__ == '__main__':
+    # Create admin
+    admin = admin.Admin(app, name='Example: PyMongo')
+
+    # Add views
+    admin.add_view(UserView(db.user, 'User'))
+    admin.add_view(TweetView(db.tweet, 'Tweets'))
+
+    # Start app
+    app.run(debug=True)

--- a/examples/tinymongo/app.py
+++ b/examples/tinymongo/app.py
@@ -20,6 +20,9 @@ app.config['SECRET_KEY'] = '123456790'
 conn = TinyMongoClient('/tmp/flask_admin_test')
 db = conn.test
 
+# create some users for testing
+# for i in range(30):
+#     db.user.insert({'name': 'Mike %s' % i})
 
 # User admin
 class InnerForm(form.Form):
@@ -46,6 +49,8 @@ class UserView(ModelView):
 
     form = UserForm
 
+    page_size = 20
+    can_set_page_size = True
 
 # Tweet view
 class TweetForm(form.Form):

--- a/examples/tinymongo/app.py
+++ b/examples/tinymongo/app.py
@@ -122,7 +122,7 @@ def index():
 
 if __name__ == '__main__':
     # Create admin
-    admin = admin.Admin(app, name='Example: PyMongo')
+    admin = admin.Admin(app, name='Example: TinyMongo - TinyDB')
 
     # Add views
     admin.add_view(UserView(db.user, 'User'))

--- a/examples/tinymongo/requirements.txt
+++ b/examples/tinymongo/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Admin
+pymongo==2.4.1

--- a/examples/tinymongo/requirements.txt
+++ b/examples/tinymongo/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 Flask-Admin
-git+https://github.com/rochacbruno/tinymongo.git#egg=tinymongo
+git+https://github.com/schapman1974/tinymongo.git#egg=tinymongo

--- a/examples/tinymongo/requirements.txt
+++ b/examples/tinymongo/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 Flask-Admin
-pymongo==2.4.1
+git+https://github.com/rochacbruno/tinymongo.git#egg=tinymongo


### PR DESCRIPTION
TinyMongo is wrapper for TinyDb which aims to expose the same API interface as PyMongo.

TinyDB is a Mongo like database which stores data in Json files so no database service is needed
(a sqlite for MongoDB)

I implemented some fixes in TinyMongo https://github.com/schapman1974/tinymongo/pull/25 to make it work with Flask Admin.

I adjusted the PyMongo example to work with TinyMongo.

NOTE: In requirements is installing TinyMongo from master branch as the changes are not yet releases to PyPI. 

![tinymongo_flask_admin](https://cloud.githubusercontent.com/assets/458654/23875605/e487d8fc-0818-11e7-968f-48601feddc17.png)

