### PR TITLE
check for valid scheme in the redirect target url (prevent xss)

### DIFF
--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -8,6 +8,9 @@ from flask_admin._compat import urljoin, urlparse, iteritems
 from ._compat import string_types
 
 
+VALID_SCHEMES = ['http', 'https']
+
+
 def set_current_view(view):
     g._admin_view = view
 
@@ -128,10 +131,16 @@ def prettify_class_name(name):
 
 
 def is_safe_url(target):
+    # prevent urls starting with "javascript:"
+    target = target.strip()
+    target_info = urlparse(target)
+    target_scheme = target_info.scheme
+    if target_scheme and target_scheme not in VALID_SCHEMES:
+        return False
+
     ref_url = urlparse(request.host_url)
     test_url = urlparse(urljoin(request.host_url, target))
-    return (test_url.scheme in ('http', 'https') and
-            ref_url.netloc == test_url.netloc)
+    return ref_url.netloc == test_url.netloc
 
 
 def get_redirect_target(param_name='url'):

--- a/flask_admin/tests/test_helpers.py
+++ b/flask_admin/tests/test_helpers.py
@@ -1,0 +1,17 @@
+import flask
+
+from flask_admin import helpers
+
+
+def test_is_safe_url():
+    app = flask.Flask(__name__)
+
+    with app.test_request_context('http://127.0.0.1/admin/car/edit/'):
+        assert helpers.is_safe_url('http://127.0.0.1/admin/car/')
+        assert helpers.is_safe_url('https://127.0.0.1/admin/car/')
+        assert helpers.is_safe_url('/admin/car/')
+        assert helpers.is_safe_url('admin/car/')
+
+        assert not helpers.is_safe_url('http://127.0.0.2/admin/car/')
+        assert not helpers.is_safe_url(' javascript:alert(document.domain)')
+        assert not helpers.is_safe_url('javascript:alert(document.domain)')


### PR DESCRIPTION
Fixes #1503 

This PR adds logic to `is_safe_url` to detect whether the the redirect url has a valid scheme. This prevents urls starting with `javascript:` which can be used for XSS.

I took some inspiration from here: https://github.com/django/django/blob/550cb3a365dee4edfdd1563224d5304de2a57fda/django/utils/http.py#L370