### PR TITLE
Fix DeprecationWarning raised by SQLAlchemy

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -594,7 +594,7 @@ class ModelView(BaseModelView):
                     if column.foreign_keys or column.primary_key:
                         continue
 
-                    visible_name = '%s / %s' % (self.get_column_name(attr.prop.table.name),
+                    visible_name = '%s / %s' % (self.get_column_name(attr.prop.target.name),
                                                 self.get_column_name(p.key))
 
                     type_name = type(column.type).__name__


### PR DESCRIPTION
I've been trying for a while to squash the warnings in our application, and I finally figured out that one of them comes from Flask-Admin, specifically this line: https://github.com/flask-admin/flask-admin/blob/1fa4ba80052910fed4f80bc339b0f04955233ed4/flask_admin/contrib/sqla/view.py#L597.

In fact, the `table` property has been deprecated for quite a while: https://github.com/zzzeek/sqlalchemy/blob/9e06ab17b9d3083cd45540f714234d1d5826da32/lib/sqlalchemy/orm/relationships.py#L1641-L1648.