### PR TITLE
Added formatters for detail view (fixes #1487)

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -263,6 +263,16 @@ class BaseModelView(BaseView, ActionsMixin):
         that macros are not supported.
     """
 
+    column_formatters_detail = None
+    """
+        Dictionary of list view column formatters to be used for the detail view.
+
+        Defaults to column_formatters when set to None.
+
+        Functions the same way as column_formatters except
+        that macros are not supported.
+    """
+
     column_type_formatters = ObsoleteAttr('column_type_formatters', 'list_type_formatters', None)
     """
         Dictionary of value type formatters to be used in the list view.
@@ -310,6 +320,18 @@ class BaseModelView(BaseView, ActionsMixin):
     column_type_formatters_export = None
     """
         Dictionary of value type formatters to be used in the export.
+
+        By default, two types are formatted:
+
+        1. ``None`` will be displayed as an empty string
+        2. ``list`` will be joined using ', '
+
+        Functions the same way as column_type_formatters.
+    """
+
+    column_type_formatters_detail = None
+    """
+        Dictionary of value type formatters to be used in the detail view.
 
         By default, two types are formatted:
 
@@ -889,12 +911,18 @@ class BaseModelView(BaseView, ActionsMixin):
         if self.column_formatters_export is None:
             self.column_formatters_export = self.column_formatters
 
+        if self.column_formatters_detail is None:
+            self.column_formatters_detail = self.column_formatters
+
         # Type formatters
         if self.column_type_formatters is None:
             self.column_type_formatters = dict(typefmt.BASE_FORMATTERS)
 
         if self.column_type_formatters_export is None:
             self.column_type_formatters_export = dict(typefmt.EXPORT_FORMATTERS)
+
+        if self.column_type_formatters_detail is None:
+            self.column_type_formatters_detail = dict(typefmt.DETAIL_FORMATTERS)
 
         if self.column_descriptions is None:
             self.column_descriptions = dict()
@@ -1803,6 +1831,26 @@ class BaseModelView(BaseView, ActionsMixin):
             self.column_type_formatters,
         )
 
+    @contextfunction
+    def get_detail_value(self, context, model, name):
+        """
+            Returns the value to be displayed in the detail view
+
+            :param context:
+                :py:class:`jinja2.runtime.Context`
+            :param model:
+                Model instance
+            :param name:
+                Field name
+        """
+        return self._get_list_value(
+            context,
+            model,
+            name,
+            self.column_formatters_detail,
+            self.column_type_formatters_detail,
+        )
+
     def get_export_value(self, model, name):
         """
             Returns the value to be displayed in export.
@@ -2103,7 +2151,7 @@ class BaseModelView(BaseView, ActionsMixin):
         return self.render(template,
                            model=model,
                            details_columns=self._details_columns,
-                           get_value=self.get_list_value,
+                           get_value=self.get_detail_value,
                            return_url=return_url)
 
     @expose('/delete/', methods=('POST',))

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -84,6 +84,13 @@ EXPORT_FORMATTERS = {
     dict: dict_formatter,
 }
 
+DETAIL_FORMATTERS = {
+    type(None): empty_formatter,
+    list: list_formatter,
+    dict: dict_formatter,
+}
+
 if Enum is not None:
     BASE_FORMATTERS[Enum] = enum_formatter
     EXPORT_FORMATTERS[Enum] = enum_formatter
+    DETAIL_FORMATTERS[Enum] = enum_formatter


### PR DESCRIPTION
I have implemented formatters for the detail views (by looking at how export formatters are implemented).

So now it's for instance possible to have a formatter in the list view that shows only a preview of a field and then the full data in the details view.