### PR TITLE
fileadmin: catch error bogus 'sort' url param is passed 

### DIFF
--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -821,6 +821,11 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         sort_column = request.args.get('sort', None, type=str)
         sort_desc = request.args.get('desc', 0, type=int)
 
+        try:
+            column_index = self.possible_columns.index(sort_column)
+        except ValueError:
+            sort_column = self.default_sort_column
+
         if sort_column is None:
             # Sort by name
             items.sort(key=itemgetter(0))
@@ -829,7 +834,6 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             # Sort by modified date
             items.sort(key=lambda x: (x[0], x[1], x[2], x[3], datetime.fromtimestamp(x[4])), reverse=True)
         else:
-            column_index = self.possible_columns.index(sort_column)
             items.sort(key=itemgetter(column_index), reverse=sort_desc)
 
         # Generate breadcrumbs

--- a/flask_admin/tests/fileadmin/test_fileadmin.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin.py
@@ -1,6 +1,7 @@
+import os
 import os.path as op
 
-from nose.tools import eq_, ok_
+from nose.tools import eq_, ok_, with_setup
 
 from flask_admin.contrib import fileadmin
 from flask_admin import Admin
@@ -133,6 +134,35 @@ def test_file_admin():
     eq_(rv.status_code, 200)
     ok_('path=dummy_renamed_dir' not in rv.data.decode('utf-8'))
     ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+
+
+def add_file():
+    # make sure that 'files/dummy2.txt' exists, is newest and has bigger size
+    with open(op.join(op.dirname(__file__), 'files', 'dummy2.txt'), 'w') as fp:
+        fp.write('test')
+
+
+def remove_file():
+    try:
+        os.remove(op.join(op.dirname(__file__), 'files', 'dummy2.txt'))
+    except (IOError, OSError):
+        pass
+
+
+@with_setup(add_file, remove_file)
+def test_fileadmin_sort_bogus_url_param():
+    app, admin, view = create_view()
+    client = app.test_client()
+
+    rv = client.get('/admin/myfileadmin/?sort=bogus')
+    eq_(rv.status_code, 200)
+    ok_(rv.data.decode('utf-8').find('path=dummy2.txt') <
+        rv.data.decode('utf-8').find('path=dummy.txt'))
+
+    rv = client.get('/admin/myfileadmin/?sort=name')
+    eq_(rv.status_code, 200)
+    ok_(rv.data.decode('utf-8').find('path=dummy.txt') <
+        rv.data.decode('utf-8').find('path=dummy2.txt'))
 
 
 def test_modal_edit():


### PR DESCRIPTION
… and preserve default sort order

When a value for the `sort` url param is passed to fileadmin's index view that doesn't correspond to a valid column name, `ValueError` is  raised.

This PR catches that and sets the  `sort_column` to the value of the  `default_sort_column` vie wattribute.

Tests added, which fail with an error without this change, due to the `ValueError` raised.