### PR TITLE
remove need for some inline javascripts

### DIFF
--- a/flask_admin/static/admin/js/actions.js
+++ b/flask_admin/static/admin/js/actions.js
@@ -48,3 +48,6 @@ var AdminModelActions = function(actionErrorMessage, actionConfirmations) {
         });
     });
 };
+if ($('#actions_confirmation').length == 1) {
+    var modelActions = new AdminModelActions(JSON.parse($('#message-data').text()), JSON.parse($('#actions-confirmation-data').text()));
+}

--- a/flask_admin/static/admin/js/bs2_modal.js
+++ b/flask_admin/static/admin/js/bs2_modal.js
@@ -2,3 +2,8 @@
 $('.modal').on('hidden', function() {
   $(this).removeData('modal');
 });
+
+$(function() {
+  // Apply flask-admin form styles after the modal is loaded
+  window.faForm.applyGlobalStyles(document);
+});

--- a/flask_admin/static/admin/js/bs3_modal.js
+++ b/flask_admin/static/admin/js/bs3_modal.js
@@ -2,3 +2,8 @@
 $('body').on('hidden.bs.modal', '.modal', function () {
   $(this).removeData('bs.modal').find(".modal-content").empty();
 });
+
+$(function() {
+  // Apply flask-admin form styles after the modal is loaded
+  window.faForm.applyGlobalStyles(document);
+});

--- a/flask_admin/static/admin/js/filters.js
+++ b/flask_admin/static/admin/js/filters.js
@@ -2,23 +2,23 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
     var $root = $(element);
     var $container = $('.filters', $root);
     var lastCount = 0;
-    
+
     function getCount(name) {
         var idx = name.indexOf('_');
-        
+
         if (idx === -1) {
             return 0;
         }
-        
+
         return parseInt(name.substr(3, idx - 3), 10);
     }
-    
+
     function makeName(name) {
         var result = 'flt' + lastCount + '_' + name;
         lastCount += 1;
         return result;
     }
-    
+
     function removeFilter() {
         $(this).closest('tr').remove();
         if($('.filters tr').length == 0) {
@@ -28,23 +28,23 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
         } else {
             $('button', $root).show();
         }
-        
+
         return false;
     }
-    
+
     // triggered when the filter operation (equals, not equals, etc) is changed
     function changeOperation(subfilters, $el, filter, $select) {
         // get the filter_group subfilter based on the index of the selected option
         var selectedFilter = subfilters[$select.select2('data').element[0].index];
         var $inputContainer = $el.find('td').last();
-        
+
         // recreate and style the input field (turn into date range or select2 if necessary)
         var $field = createFilterInput($inputContainer, null, selectedFilter);
         styleFilterInput(selectedFilter, $field);
-        
+
         $('button', $root).show();
     }
-    
+
     // generate HTML for filter input - allows changing filter input type to one with options or tags
     function createFilterInput(inputContainer, filterValue, filter) {
         if (filter.type == "select2-tags") {
@@ -52,7 +52,7 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
             $field.val(filterValue);
         } else if (filter.options) {
             var $field = $('<select class="filter-val" />').attr('name', makeName(filter.arg));
-            
+
             $(filter.options).each(function() {
                 // for active filter inputs with options, add "selected" if there is a matching active filter
                 if (filterValue && (filterValue == this[0])) {
@@ -68,10 +68,10 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
             $field.val(filterValue);
         }
         inputContainer.replaceWith($('<td/>').append($field));
-        
+
         return $field;
     }
-    
+
     // add styling to input field, accommodates filters that change the input field's HTML
     function styleFilterInput(filter, field) {
         if (filter.type) {
@@ -90,19 +90,19 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
                     // save tag options as json on data attribute
                     field.attr('data-tags', JSON.stringify(options));
                 }
-            } 
+            }
             faForm.applyStyle(field, filter.type);
         } else if (filter.options) {
             filter.type = "select2";
             faForm.applyStyle(field, filter.type);
         }
-        
+
         return field;
     }
-    
+
     function addFilter(name, subfilters, selectedIndex, filterValue) {
         var $el = $('<tr class="form-horizontal" />').appendTo($container);
-        
+
         // Filter list
         $el.append(
             $('<td/>').append(
@@ -113,10 +113,10 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
                     .click(removeFilter)
                 )
         );
-        
+
         // Filter operation <select> (equal, not equal, etc)
         var $select = $('<select class="filter-op" />');
-        
+
         // if one of the subfilters are selected, use that subfilter to create the input field
         var filterSelection = 0;
         $.each(subfilters, function( subfilterIndex, subfilter ) {
@@ -127,55 +127,69 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
                 $select.append($('<option/>').attr('value', subfilter.arg).text(subfilter.operation));
             }
         });
-        
+
         $el.append(
             $('<td/>').append($select)
         );
-        
+
         // select2 for filter-op (equal, not equal, etc)
         $select.select2({width: 'resolve'}).on("change", function(e) {
             changeOperation(subfilters, $el, filter, $select);
         });
-        
+
         // get filter option from filter_group, only for new filter creation
         var filter = subfilters[filterSelection];
         var $inputContainer = $('<td/>').appendTo($el);
-         
+
         var $newFilterField = createFilterInput($inputContainer, filterValue, filter).focus();
         var $styledFilterField = styleFilterInput(filter, $newFilterField);
-        
+
         return $styledFilterField;
     }
-    
+
     // Add Filter Button, new filter
     $('a.filter', filtersElement).click(function() {
         var name = ($(this).text().trim !== undefined ? $(this).text().trim() : $(this).text().replace(/^\s+|\s+$/g,''));
-        
+
         addFilter(name, filterGroups[name], false, null);
-        
-        $('button', $root).show();        
+
+        $('button', $root).show();
     });
-    
-    // on page load - add active filters 
+
+    // on page load - add active filters
     $.each(activeFilters, function( activeIndex, activeFilter ) {
         var idx = activeFilter[0],
             name = activeFilter[1],
             filterValue = activeFilter[2];
-        var $activeField = addFilter(name, filterGroups[name], idx, filterValue);        
+        var $activeField = addFilter(name, filterGroups[name], idx, filterValue);
     });
-    
+
     // show "Apply Filter" button when filter input is changed
     $('.filter-val', $root).on('input change', function() {
         $('button', $root).show();
     });
-    
+
     $('.remove-filter', $root).click(removeFilter);
-    
+
     $('.filter-val', $root).not('.select2-container').each(function() {
         var count = getCount($(this).attr('name'));
         if (count > lastCount)
             lastCount = count;
     });
-    
+
     lastCount += 1;
 };
+
+(function($) {
+    $('[data-role=tooltip]').tooltip({
+        html: true,
+        placement: 'bottom'
+    });
+    if ($('#filter-groups-data').length == 1) {
+        var filter = new AdminFilters(
+            '#filter_form', '.field-filters',
+            JSON.parse($('#filter-groups-data').text()),
+            JSON.parse($('#active-filters-data').text())
+        );
+    }
+})(jQuery);

--- a/flask_admin/static/admin/js/rediscli.js
+++ b/flask_admin/static/admin/js/rediscli.js
@@ -115,3 +115,7 @@ var RedisCli = function(postUrl) {
 
 	sendCommand('ping');
 };
+
+$(function() {
+    var redisCli = new RedisCli(JSON.parse($('#execute-view-data').text()));
+});

--- a/flask_admin/templates/bootstrap2/admin/actions.html
+++ b/flask_admin/templates/bootstrap2/admin/actions.html
@@ -27,9 +27,8 @@
 
 {% macro script(message, actions, actions_confirmation) %}
     {% if actions %}
-    <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
-    <script language="javascript">
-        var modelActions = new AdminModelActions({{ message|tojson|safe }}, {{ actions_confirmation|tojson|safe }});
-    </script>
+        <div id="actions-confirmation-data" style="display:none;">{{ actions_confirmation|tojson|safe }}</div>
+        <div id="message-data" style="display:none;">{{ message|tojson|safe }}</div>
+        <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
     {% endif %}
 {% endmacro %}

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -179,26 +179,16 @@
 
 {% block tail %}
     {{ super() }}
-    {{ lib.form_js() }}
+
+    {% if filter_groups %}
+      <div id="filter-groups-data" style="display:none;">{{ filter_groups|tojson|safe }}</div>
+      <div id="active-filters-data" style="display:none;">{{ active_filters|tojson|safe }}</div>
+    {% endif %}
+
     <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
+    {{ lib.form_js() }}
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,
                         actions_confirmation) }}
-
-    <script language="javascript">
-        (function($) {
-            $('[data-role=tooltip]').tooltip({
-                html: true,
-                placement: 'bottom'
-            });
-            {% if filter_groups %}
-                var filter = new AdminFilters(
-                    '#filter_form', '.field-filters',
-                    {{ filter_groups|tojson|safe }},
-                    {{ active_filters|tojson|safe }}
-                );
-            {% endif %}
-        })(jQuery);
-    </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/create.html
@@ -21,10 +21,5 @@
   $('.modal-header h3').html('{% block header_text -%}
     <h3>{{ _gettext('Create New Record') }}</h3>
   {%- endblock %}');
-
-  $(function() {
-    // Apply flask-admin form styles after the modal is loaded
-    window.faForm.applyGlobalStyles(document);
-  });
   </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
@@ -21,10 +21,5 @@
   $('.modal-header h3').html('{% block header_text -%}
     {{ _gettext('Edit Record') + ' #' + request.args.get('id') }}
   {%- endblock %}');
-
-  $(function() {
-    // Apply flask-admin form styles after the modal is loaded
-    window.faForm.applyGlobalStyles(document);
-  });
   </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/rediscli/console.html
+++ b/flask_admin/templates/bootstrap2/admin/rediscli/console.html
@@ -21,10 +21,7 @@
 
 {% block tail %}
   {{ super() }}
+
+  <div id="execute-view-data" style="display:none;">{{ admin_view.get_url('.execute_view')|tojson|safe }}</div>
   <script src="{{ admin_static.url(filename='admin/js/rediscli.js', v='1.0.0') }}"></script>
-  <script language="javascript">
-    $(function() {
-      var redisCli = new RedisCli({{ get_url('.execute_view')|tojson }});
-    });
-  </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/actions.html
+++ b/flask_admin/templates/bootstrap3/admin/actions.html
@@ -27,9 +27,8 @@
 
 {% macro script(message, actions, actions_confirmation) %}
     {% if actions %}
-    <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
-    <script language="javascript">
-        var modelActions = new AdminModelActions({{ message|tojson|safe }}, {{ actions_confirmation|tojson|safe }});
-    </script>
+        <div id="actions-confirmation-data" style="display:none;">{{ actions_confirmation|tojson|safe }}</div>
+        <div id="message-data" style="display:none;">{{ message|tojson|safe }}</div>
+        <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
     {% endif %}
 {% endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -180,43 +180,16 @@
 
 {% block tail %}
     {{ super() }}
+
+    {% if filter_groups %}
+      <div id="filter-groups-data" style="display:none;">{{ filter_groups|tojson|safe }}</div>
+      <div id="active-filters-data" style="display:none;">{{ active_filters|tojson|safe }}</div>
+    {% endif %}
+
     <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
     {{ lib.form_js() }}
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,
                         actions_confirmation) }}
-
-    <script language="javascript">
-        (function($) {
-            $('[data-role=tooltip]').tooltip({
-                html: true,
-                placement: 'bottom'
-            });
-            {% if filter_groups %}
-                var filter = new AdminFilters(
-                    '#filter_form', '.field-filters',
-                    {{ filter_groups|tojson|safe }},
-                    {{ active_filters|tojson|safe }}
-                );
-            {% endif %}
-        })(jQuery);
-
-        // Catch exception when closing dialog with <esc> key
-        // and prevent accidental deletions.
-        function safeConfirm(msg) {
-          try {
-            var isconfirmed = confirm(msg);
-            if (isconfirmed == true) {
-              return true;
-            }
-            else {
-              return false;
-            }
-          }
-          catch(err) {
-            return false;
-          }
-        }
-    </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/create.html
@@ -21,11 +21,4 @@
 
 {% block tail %}
   <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
-
-  <script>
-  $(function() {
-    // Apply flask-admin form styles after the modal is loaded
-    window.faForm.applyGlobalStyles(document);
-  });
-  </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
@@ -23,11 +23,4 @@
 
 {% block tail %}
   <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
-
-  <script>
-  $(function() {
-    // Apply flask-admin form styles after the modal is loaded
-    window.faForm.applyGlobalStyles(document);
-  });
-  </script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/rediscli/console.html
+++ b/flask_admin/templates/bootstrap3/admin/rediscli/console.html
@@ -21,10 +21,7 @@
 
 {% block tail %}
   {{ super() }}
+
+  <div id="execute-view-data" style="display:none;">{{ admin_view.get_url('.execute_view')|tojson|safe }}</div>
   <script src="{{ admin_static.url(filename='admin/js/rediscli.js', v='1.0.0') }}"></script>
-  <script language="javascript">
-    $(function() {
-      var redisCli = new RedisCli({{ admin_view.get_url('.execute_view')|tojson }});
-    });
-  </script>
 {% endblock %}


### PR DESCRIPTION
Fixes most common cases of #1135, except for:

* `templates/bootstrap2/admin/lib.html` (map widget)
* `templates/bootstrap3/admin/lib.html` (map widget)
* `templates/bootstrap2/admin/file/modals/form.html`
* `templates/bootstrap2/admin/model/modals/create.html`
* `templates/bootstrap2/admin/model/modals/details.html`
* `templates/bootstrap2/admin/model/modals/edit.html`

Also should move inline `onclick` event attributes into JavaScript files in `static` folder:

* `templates/bootstrap2/admin/actions.html`
* `templates/bootstrap3/admin/actions.html`
* `templates/bootstrap2/admin/file/list.html`
* `templates/bootstrap2/admin/model/inline_list_base.html`
* `templates/bootstrap2/admin/model/layout.html`
* `templates/bootstrap2/admin/model/row_actions.html`
* `templates/bootstrap3/admin/file/list.html`
* `templates/bootstrap3/admin/model/inline_list_base.html`
* `templates/bootstrap3/admin/model/layout.html`
* `templates/bootstrap3/admin/model/row_actions.html`