### PR TITLE
Mongoengine model converter fix

### DIFF
--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -11,6 +11,7 @@ from flask_admin._compat import iteritems
 
 from .fields import ModelFormField, MongoFileField, MongoImageField
 from .subdoc import EmbeddedForm
+from .validators import ListFieldInputRequired
 
 
 class CustomModelConverter(orm.ModelConverter):
@@ -74,7 +75,10 @@ class CustomModelConverter(orm.ModelConverter):
             kwargs['validators'] = list(kwargs['validators'])
 
         if field.required:
-            kwargs['validators'].append(validators.InputRequired())
+            if isinstance(field, ListField):
+                kwargs['validators'].append(ListFieldInputRequired())
+            else:
+                kwargs['validators'].append(validators.InputRequired())
         elif not isinstance(field, ListField):
             kwargs['validators'].append(validators.Optional())
 

--- a/flask_admin/contrib/mongoengine/form.py
+++ b/flask_admin/contrib/mongoengine/form.py
@@ -7,11 +7,11 @@ from flask_mongoengine.wtf import orm, fields as mongo_fields
 from flask_admin import form
 from flask_admin.model.form import FieldPlaceholder
 from flask_admin.model.fields import InlineFieldList, AjaxSelectField, AjaxSelectMultipleField
+from flask_admin.form.validators import FieldListInputRequired
 from flask_admin._compat import iteritems
 
 from .fields import ModelFormField, MongoFileField, MongoImageField
 from .subdoc import EmbeddedForm
-from .validators import ListFieldInputRequired
 
 
 class CustomModelConverter(orm.ModelConverter):
@@ -76,7 +76,7 @@ class CustomModelConverter(orm.ModelConverter):
 
         if field.required:
             if isinstance(field, ListField):
-                kwargs['validators'].append(ListFieldInputRequired())
+                kwargs['validators'].append(FieldListInputRequired())
             else:
                 kwargs['validators'].append(validators.InputRequired())
         elif not isinstance(field, ListField):

--- a/flask_admin/contrib/mongoengine/validators.py
+++ b/flask_admin/contrib/mongoengine/validators.py
@@ -1,0 +1,12 @@
+from wtforms.validators import StopValidation
+
+
+class ListFieldInputRequired(object):
+    """ Validates that at least one item was provided for a ListField to match """
+
+    field_flags = ('required',)
+
+    def __call__(self, form, field):
+        if len(field.entries) == 0:
+            field.errors[:] = []
+            raise StopValidation('This field requires at least one item')

--- a/flask_admin/form/validators.py
+++ b/flask_admin/form/validators.py
@@ -1,8 +1,8 @@
 from wtforms.validators import StopValidation
 
 
-class ListFieldInputRequired(object):
-    """ Validates that at least one item was provided for a ListField to match """
+class FieldListInputRequired(object):
+    """Validates that at least one item was provided for a FieldList"""
 
     field_flags = ('required',)
 

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -2,7 +2,7 @@ from re import sub
 from jinja2 import contextfunction
 from flask import g, request, url_for, flash
 from wtforms.validators import DataRequired, InputRequired
-from contrib.mongoengine.validators import ListFieldInputRequired
+from flask_admin.contrib.mongoengine.validators import ListFieldInputRequired
 
 from flask_admin._compat import urljoin, urlparse, iteritems
 

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -10,6 +10,7 @@ from ._compat import string_types
 
 REQUIRED_VALIDATORS = {DataRequired, InputRequired, FieldListInputRequired}
 
+
 def set_current_view(view):
     g._admin_view = view
 

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -2,12 +2,13 @@ from re import sub
 from jinja2 import contextfunction
 from flask import g, request, url_for, flash
 from wtforms.validators import DataRequired, InputRequired
-from flask_admin.contrib.mongoengine.validators import ListFieldInputRequired
+from flask_admin.form.validators import FieldListInputRequired
 
 from flask_admin._compat import urljoin, urlparse, iteritems
 
 from ._compat import string_types
 
+REQUIRED_VALIDATORS = {DataRequired, InputRequired, FieldListInputRequired}
 
 def set_current_view(view):
     g._admin_view = view
@@ -41,15 +42,13 @@ def get_url(endpoint, **kwargs):
 
 def is_required_form_field(field):
     """
-        Check if form field has `DataRequired` or `InputRequired` validators.
+        Check if form field has `DataRequired`, `InputRequired`, or
+        `FieldListInputRequired` validators.
 
         :param field:
             WTForms field to check
     """
-    for validator in field.validators:
-        if isinstance(validator, (DataRequired, InputRequired, ListFieldInputRequired)):
-            return True
-    return False
+    return any(type(v) in REQUIRED_VALIDATORS for v in field.validators)
 
 
 def is_form_submitted():

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -2,6 +2,7 @@ from re import sub
 from jinja2 import contextfunction
 from flask import g, request, url_for, flash
 from wtforms.validators import DataRequired, InputRequired
+from contrib.mongoengine.validators import ListFieldInputRequired
 
 from flask_admin._compat import urljoin, urlparse, iteritems
 
@@ -46,7 +47,7 @@ def is_required_form_field(field):
             WTForms field to check
     """
     for validator in field.validators:
-        if isinstance(validator, (DataRequired, InputRequired)):
+        if isinstance(validator, (DataRequired, InputRequired, ListFieldInputRequired)):
             return True
     return False
 


### PR DESCRIPTION
Modify `CustomModelConverter` for mongoengine to use new `ListFieldInputRequired` validator for mongoengine `ListField`s with `required=True`

[#1671](https://github.com/flask-admin/flask-admin/issues/1671)