### PR TITLE
Fixed x-editable does not show completely in bootstrap's responsive table

### DIFF
--- a/flask_admin/static/admin/css/bootstrap2/admin.css
+++ b/flask_admin/static/admin/css/bootstrap2/admin.css
@@ -28,7 +28,7 @@
 
 /* List View - fix gap between actions and table */
 .model-list  {
-    position: relative;
+    position: static;
     margin-top: -1px;
     z-index: 999;
 }

--- a/flask_admin/static/admin/css/bootstrap3/admin.css
+++ b/flask_admin/static/admin/css/bootstrap3/admin.css
@@ -28,7 +28,7 @@
 
 /* List View - fix overlapping border between actions and table */
 .model-list  {
-    position: relative;
+    position: static;
     margin-top: -1px;
     z-index: 999;
 }


### PR DESCRIPTION
Try to fix #1570 

There is two way to fix this. By updating ```table-responsive``` overflow field to ```overflow:hidden``` instead of ```overflow:auto```. But this will make table non-responsive.

So I choose the second way by modifying popup's parent's position to ```static```.

Here is the views in boostrap2 and bootstrap3 mode.

![image](https://user-images.githubusercontent.com/1401630/33597535-ae5c255a-d9da-11e7-8542-475d7af3b3b4.png)
![image](https://user-images.githubusercontent.com/1401630/33597579-d2ad2436-d9da-11e7-9f8c-2446d20627d8.png)


