### PR TITLE
fileadmin: respect 'default_sort_column' and 'default_desc' view attributes

### DIFF
--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -818,8 +818,8 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             if self.is_accessible_path(rel_path):
                 items.append(item)
 
-        sort_column = request.args.get('sort', None, type=str)
-        sort_desc = request.args.get('desc', 0, type=int)
+        sort_column = request.args.get('sort', self.default_sort_column, type=str)
+        sort_desc = request.args.get('desc', self.default_desc, type=int)
 
         if sort_column is None:
             # Sort by name


### PR DESCRIPTION
Attributes `default_sort_column` and `default_desc` aren't actually used at the moment to set the default sort order of the list in fileadmin's index view.

This PR fixes this and adds tests.

Test `test_fileadmin_sort_default_sort_column` should fail with out this change.