### PR TITLE
fix x-editable booleans on list views

### DIFF
--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -105,6 +105,7 @@ class XEditableWidget(object):
             kwargs['data-rows'] = '5'
         elif field.type == 'BooleanField':
             kwargs['data-type'] = 'select'
+            kwargs['data-value'] = '1' if field.data else ''
             # data-source = dropdown options
             kwargs['data-source'] = json.dumps([
                 {'value': '', 'text': gettext('No')},

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -484,13 +484,11 @@
                 $el.editable({
                     params: overrideXeditableParams,
                     display: function(value, sourceData, response) {
-                       // display new boolean value as an icon
-                       if(response) {
-                           if(value == '1') {
-                               $(this).html('<span class="fa fa-check-circle glyphicon glyphicon-ok-circle icon-ok-circle"></span>');
-                           } else {
-                               $(this).html('<span class="fa fa-minus-circle glyphicon glyphicon-minus-sign icon-minus-sign"></span>');
-                           }
+                       // display boolean value as an icon
+                       if(value == '1') {
+                           $(this).html('<span class="fa fa-check-circle glyphicon glyphicon-ok-circle icon-ok-circle"></span>');
+                       } else {
+                           $(this).html('<span class="fa fa-minus-circle glyphicon glyphicon-minus-sign icon-minus-sign"></span>');
                        }
                     }
                 });


### PR DESCRIPTION
This PR fixes an issue where boolean fields editable on the list view do not render correctly on initial page load. (They show up as clickable links with el.innerText as "True" or "False", and once clicked, the popup form doesn't understand which value the row's item currently has.) This patch adds a `data-value` attribute so that the popup form knows which value the row's item has, and modifies the corresponding JavaScript so that it can render the field immediately as an icon.