### PR TITLE
added custom tilelayers leaflet

### DIFF
--- a/flask_admin/contrib/geoa/fields.py
+++ b/flask_admin/contrib/geoa/fields.py
@@ -8,10 +8,14 @@ from .widgets import LeafletWidget
 
 
 class GeoJSONField(JSONField):
-    widget = LeafletWidget()
 
     def __init__(self, label=None, validators=None, geometry_type="GEOMETRY",
-                 srid='-1', session=None, **kwargs):
+                 srid='-1', session=None, tile_layer_url=None,
+                 tile_layer_attribution=None, **kwargs):
+        self.widget = LeafletWidget(
+            tile_layer_url=tile_layer_url,
+            tile_layer_attribution=tile_layer_attribution
+        )
         super(GeoJSONField, self).__init__(label, validators, **kwargs)
         self.web_srid = 4326
         self.srid = srid

--- a/flask_admin/contrib/geoa/form.py
+++ b/flask_admin/contrib/geoa/form.py
@@ -9,4 +9,6 @@ class AdminModelConverter(SQLAAdminConverter):
         field_args['geometry_type'] = column.type.geometry_type
         field_args['srid'] = column.type.srid
         field_args['session'] = self.session
+        field_args['tile_layer_url'] = self.view.tile_layer_url
+        field_args['tile_layer_attribution'] = self.view.tile_layer_attribution
         return GeoJSONField(**field_args)

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -14,6 +14,8 @@ def geom_formatter(view, value):
         "data-height": 70,
         "data-geometry-type": to_shape(value).geom_type,
         "data-zoom": 15,
+        "data-tile-layer-url": view.tile_layer_url,
+        "data-tile-layer-attribution": view.tile_layer_attribution
     })
     if value.srid is -1:
         value.srid = 4326

--- a/flask_admin/contrib/geoa/view.py
+++ b/flask_admin/contrib/geoa/view.py
@@ -5,3 +5,5 @@ from flask_admin.contrib.geoa import form, typefmt
 class ModelView(SQLAModelView):
     model_form_converter = form.AdminModelConverter
     column_type_formatters = typefmt.DEFAULT_FORMATTERS
+    tile_layer_url = None
+    tile_layer_attribution = None

--- a/flask_admin/contrib/geoa/widgets.py
+++ b/flask_admin/contrib/geoa/widgets.py
@@ -23,7 +23,8 @@ class LeafletWidget(TextArea):
     """
     def __init__(
             self, width='auto', height=350, center=None,
-            zoom=None, min_zoom=None, max_zoom=None, max_bounds=None):
+            zoom=None, min_zoom=None, max_zoom=None, max_bounds=None,
+            tile_layer_url=None, tile_layer_attribution=None):
         self.width = width
         self.height = height
         self.center = center
@@ -31,6 +32,8 @@ class LeafletWidget(TextArea):
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
         self.max_bounds = max_bounds
+        self.tile_layer_url = tile_layer_url
+        self.tile_layer_attribution = tile_layer_attribution
 
     def __call__(self, field, **kwargs):
         kwargs.setdefault('data-role', self.data_role)
@@ -38,6 +41,10 @@ class LeafletWidget(TextArea):
         kwargs.setdefault('data-geometry-type', gtype)
 
         # set optional values from constructor
+        if self.tile_layer_url:
+            kwargs['data-tile-layer-url'] = self.tile_layer_url
+        if self.tile_layer_attribution:
+            kwargs['data-tile-layer-attribution'] = self.tile_layer_attribution
         if "data-width" not in kwargs:
             kwargs["data-width"] = self.width
         if "data-height" not in kwargs:

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -157,11 +157,19 @@
         }
 
         // set up tiles
-        var mapboxVersion = window.MAPBOX_ACCESS_TOKEN ? 4 : 3;
-        L.tileLayer('//{s}.tiles.mapbox.com/v'+mapboxVersion+'/'+MAPBOX_MAP_ID+'/{z}/{x}/{y}.png?access_token='+window.MAPBOX_ACCESS_TOKEN, {
-          attribution: 'Map data &copy; <a href="//openstreetmap.org">OpenStreetMap</a> contributors, <a href="//creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="//mapbox.com">Mapbox</a>',
-          maxZoom: 18
-        }).addTo(map);
+        if($el.data('tile-layer-url')){
+          var attribution = $el.data('tile-layer-attribution') || ''
+          L.tileLayer('//'+$el.data('tile-layer-url'), {
+            attribution: attribution,
+            maxZoom: 18
+          }).addTo(map)
+        } else {
+          var mapboxVersion = window.MAPBOX_ACCESS_TOKEN ? 4 : 3;
+          L.tileLayer('//{s}.tiles.mapbox.com/v'+mapboxVersion+'/'+MAPBOX_MAP_ID+'/{z}/{x}/{y}.png?access_token='+window.MAPBOX_ACCESS_TOKEN, {
+            attribution: 'Map data &copy; <a href="//openstreetmap.org">OpenStreetMap</a> contributors, <a href="//creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="//mapbox.com">Mapbox</a>',
+            maxZoom: 18
+          }).addTo(map);
+        }
 
 
         // everything below here is to set up editing, so if we're not editable,


### PR DESCRIPTION
As stated [here](https://flask-admin.readthedocs.io/en/v1.0.9/db_geoa/#getting-started), support for different tile layers was still lacking. 

I needed this feature, so I implemented it. 
 
The geoa example can be adjusted to for instance:

```
class CustomTileView(ModelView):
    tile_layer_url = 'a.tile.openstreetmap.org/{z}/{x}/{y}.png'
    tile_layer_attribution = 'some string or html goes here'

admin.add_view(CustomTileView(Point, db.session, category='Points'))
```

This also leads to the situation where a mapbox key and account are no longer needed to get functioning maps in your admin interface, although I didn't change the logic behind requirements. 
