### PR TITLE
allow to filter by primary key in scaffold_filters

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -591,7 +591,7 @@ class ModelView(BaseModelView):
                     # TODO: Check for multiple columns
                     column = p.columns[0]
 
-                    if column.foreign_keys or column.primary_key:
+                    if column.foreign_keys:
                         continue
 
                     visible_name = '%s / %s' % (self.get_column_name(attr.prop.target.name),


### PR DESCRIPTION
I'm working on an application where my models used to have `id` and `uid` unique 5 letters column, and I was able to filter using `uid`. Then the specs changed to make uid is the ID of the table so the id would be a unique 5 letters, but I wasn't able to filter because filters are skipped if the column is a primary key, and I had to override the scaffold_filters function. I think it's reasonable to allow filtering by IDs in general, unless that's by design.

Thanks :) 