### PR TITLE
rediscli: prevent form submit when execute command

### DIFF
--- a/flask_admin/static/admin/js/rediscli.js
+++ b/flask_admin/static/admin/js/rediscli.js
@@ -79,6 +79,7 @@ var RedisCli = function(postUrl) {
 		sendCommand(val);
 
 		$input.val('');
+		return false;
 	}
 
 	function onKeyPress(e) {


### PR DESCRIPTION
Prevent form submit when user pressing ENTER to execute command. This make url does not change to /rediscli/?# url after every first command was executed.