### PR TITLE
Change fields.py to be compatible with SQLAlchemy>=1.2

### DIFF
--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -296,5 +296,5 @@ class InlineModelFormList(InlineFieldList):
 
 def get_pk_from_identity(obj):
     # TODO: Remove me
-    cls, key = identity_key(instance=obj)
+    cls, key, *token = identity_key(instance=obj)
     return u':'.join(text_type(x) for x in key)

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -296,5 +296,5 @@ class InlineModelFormList(InlineFieldList):
 
 def get_pk_from_identity(obj):
     # TODO: Remove me
-    cls, key, *token = identity_key(instance=obj)
+    key = identity_key(instance=obj)[1]
     return u':'.join(text_type(x) for x in key)


### PR DESCRIPTION
SQLAlchemy 1.2 added a third return value to identity_key, which broke this line. It was added as an optional return value. 