### PR TITLE
BaseModel changed to ModelBase in newer versions of peewee

### DIFF
--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -1,7 +1,7 @@
 from wtforms import fields
 
 from peewee import (CharField, DateTimeField, DateField, TimeField,
-                    PrimaryKeyField, ForeignKeyField, BaseModel)
+                    PrimaryKeyField, ForeignKeyField, ModelBase)
 
 from wtfpeewee.orm import ModelConverter, model_form
 
@@ -189,7 +189,7 @@ class InlineModelConverter(InlineModelConverterBase):
         info = super(InlineModelConverter, self).get_info(p)
 
         if info is None:
-            if isinstance(p, BaseModel):
+            if isinstance(p, ModelBase):
                 info = InlineFormAdmin(p)
             else:
                 model = getattr(p, 'model', None)


### PR DESCRIPTION
Starting from peewee version 3, BaseModel is called ModelBase.