### PR TITLE
Fix typo in templating example

### DIFF
--- a/examples/layout/templates/list.html
+++ b/examples/layout/templates/list.html
@@ -1,7 +1,7 @@
 {% extends 'admin/model/list.html' %}
 {% import 'admin/model/layout.html' as model_layout with context %}
 
-{% block brand %}
+{% block model_menu_bar %}
     <h2 id="brand">{{ admin_view.name|capitalize }} list</h2>
     {% if admin_view.can_create %}
     <div class="btn-menu">
@@ -28,7 +28,4 @@
     {% endif %}
     <div class="clearfix"></div>
     <hr>
-{% endblock %}
-
-{% block model_menu_bar %}
 {% endblock %}


### PR DESCRIPTION
I think you want the menu of the list view to be in the `model_menu_bar` block, not to override the `brand` block