### PR TITLE
The language attribute on the script element is obsolete. 

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/actions.html
+++ b/flask_admin/templates/bootstrap2/admin/actions.html
@@ -28,7 +28,7 @@
 {% macro script(message, actions, actions_confirmation) %}
     {% if actions %}
     <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
-    <script language="javascript">
+    <script>
         var modelActions = new AdminModelActions({{ message|tojson|safe }}, {{ actions_confirmation|tojson|safe }});
     </script>
     {% endif %}

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -186,7 +186,7 @@
                         actions,
                         actions_confirmation) }}
 
-    <script language="javascript">
+    <script>
         (function($) {
             $('[data-role=tooltip]').tooltip({
                 html: true,

--- a/flask_admin/templates/bootstrap2/admin/rediscli/console.html
+++ b/flask_admin/templates/bootstrap2/admin/rediscli/console.html
@@ -22,7 +22,7 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ admin_static.url(filename='admin/js/rediscli.js', v='1.0.0') }}"></script>
-  <script language="javascript">
+  <script>
     $(function() {
       var redisCli = new RedisCli({{ get_url('.execute_view')|tojson }});
     });

--- a/flask_admin/templates/bootstrap3/admin/actions.html
+++ b/flask_admin/templates/bootstrap3/admin/actions.html
@@ -28,7 +28,7 @@
 {% macro script(message, actions, actions_confirmation) %}
     {% if actions %}
     <script src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
-    <script language="javascript">
+    <script>
         var modelActions = new AdminModelActions({{ message|tojson|safe }}, {{ actions_confirmation|tojson|safe }});
     </script>
     {% endif %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -187,7 +187,7 @@
                         actions,
                         actions_confirmation) }}
 
-    <script language="javascript">
+    <script>
         (function($) {
             $('[data-role=tooltip]').tooltip({
                 html: true,

--- a/flask_admin/templates/bootstrap3/admin/rediscli/console.html
+++ b/flask_admin/templates/bootstrap3/admin/rediscli/console.html
@@ -22,7 +22,7 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ admin_static.url(filename='admin/js/rediscli.js', v='1.0.0') }}"></script>
-  <script language="javascript">
+  <script>
     $(function() {
       var redisCli = new RedisCli({{ admin_view.get_url('.execute_view')|tojson }});
     });


### PR DESCRIPTION
Very small change to conform to HTML standards.   Affects no functionality.  

This attribute `language` for <script> tags is obsolete and raises a *warning* with the W3C validator here:[https://validator.w3.org/nu/].  

It can safely be omitted as the default value for `type` is `text/javascript` and serves the same purpose.  

More info:
https://www.w3.org/TR/html5/scripting-1.html#attr-script-type