### PR TITLE
Fixing ajax casting

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -1,4 +1,5 @@
-from sqlalchemy import or_, and_
+from sqlalchemy import or_, and_, cast
+from sqlalchemy.types import String
 
 from flask_admin._compat import as_unicode, string_types
 from flask_admin.model.ajax import AjaxModelLoader, DEFAULT_PAGE_SIZE
@@ -65,7 +66,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
     def get_list(self, term, offset=0, limit=DEFAULT_PAGE_SIZE):
         query = self.session.query(self.model)
 
-        filters = (field.ilike(u'%%%s%%' % term) for field in self._cached_fields)
+        filters = (cast(field, String).ilike(u'%%%s%%' % term) for field in self._cached_fields)
         query = query.filter(or_(*filters))
 
         if self.filters:


### PR DESCRIPTION
Right now, Ajax was not able to search for an integer for example. It was a problem for id fields.
This makes sure ILIKE will work with such field.