### PR TITLE
Composite keys

### DIFF
--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -419,6 +419,8 @@ class ModelView(BaseModelView):
         return count, query
 
     def get_one(self, id):
+        if self.model._meta.composite_key:
+            return self.model.get(**dict(zip(self.model._meta.primary_key.field_names, id)))
         return self.model.get(**{self._primary_key: id})
 
     def create_model(self, form):

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -183,7 +183,6 @@ class ModelView(BaseModelView):
 
     def get_pk_value(self, model):
         if self.model._meta.composite_key:
-            # return self.model.get(**dict(zip(self.model._meta.primary_key.field_names, id)))
             return tuple([
                 model._data[field_name]
                 for field_name in self.model._meta.primary_key.field_names])

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -182,6 +182,11 @@ class ModelView(BaseModelView):
         return get_primary_key(self.model)
 
     def get_pk_value(self, model):
+        if self.model._meta.composite_key:
+            # return self.model.get(**dict(zip(self.model._meta.primary_key.field_names, id)))
+            return tuple([
+                model._data[field_name]
+                for field_name in self.model._meta.primary_key.field_names])
         return getattr(model, self._primary_key)
 
     def scaffold_list_columns(self):


### PR DESCRIPTION
Fixed support for peewee composite keys:
 - get_pk_value - returns correct foreign key values;
 - get_one - retrieves instance based of the composite key value.