### PR TITLE
Make the Select2Field coerce enum values to their name as required.

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -1,4 +1,5 @@
 import warnings
+from enum import Enum
 
 from wtforms import fields, validators
 from sqlalchemy import Boolean, Column
@@ -9,7 +10,7 @@ from flask_admin.model.form import (converts, ModelConverterBase,
 from flask_admin.model.fields import AjaxSelectField, AjaxSelectMultipleField
 from flask_admin.model.helpers import prettify_name
 from flask_admin._backwards import get_property
-from flask_admin._compat import iteritems
+from flask_admin._compat import iteritems, text_type
 
 from .validators import Unique
 from .fields import (QuerySelectField, QuerySelectMultipleField,
@@ -281,6 +282,7 @@ class AdminModelConverter(ModelConverterBase):
                 accepted_values.append(None)
 
             field_args['validators'].append(validators.AnyOf(accepted_values))
+            field_args['coerce'] = lambda v: v.name if isinstance(v, Enum) else text_type(v)
 
             return form.Select2Field(**field_args)
 


### PR DESCRIPTION
When an [SQLAlchemy Enum](http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Enum) column is used: 

``` python
class Seasons(Enum):
    winter = 1
    spring = 2
    summer = 3
    autumn = 4

class MyModel(db.Model):
    id = db.Column(db.Integer, primary_key=True)
    season = db.Column(db.Enum(Seasons), nullable=False)
```
When a model is edited, the value selected by **Select2** is **not** the real value of the model but the first enum value instead. As a result, every time an edit is made to a model that has one or more enum columns, the user will reset the enum value without realizing.

The first enum value is selected instead of the real one because `Select2Field` is coercing enum values to `_compat.text_type` (`str` for python 2 and `unicode` for python 3) instead of coercing the name of the enum value (coercing to `Seasons.summer` instead of `summer` for example).

Fixes #1315.