### PR TITLE
fix python 2.6 build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: TOX_ENV=py27-WTForms2
     - python: 2.7
       env: TOX_ENV=flake8
+    - python: 2.7
+      env: TOX_ENV=docs-html
     - python: 3.3
       env: TOX_ENV=py33-WTForms1
     - python: 3.3

--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,7 @@ if you think of anything else that should be included, then please make the chan
 
 To build the docs in your local environment, from the project directory::
 
-    pip install -r requirements-dev.txt
-    sudo make html
+    tox -e docs-html
 
 And if you want to preview any *.rst* snippets that you may want to contribute, go to `http://rst.ninjs.org/ <http://rst.ninjs.org/>`_.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,5 @@ shapely==1.5.9
 geoalchemy2
 psycopg2
 nose
-sphinx
-sphinx-intl
 coveralls
 pylint

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py{26,27,33,34,35,36}-WTForms{1,2},flake8
+envlist =
+    py{26,27,33,34,35,36}-WTForms{1,2}
+    flake8
+    docs-html
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -19,3 +22,9 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands = flake8 flask_admin
+
+[testenv:docs-html]
+deps =
+    sphinx
+    sphinx-intl
+commands = sphinx-build -b html -d build/doctrees doc build/html


### PR DESCRIPTION
Fixes #1492

This PR removes the sphinx requirements from requirements-dev.txt and makes it so the sphinx requirements aren't installed each time the tests are run. We only need sphinx installed for building the docs, so I moved that requirement into tox.ini where I added a task for building the docs. Now the travis tests build the docs so we can see new build errors.

This is similar to the way flask does it: https://github.com/pallets/flask/blob/master/tox.ini#L40-L42