### PR TITLE
clean() data in filters during get_list for pymongo

### DIFF
--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -238,7 +238,7 @@ class ModelView(BaseModelView):
 
             for flt, flt_name, value in filters:
                 f = self._filters[flt]
-                data = f.apply(data, value)
+                data = f.apply(data, f.clean(value))
 
             if data:
                 if len(data) == 1:


### PR DESCRIPTION
in `contrib/mongoengine/view.py:get_list()` we have

    query = f.apply(query, f.clean(value))

in `contrib/peewee/view.py:get_list()` we have:

    query = f.apply(query, f.clean(value))

same as in `contrib/sqla/view.py:get_list()`:

     clean_value = flt.clean(value)

This commit modifies `contrib/pymongo/view.py:get_list()` like this

    data = f.apply(data, f.clean(value))

so we could compose something like this in `pymongo` admin:

    class FilterIntEqual(filters.filters.BaseIntFilter, filters.FilterEqual):
        pass
