### PR TITLE
Fix #675: Multi column support for column_default_sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: false
 language: python
 matrix:
   include:
-    - python: 2.6
-      env: TOX_ENV=py26-WTForms1
-    - python: 2.6
-      env: TOX_ENV=py26-WTForms2
     - python: 2.7
       env: TOX_ENV=py27-WTForms1
     - python: 2.7

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -520,7 +520,9 @@ class ModelView(BaseModelView):
             order = self._get_default_order()
 
             if order:
-                query = query.order_by('%s%s' % ('-' if order[1] else '', order[0]))
+                keys = ['%s%s' % ('-' if desc else '', col)
+                        for (desc, col) in order]
+                query = query.order_by(*keys)
 
         # Pagination
         if page_size is None:

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -521,7 +521,7 @@ class ModelView(BaseModelView):
 
             if order:
                 keys = ['%s%s' % ('-' if desc else '', col)
-                        for (desc, col) in order]
+                        for (col, desc) in order]
                 query = query.order_by(*keys)
 
         # Pagination

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -316,17 +316,24 @@ class ModelView(BaseModelView):
 
         return query
 
-    def _order_by(self, query, joins, sort_field, sort_desc):
+    def _order_by(self, query, joins, order):
+        clauses = []
+        for sort_field, sort_desc in order:
+            query, joins, clause = self._sort_clause(
+                query, joins, sort_field, sort_desc)
+            clauses.append(clause)
+        query = query.order_by(*clauses)
+        return query, joins
+
+    def _sort_clause(self, query, joins, sort_field, sort_desc):
         if isinstance(sort_field, string_types):
             field = getattr(self.model, sort_field)
-            query = query.order_by(field.desc() if sort_desc else field.asc())
+            clause = field.desc() if sort_desc else field.asc()
         elif isinstance(sort_field, Field):
             if sort_field.model_class != self.model:
                 query = self._handle_join(query, sort_field, joins)
-
-            query = query.order_by(sort_field.desc() if sort_desc else sort_field.asc())
-
-        return query, joins
+            clause = sort_field.desc() if sort_desc else sort_field.asc()
+        return query, joins, clause
 
     def get_query(self):
         return self.model.select()
@@ -395,13 +402,12 @@ class ModelView(BaseModelView):
         # Apply sorting
         if sort_column is not None:
             sort_field = self._sortable_columns[sort_column]
-
-            query, joins = self._order_by(query, joins, sort_field, sort_desc)
+            order = [(sort_field, sort_desc)]
+            query, joins = self._order_by(query, joins, order)
         else:
             order = self._get_default_order()
-
             if order:
-                query, joins = self._order_by(query, joins, order[0], order[1])
+                query, joins = self._order_by(query, joins, order)
 
         # Pagination
         if page_size is None:

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -328,11 +328,11 @@ class ModelView(BaseModelView):
     def _sort_clause(self, query, joins, sort_field, sort_desc):
         if isinstance(sort_field, string_types):
             field = getattr(self.model, sort_field)
-            clause = field.desc() if sort_desc else field.asc()
         elif isinstance(sort_field, Field):
             if sort_field.model_class != self.model:
                 query = self._handle_join(query, sort_field, joins)
-            clause = sort_field.desc() if sort_desc else sort_field.asc()
+            field = sort_field
+        clause = field.desc() if sort_desc else field.asc()
         return query, joins, clause
 
     def get_query(self):

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -262,7 +262,8 @@ class ModelView(BaseModelView):
             order = self._get_default_order()
 
             if order:
-                sort_by = [(order[0], pymongo.DESCENDING if order[1] else pymongo.ASCENDING)]
+                sort_by = [(col, pymongo.DESCENDING if desc else pymongo.ASCENDING)
+                           for (col, desc) in order]
 
         # Pagination
         if page_size is None:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -842,15 +842,9 @@ class ModelView(BaseModelView):
 
     def _get_default_order(self):
         order = super(ModelView, self)._get_default_order()
-
-        if order is not None:
-            field, direction = order
-
+        for field, direction in (order or []):
             attr, joins = tools.get_field_with_path(self.model, field)
-
-            return attr, joins, direction
-
-        return None
+            yield attr, joins, direction
 
     def _apply_sorting(self, query, joins, sort_column, sort_desc):
         if sort_column is not None:
@@ -861,10 +855,7 @@ class ModelView(BaseModelView):
                 query, joins = self._order_by(query, joins, sort_joins, sort_field, sort_desc)
         else:
             order = self._get_default_order()
-
-            if order:
-                sort_field, sort_joins, sort_desc = order
-
+            for sort_field, sort_joins, sort_desc in order:
                 query, joins = self._order_by(query, joins, sort_joins, sort_field, sort_desc)
 
         return query, joins

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -381,6 +381,12 @@ class BaseModelView(BaseView, ActionsMixin):
 
             class MyModelView(BaseModelView):
                 column_default_sort = ('user', True)
+
+        If you want to sort by more than one column,
+        you can pass a list of tuples::
+
+            class MyModelView(BaseModelView):
+                column_default_sort = [('name', True), ('last_name', True)]
     """
 
     column_searchable_list = ObsoleteAttr('column_searchable_list',
@@ -1435,10 +1441,12 @@ class BaseModelView(BaseView, ActionsMixin):
             Return default sort order
         """
         if self.column_default_sort:
-            if isinstance(self.column_default_sort, tuple):
+            if isinstance(self.column_default_sort, list):
                 return self.column_default_sort
+            if isinstance(self.column_default_sort, tuple):
+                return [self.column_default_sort]
             else:
-                return self.column_default_sort, False
+                return [(self.column_default_sort, False)]
 
         return None
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -685,9 +685,9 @@ def test_default_sort():
     app, db, admin = setup()
     M1, _ = create_models(db)
 
-    M1(test1='c').save()
-    M1(test1='b').save()
-    M1(test1='a').save()
+    M1(test1='c', test2='x').save()
+    M1(test1='b', test2='x').save()
+    M1(test1='a', test2='y').save()
 
     eq_(M1.objects.count(), 3)
 
@@ -699,6 +699,18 @@ def test_default_sort():
     eq_(data[0].test1, 'a')
     eq_(data[1].test1, 'b')
     eq_(data[2].test1, 'c')
+
+    # test default sort with multiple columns
+    order = [('test2', False), ('test1', False)]
+    view2 = CustomModelView(M1, column_default_sort=order, endpoint='m1_2')
+    admin.add_view(view2)
+
+    _, data = view2.get_list(0, None, None, None, None)
+
+    eq_(len(data), 3)
+    eq_(data[0].test1, 'b')
+    eq_(data[1].test1, 'c')
+    eq_(data[2].test1, 'a')
 
 
 def test_extra_fields():

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -870,8 +870,8 @@ def test_default_sort():
     M1, _ = create_models(db)
 
     M1('c', 1).save()
-    M1('b', 2).save()
-    M1('a', 3).save()
+    M1('b', 1).save()
+    M1('a', 2).save()
 
     eq_(M1.select().count(), 3)
 
@@ -883,6 +883,18 @@ def test_default_sort():
     eq_(data[0].test1, 'a')
     eq_(data[1].test1, 'b')
     eq_(data[2].test1, 'c')
+
+    # test default sort with multiple columns
+    order = [('test2', False), ('test1', False)]
+    view2 = CustomModelView(M1, column_default_sort=order, endpoint='m1_2')
+    admin.add_view(view2)
+
+    _, data = view2.get_list(0, None, None, None, None)
+
+    eq_(len(data), 3)
+    eq_(data[0].test1, 'b')
+    eq_(data[1].test1, 'c')
+    eq_(data[2].test1, 'a')
 
 
 def test_extra_fields():

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -1676,7 +1676,7 @@ def test_default_sort():
     app, db, admin = setup()
     M1, _ = create_models(db)
 
-    db.session.add_all([M1('c'), M1('b'), M1('a')])
+    db.session.add_all([M1('c', 'x'), M1('b', 'x'), M1('a', 'y')])
     db.session.commit()
     eq_(M1.query.count(), 3)
 
@@ -1714,6 +1714,18 @@ def test_default_sort():
     eq_(data[0].test1, 'a')
     eq_(data[1].test1, 'b')
     eq_(data[2].test1, 'c')
+
+    # test default sort with multiple columns
+    order = [('test2', False), ('test1', False)]
+    view4 = CustomModelView(M1, db.session, column_default_sort=order, endpoint='m1_4')
+    admin.add_view(view4)
+
+    _, data = view4.get_list(0, None, None, None, None)
+
+    eq_(len(data), 3)
+    eq_(data[0].test1, 'b')
+    eq_(data[1].test1, 'c')
+    eq_(data[2].test1, 'a')
 
 
 def test_complex_sort():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34,35,36}-WTForms{1,2}
+    py{27,33,34,35,36}-WTForms{1,2}
     flake8
     docs-html
 skipsdist = true


### PR DESCRIPTION
Fixes #675 

TODO:

- [x] Make sure mongo and postgres tests pass
- [x] Add at least one new test with more than one column