### PR TITLE
remove identity_token from fields.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: false
 language: python
 matrix:
   include:
-    - python: 2.6
-      env: TOX_ENV=py26-WTForms1
-    - python: 2.6
-      env: TOX_ENV=py26-WTForms2
     - python: 2.7
       env: TOX_ENV=py27-WTForms1
     - python: 2.7

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -295,6 +295,5 @@ class InlineModelFormList(InlineFieldList):
 
 
 def get_pk_from_identity(obj):
-    # TODO: Remove me
-    cls, key = identity_key(instance=obj)
+    key = obj.__mapper__.primary_key_from_instance(instance=obj)
     return u':'.join(text_type(x) for x in key)

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -17,6 +17,7 @@ from flask_admin.form import FormOpts, BaseForm, Select2Widget
 from flask_admin.model.fields import InlineFieldList, InlineModelFormField
 from flask_admin.babel import lazy_gettext
 
+
 class QuerySelectField(SelectFieldBase):
     """
     Will display a select drop-down field to choose between ORM results in a

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -17,13 +17,6 @@ from flask_admin.form import FormOpts, BaseForm, Select2Widget
 from flask_admin.model.fields import InlineFieldList, InlineModelFormField
 from flask_admin.babel import lazy_gettext
 
-try:
-    from sqlalchemy.orm.util import identity_key
-    has_identity_key = True
-except ImportError:
-    has_identity_key = False
-
-
 class QuerySelectField(SelectFieldBase):
     """
     Will display a select drop-down field to choose between ORM results in a
@@ -63,8 +56,6 @@ class QuerySelectField(SelectFieldBase):
         self.query_factory = query_factory
 
         if get_pk is None:
-            if not has_identity_key:
-                raise Exception(u'The sqlalchemy identity_key function could not be imported.')
             self.get_pk = get_pk_from_identity
         else:
             self.get_pk = get_pk

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34,35,36}-WTForms{1,2}
+    py{27,33,34,35,36}-WTForms{1,2}
     flake8
     docs-html
 skipsdist = true


### PR DESCRIPTION
On the method `get_pk_from_identity`, replace the `identity_token` method by `__mapper__.primary_key_from_instance`, that returns only the primary_key, in an attempt to solve issue #1583