### PR TITLE
Add support for columns-mapped column_property

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -2,6 +2,7 @@ import warnings
 
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
+from sqlalchemy.orm import ColumnProperty
 
 from flask_admin import form
 from flask_admin.model.form import (converts, ModelConverterBase,
@@ -151,7 +152,7 @@ class AdminModelConverter(ModelConverterBase):
             return self._convert_relation(name, prop, property_is_association_proxy, kwargs)
         elif hasattr(prop, 'columns'):  # Ignore pk/fk
             # Check if more than one column mapped to the property
-            if len(prop.columns) > 1:
+            if len(prop.columns) > 1 and not isinstance(prop, ColumnProperty):
                 columns = filter_foreign_columns(model.__table__, prop.columns)
 
                 if len(columns) > 1:


### PR DESCRIPTION
Add support for column_property in virtual models like here
https://docs.sqlalchemy.org/en/latest/orm/nonstandard_mappings.html#mapping-a-class-against-multiple-tables