### PR TITLE
Keep name from sorted column tuple in sqla

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -499,8 +499,6 @@ class ModelView(BaseModelView):
                     # column is in same table, use only model attribute name
                     if getattr(column, 'key', None) is not None:
                         column_name = column.key
-                    else:
-                        column_name = text_type(c)
 
                 # column_name must match column_name used in `get_list_columns`
                 result[column_name] = column


### PR DESCRIPTION
This else clause is not needed since the column_name has been set earlier. However leaving it there break the `tuple` behavior where one might want to define a specific column name. My actual use case is to sort on Postgresql JSON column by using something like:
```
    column_list = ['price']
    column_formatters = {
        'price': lambda v,c,m,a: m.data['price']
    }
    column_sortable_list = [('price', MyModel.data['price'])]
```

Right now the `price` column is not set since the sortable column name is `"('price', <sqlalchemy.sql.elements.BinaryExpression object at 0x7fac0ce2e320>)"`.