### PR TITLE
Fix sorting in subdirectories in fileadmin

### DIFF
--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -848,13 +848,13 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         else:
             action_form = None
 
-        def sort_url(column, invert=False):
+        def sort_url(column, path, invert=False):
             desc = None
 
             if invert and not sort_desc:
                 desc = 1
 
-            return self.get_url('.index_view', sort=column, desc=desc)
+            return self.get_url('.index_view', path=path, sort=column, desc=desc)
 
         return self.render(self.list_template,
                            dir_path=path,

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -822,6 +822,12 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         sort_desc = request.args.get('desc', 0, type=int)
 
         if sort_column is None:
+            if self.default_sort_column:
+                sort_column = self.default_sort_column
+            if self.default_desc:
+                sort_desc = self.default_desc
+
+        if sort_column is None:
             # Sort by name
             items.sort(key=itemgetter(0))
             # Sort by type

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -851,6 +851,9 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         def sort_url(column, path, invert=False):
             desc = None
 
+            if not path:
+                path = None
+
             if invert and not sort_desc:
                 desc = 1
 

--- a/flask_admin/templates/bootstrap2/admin/file/list.html
+++ b/flask_admin/templates/bootstrap2/admin/file/list.html
@@ -37,7 +37,7 @@
                 <th>
                     {% if admin_view.is_column_sortable(column) %}
                     {% if sort_column == column %}
-                        <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">
+                        <a href="{{ sort_url(column, dir_path, True) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">
                             {{ admin_view.column_label(column) }}
                             {% if sort_desc %}
                                 <i class="fa fa-chevron-up icon-chevron-up"></i>
@@ -46,7 +46,7 @@
                             {% endif %}
                         </a>
                     {% else %}
-                        <a href="{{ sort_url(column) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">{{ admin_view.column_label(column) }}</a>
+                        <a href="{{ sort_url(column, dir_path) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">{{ admin_view.column_label(column) }}</a>
                     {% endif %}
                     {% else %}
                     {{ _gettext(admin_view.column_label(column)) }}

--- a/flask_admin/templates/bootstrap3/admin/file/list.html
+++ b/flask_admin/templates/bootstrap3/admin/file/list.html
@@ -126,11 +126,11 @@
                 {{ size|filesizeformat }}
             </td>
             {% endif %}
+            {% endif %}
             {% if admin_view.is_column_visible('date') %}
             <td>
                 {{ timestamp_format(date) }}
             </td>
-            {% endif %}
             {% endif %}
             {% endblock %}
         </tr>

--- a/flask_admin/templates/bootstrap3/admin/file/list.html
+++ b/flask_admin/templates/bootstrap3/admin/file/list.html
@@ -37,7 +37,7 @@
                 <th>
                     {% if admin_view.is_column_sortable(column) %}
                     {% if sort_column == column %}
-                        <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">
+                        <a href="{{ sort_url(column, dir_path, True) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">
                             {{ admin_view.column_label(column) }}
                             {% if sort_desc %}
                                 <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
@@ -46,7 +46,7 @@
                             {% endif %}
                         </a>
                     {% else %}
-                        <a href="{{ sort_url(column) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">{{ admin_view.column_label(column) }}</a>
+                        <a href="{{ sort_url(column, dir_path) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">{{ admin_view.column_label(column) }}</a>
                     {% endif %}
                     {% else %}
                     {{ _gettext(admin_view.column_label(column)) }}


### PR DESCRIPTION
Sorting was broken for subdirectories due to the path not being passed to the sort_url method.

Also, there was an unused default sort setting, I've made use of that.