### PR TITLE
Add file-admin based on Azure Blob Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,13 @@ addons:
 services:
   - postgresql
   - mongodb
+  - docker
 
 before_script:
   - psql -U postgres -c 'CREATE DATABASE flask_admin_test;'
   - psql -U postgres -c 'CREATE EXTENSION postgis;' flask_admin_test
   - psql -U postgres -c 'CREATE EXTENSION hstore;' flask_admin_test
+  - docker run --restart always -d -e executable=blob -p 10000:10000 --tmpfs /opt/azurite/folder arafato/azurite:2.6.5
 
 install:
   - pip install tox

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -822,12 +822,9 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         sort_desc = request.args.get('desc', 0, type=int)
 
         if sort_column is None:
-            # Sort by name
-            items.sort(key=itemgetter(0))
-            # Sort by type
-            items.sort(key=itemgetter(2), reverse=True)
-            # Sort by modified date
-            items.sort(key=lambda x: (x[0], x[1], x[2], x[3], datetime.fromtimestamp(x[4])), reverse=True)
+            items.sort(key=self._sort_by_name_key)
+            items.sort(key=self._sort_by_type_key, reverse=True)
+            items.sort(key=self._sort_by_modified_date_key, reverse=True)
         else:
             column_index = self.possible_columns.index(sort_column)
             items.sort(key=itemgetter(column_index), reverse=sort_desc)
@@ -864,6 +861,13 @@ class BaseFileAdmin(BaseView, ActionsMixin):
                            sort_desc=sort_desc,
                            sort_url=sort_url,
                            timestamp_format=self.timestamp_format)
+
+    _sort_by_name_key = itemgetter(0)
+    _sort_by_type_key = itemgetter(2)
+
+    @staticmethod
+    def _sort_by_modified_date_key(x):
+        return x[4] if x[4] > 0 else float('inf')
 
     @expose('/upload/', methods=('GET', 'POST'))
     @expose('/upload/<path:path>', methods=('GET', 'POST'))

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -107,6 +107,20 @@ class LocalFileStorage(object):
         """
         return send_file(file_path)
 
+    def read_file(self, path):
+        """
+            Reads the content of the file located at `file_path`.
+        """
+        with open(path, 'rb') as f:
+            return f.read()
+
+    def write_file(self, path, content):
+        """
+            Writes `content` to the file located at `file_path`.
+        """
+        with open(path, 'w') as f:
+            return f.write(content)
+
     def save_file(self, path, file_data):
         """
             Save uploaded file to the disk
@@ -1113,8 +1127,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             form.process(request.form, content='')
             if form.validate():
                 try:
-                    with open(full_path, 'w') as f:
-                        f.write(request.form['content'])
+                    self.storage.write_file(full_path, request.form['content'])
                 except IOError:
                     flash(gettext("Error saving changes to %(name)s.", name=path), 'error')
                     error = True
@@ -1126,8 +1139,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             helpers.flash_errors(form, message='Failed to edit file. %(error)s')
 
             try:
-                with open(full_path, 'rb') as f:
-                    content = f.read()
+                content = self.storage.read_file(full_path)
             except IOError:
                 flash(gettext("Error reading %(name)s.", name=path), 'error')
                 error = True

--- a/flask_admin/contrib/fileadmin/azure.py
+++ b/flask_admin/contrib/fileadmin/azure.py
@@ -1,0 +1,264 @@
+from __future__ import absolute_import
+from datetime import datetime
+from datetime import timedelta
+from time import sleep
+import os.path as op
+
+try:
+    from azure.storage.blob import BlobPermissions
+    from azure.storage.blob import BlockBlobService
+except ImportError:
+    BlobPermissions = BlockBlobService = None
+
+from flask import redirect
+
+from . import BaseFileAdmin
+
+
+class AzureStorage(object):
+    """
+        Storage object representing files on an Azure Storage container.
+
+        Usage::
+
+            from flask_admin.contrib.fileadmin import BaseFileAdmin
+            from flask_admin.contrib.fileadmin.azure import AzureStorage
+
+            class MyAzureAdmin(BaseFileAdmin):
+                # Configure your class however you like
+                pass
+
+            fileadmin_view = MyAzureAdmin(storage=AzureStorage(...))
+
+    """
+    _fakedir = '.dir'
+    _copy_poll_interval_seconds = 1
+    _send_file_lookback = timedelta(minutes=15)
+    _send_file_validity = timedelta(hours=1)
+    separator = '/'
+
+    def __init__(self, container_name, connection_string):
+        """
+            Constructor
+
+            :param container_name:
+                Name of the container that the files are on.
+
+            :param connection_string:
+                Azure Blob Storage Connection String
+        """
+
+        if not BlockBlobService:
+            raise ValueError('Could not import Azure Blob Storage SDK. '
+                             'You can install the SDK using '
+                             'pip install azure-storage-blob')
+
+        self._container_name = container_name
+        self._connection_string = connection_string
+        self.__client = None
+
+    @property
+    def _client(self):
+        if not self.__client:
+            self.__client = BlockBlobService(
+                connection_string=self._connection_string)
+            self.__client.create_container(
+                self._container_name, fail_on_exist=False)
+        return self.__client
+
+    @classmethod
+    def _get_blob_last_modified(cls, blob):
+        last_modified = blob.properties.last_modified
+        tzinfo = last_modified.tzinfo
+        epoch = last_modified - datetime(1970, 1, 1, tzinfo=tzinfo)
+        return epoch.total_seconds()
+
+    @classmethod
+    def _ensure_blob_path(cls, path):
+        if path is None:
+            return None
+
+        path_parts = path.split(op.sep)
+        return cls.separator.join(path_parts).lstrip(cls.separator)
+
+    def get_files(self, path, directory):
+        path = self._ensure_blob_path(path)
+        directory = self._ensure_blob_path(directory)
+
+        path_parts = path.split(self.separator) if path else []
+        num_path_parts = len(path_parts)
+        folders = set()
+        files = []
+
+        for blob in self._client.list_blobs(self._container_name, path):
+            blob_path_parts = blob.name.split(self.separator)
+            name = blob_path_parts.pop()
+
+            blob_is_file_at_current_level = blob_path_parts == path_parts
+            blob_is_directory_file = name == self._fakedir
+
+            if blob_is_file_at_current_level and not blob_is_directory_file:
+                rel_path = blob.name
+                is_dir = False
+                size = blob.properties.content_length
+                last_modified = self._get_blob_last_modified(blob)
+                files.append((name, rel_path, is_dir, size, last_modified))
+            else:
+                next_level_folder = blob_path_parts[:num_path_parts + 1]
+                folder_name = self.separator.join(next_level_folder)
+                folders.add(folder_name)
+
+        folders.discard(directory)
+        for folder in folders:
+            name = folder.split(self.separator)[-1]
+            rel_path = folder
+            is_dir = True
+            size = 0
+            last_modified = 0
+            files.append((name, rel_path, is_dir, size, last_modified))
+
+        return files
+
+    def is_dir(self, path):
+        path = self._ensure_blob_path(path)
+
+        num_blobs = 0
+        for blob in self._client.list_blobs(self._container_name, path):
+            blob_path_parts = blob.name.split(self.separator)
+            is_explicit_directory = blob_path_parts[-1] == self._fakedir
+            if is_explicit_directory:
+                return True
+
+            num_blobs += 1
+            path_cannot_be_leaf = num_blobs >= 2
+            if path_cannot_be_leaf:
+                return True
+
+        return False
+
+    def path_exists(self, path):
+        path = self._ensure_blob_path(path)
+
+        if path == self.get_base_path():
+            return True
+
+        try:
+            next(iter(self._client.list_blobs(self._container_name, path)))
+        except StopIteration:
+            return False
+        else:
+            return True
+
+    def get_base_path(self):
+        return ''
+
+    def get_breadcrumbs(self, path):
+        path = self._ensure_blob_path(path)
+
+        accumulator = []
+        breadcrumbs = []
+        for folder in path.split(self.separator):
+            accumulator.append(folder)
+            breadcrumbs.append((folder, self.separator.join(accumulator)))
+        return breadcrumbs
+
+    def send_file(self, file_path):
+        file_path = self._ensure_blob_path(file_path)
+
+        if not self._client.exists(self._container_name, file_path):
+            raise ValueError()
+
+        now = datetime.utcnow()
+        url = self._client.make_blob_url(self._container_name, file_path)
+        sas = self._client.generate_blob_shared_access_signature(
+            self._container_name, file_path,
+            BlobPermissions.READ,
+            expiry=now + self._send_file_validity,
+            start=now - self._send_file_lookback)
+        return redirect('%s?%s' % (url, sas))
+
+    def read_file(self, path):
+        path = self._ensure_blob_path(path)
+
+        blob = self._client.get_blob_to_bytes(self._container_name, path)
+        return blob.content
+
+    def write_file(self, path, content):
+        path = self._ensure_blob_path(path)
+
+        self._client.create_blob_from_text(self._container_name, path, content)
+
+    def save_file(self, path, file_data):
+        path = self._ensure_blob_path(path)
+
+        self._client.create_blob_from_stream(self._container_name, path,
+                                             file_data.stream)
+
+    def delete_tree(self, directory):
+        directory = self._ensure_blob_path(directory)
+
+        for blob in self._client.list_blobs(self._container_name, directory):
+            self._client.delete_blob(self._container_name, blob.name)
+
+    def delete_file(self, file_path):
+        file_path = self._ensure_blob_path(file_path)
+
+        self._client.delete_blob(self._container_name, file_path)
+
+    def make_dir(self, path, directory):
+        path = self._ensure_blob_path(path)
+        directory = self._ensure_blob_path(directory)
+
+        blob = self.separator.join([path, directory, self._fakedir])
+        blob = blob.lstrip(self.separator)
+        self._client.create_blob_from_text(self._container_name, blob, '')
+
+    def _copy_blob(self, src, dst):
+        src_url = self._client.make_blob_url(self._container_name, src)
+        copy = self._client.copy_blob(self._container_name, dst, src_url)
+        while copy.status != 'success':
+            sleep(self._copy_poll_interval_seconds)
+            copy = self._client.get_blob_properties(
+                self._container_name, dst).properties.copy
+
+    def _rename_file(self, src, dst):
+        self._copy_blob(src, dst)
+        self.delete_file(src)
+
+    def _rename_directory(self, src, dst):
+        for blob in self._client.list_blobs(self._container_name, src):
+            self._rename_file(blob.name, blob.name.replace(src, dst, 1))
+
+    def rename_path(self, src, dst):
+        src = self._ensure_blob_path(src)
+        dst = self._ensure_blob_path(dst)
+
+        if self.is_dir(src):
+            self._rename_directory(src, dst)
+        else:
+            self._rename_file(src, dst)
+
+
+class AzureFileAdmin(BaseFileAdmin):
+    """
+        Simple Azure Blob Storage file-management interface.
+
+            :param container_name:
+                Name of the container that the files are on.
+
+            :param connection_string:
+                Azure Blob Storage Connection String
+
+        Sample usage::
+
+            from flask_admin import Admin
+            from flask_admin.contrib.fileadmin.azure import AzureFileAdmin
+
+            admin = Admin()
+
+            admin.add_view(AzureFileAdmin('files_container', 'my-connection-string')
+    """
+
+    def __init__(self, container_name, connection_string, *args, **kwargs):
+        storage = AzureStorage(container_name, connection_string)
+        super(AzureFileAdmin, self).__init__(*args, storage=storage, **kwargs)

--- a/flask_admin/contrib/fileadmin/s3.py
+++ b/flask_admin/contrib/fileadmin/s3.py
@@ -166,6 +166,14 @@ class S3Storage(object):
         keys = self._get_path_keys(path + self.separator)
         return len(keys) == 1
 
+    def read_file(self, path):
+        key = Key(self.bucket, path)
+        return key.get_contents_as_string()
+
+    def write_file(self, path, content):
+        key = Key(self.bucket, path)
+        key.set_contents_from_file(content)
+
 
 class S3FileAdmin(BaseFileAdmin):
     """

--- a/flask_admin/tests/fileadmin/test_fileadmin.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin.py
@@ -1,4 +1,5 @@
 import os.path as op
+import unittest
 
 from nose.tools import eq_, ok_
 
@@ -14,178 +15,196 @@ except ImportError:
     from io import StringIO
 
 
-def create_view():
-    app, admin = setup()
+class Base:
+    class FileAdminTests(unittest.TestCase):
+        _test_files_root = op.join(op.dirname(__file__), 'files')
 
-    class MyFileAdmin(fileadmin.FileAdmin):
-        editable_extensions = ('txt',)
+        def fileadmin_class(self):
+            raise NotImplementedError
 
-    path = op.join(op.dirname(__file__), 'files')
-    view = MyFileAdmin(path, '/files/', name='Files')
-    admin.add_view(view)
+        def fileadmin_args(self):
+            raise NotImplementedError
 
-    return app, admin, view
+        def test_file_admin(self):
+            fileadmin_class = self.fileadmin_class()
+            fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
+
+            app, admin = setup()
+
+            class MyFileAdmin(fileadmin_class):
+                editable_extensions = ('txt',)
+
+            view_kwargs = dict(fileadmin_kwargs)
+            view_kwargs.setdefault('name', 'Files')
+            view = MyFileAdmin(*fileadmin_args, **view_kwargs)
+
+            admin.add_view(view)
+
+            client = app.test_client()
+
+            # index
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+
+            # edit
+            rv = client.get('/admin/myfileadmin/edit/?path=dummy.txt')
+            eq_(rv.status_code, 200)
+            ok_('dummy.txt' in rv.data.decode('utf-8'))
+
+            rv = client.post('/admin/myfileadmin/edit/?path=dummy.txt',
+                             data=dict(content='new_string'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/edit/?path=dummy.txt')
+            eq_(rv.status_code, 200)
+            ok_('dummy.txt' in rv.data.decode('utf-8'))
+            ok_('new_string' in rv.data.decode('utf-8'))
+
+            # rename
+            rv = client.get('/admin/myfileadmin/rename/?path=dummy.txt')
+            eq_(rv.status_code, 200)
+            ok_('dummy.txt' in rv.data.decode('utf-8'))
+
+            rv = client.post('/admin/myfileadmin/rename/?path=dummy.txt',
+                             data=dict(name='dummy_renamed.txt',
+                                       path='dummy.txt'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy_renamed.txt' in rv.data.decode('utf-8'))
+            ok_('path=dummy.txt' not in rv.data.decode('utf-8'))
+
+            # upload
+            rv = client.get('/admin/myfileadmin/upload/')
+            eq_(rv.status_code, 200)
+
+            rv = client.post('/admin/myfileadmin/upload/',
+                             data=dict(upload=(StringIO(""), 'dummy.txt')))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+            ok_('path=dummy_renamed.txt' in rv.data.decode('utf-8'))
+
+            # delete
+            rv = client.post('/admin/myfileadmin/delete/',
+                             data=dict(path='dummy_renamed.txt'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy_renamed.txt' not in rv.data.decode('utf-8'))
+            ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+
+            # mkdir
+            rv = client.get('/admin/myfileadmin/mkdir/')
+            eq_(rv.status_code, 200)
+
+            rv = client.post('/admin/myfileadmin/mkdir/',
+                             data=dict(name='dummy_dir'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+            ok_('path=dummy_dir' in rv.data.decode('utf-8'))
+
+            # rename - directory
+            rv = client.get('/admin/myfileadmin/rename/?path=dummy_dir')
+            eq_(rv.status_code, 200)
+            ok_('dummy_dir' in rv.data.decode('utf-8'))
+
+            rv = client.post('/admin/myfileadmin/rename/?path=dummy_dir',
+                             data=dict(name='dummy_renamed_dir',
+                                       path='dummy_dir'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy_renamed_dir' in rv.data.decode('utf-8'))
+            ok_('path=dummy_dir' not in rv.data.decode('utf-8'))
+
+            # delete - directory
+            rv = client.post('/admin/myfileadmin/delete/',
+                             data=dict(path='dummy_renamed_dir'))
+            eq_(rv.status_code, 302)
+
+            rv = client.get('/admin/myfileadmin/')
+            eq_(rv.status_code, 200)
+            ok_('path=dummy_renamed_dir' not in rv.data.decode('utf-8'))
+            ok_('path=dummy.txt' in rv.data.decode('utf-8'))
+
+        def test_modal_edit(self):
+            # bootstrap 2 - test edit_modal
+            app_bs2 = Flask(__name__)
+            admin_bs2 = Admin(app_bs2, template_mode="bootstrap2")
+
+            fileadmin_class = self.fileadmin_class()
+            fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
+
+            class EditModalOn(fileadmin_class):
+                edit_modal = True
+                editable_extensions = ('txt',)
+
+            class EditModalOff(fileadmin_class):
+                edit_modal = False
+                editable_extensions = ('txt',)
+
+            on_view_kwargs = dict(fileadmin_kwargs)
+            on_view_kwargs.setdefault('endpoint', 'edit_modal_on')
+            edit_modal_on = EditModalOn(*fileadmin_args, **on_view_kwargs)
+
+            off_view_kwargs = dict(fileadmin_kwargs)
+            off_view_kwargs.setdefault('endpoint', 'edit_modal_off')
+            edit_modal_off = EditModalOff(*fileadmin_args, **off_view_kwargs)
+
+            admin_bs2.add_view(edit_modal_on)
+            admin_bs2.add_view(edit_modal_off)
+
+            client_bs2 = app_bs2.test_client()
+
+            # bootstrap 2 - ensure modal window is added when edit_modal is
+            # enabled
+            rv = client_bs2.get('/admin/edit_modal_on/')
+            eq_(rv.status_code, 200)
+            data = rv.data.decode('utf-8')
+            ok_('fa_modal_window' in data)
+
+            # bootstrap 2 - test edit modal disabled
+            rv = client_bs2.get('/admin/edit_modal_off/')
+            eq_(rv.status_code, 200)
+            data = rv.data.decode('utf-8')
+            ok_('fa_modal_window' not in data)
+
+            # bootstrap 3
+            app_bs3 = Flask(__name__)
+            admin_bs3 = Admin(app_bs3, template_mode="bootstrap3")
+
+            admin_bs3.add_view(edit_modal_on)
+            admin_bs3.add_view(edit_modal_off)
+
+            client_bs3 = app_bs3.test_client()
+
+            # bootstrap 3 - ensure modal window is added when edit_modal is
+            # enabled
+            rv = client_bs3.get('/admin/edit_modal_on/')
+            eq_(rv.status_code, 200)
+            data = rv.data.decode('utf-8')
+            ok_('fa_modal_window' in data)
+
+            # bootstrap 3 - test modal disabled
+            rv = client_bs3.get('/admin/edit_modal_off/')
+            eq_(rv.status_code, 200)
+            data = rv.data.decode('utf-8')
+            ok_('fa_modal_window' not in data)
 
 
-def test_file_admin():
-    app, admin, view = create_view()
+class LocalFileAdminTests(Base.FileAdminTests):
+    def fileadmin_class(self):
+        return fileadmin.FileAdmin
 
-    client = app.test_client()
-
-    # index
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy.txt' in rv.data.decode('utf-8'))
-
-    # edit
-    rv = client.get('/admin/myfileadmin/edit/?path=dummy.txt')
-    eq_(rv.status_code, 200)
-    ok_('dummy.txt' in rv.data.decode('utf-8'))
-
-    rv = client.post('/admin/myfileadmin/edit/?path=dummy.txt', data=dict(
-        content='new_string'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/edit/?path=dummy.txt')
-    eq_(rv.status_code, 200)
-    ok_('dummy.txt' in rv.data.decode('utf-8'))
-    ok_('new_string' in rv.data.decode('utf-8'))
-
-    # rename
-    rv = client.get('/admin/myfileadmin/rename/?path=dummy.txt')
-    eq_(rv.status_code, 200)
-    ok_('dummy.txt' in rv.data.decode('utf-8'))
-
-    rv = client.post('/admin/myfileadmin/rename/?path=dummy.txt', data=dict(
-        name='dummy_renamed.txt',
-        path='dummy.txt'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy_renamed.txt' in rv.data.decode('utf-8'))
-    ok_('path=dummy.txt' not in rv.data.decode('utf-8'))
-
-    # upload
-    rv = client.get('/admin/myfileadmin/upload/')
-    eq_(rv.status_code, 200)
-
-    rv = client.post('/admin/myfileadmin/upload/', data=dict(
-        upload=(StringIO(""), 'dummy.txt'),
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy.txt' in rv.data.decode('utf-8'))
-    ok_('path=dummy_renamed.txt' in rv.data.decode('utf-8'))
-
-    # delete
-    rv = client.post('/admin/myfileadmin/delete/', data=dict(
-        path='dummy_renamed.txt'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy_renamed.txt' not in rv.data.decode('utf-8'))
-    ok_('path=dummy.txt' in rv.data.decode('utf-8'))
-
-    # mkdir
-    rv = client.get('/admin/myfileadmin/mkdir/')
-    eq_(rv.status_code, 200)
-
-    rv = client.post('/admin/myfileadmin/mkdir/', data=dict(
-        name='dummy_dir'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy.txt' in rv.data.decode('utf-8'))
-    ok_('path=dummy_dir' in rv.data.decode('utf-8'))
-
-    # rename - directory
-    rv = client.get('/admin/myfileadmin/rename/?path=dummy_dir')
-    eq_(rv.status_code, 200)
-    ok_('dummy_dir' in rv.data.decode('utf-8'))
-
-    rv = client.post('/admin/myfileadmin/rename/?path=dummy_dir', data=dict(
-        name='dummy_renamed_dir',
-        path='dummy_dir'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy_renamed_dir' in rv.data.decode('utf-8'))
-    ok_('path=dummy_dir' not in rv.data.decode('utf-8'))
-
-    # delete - directory
-    rv = client.post('/admin/myfileadmin/delete/', data=dict(
-        path='dummy_renamed_dir'
-    ))
-    eq_(rv.status_code, 302)
-
-    rv = client.get('/admin/myfileadmin/')
-    eq_(rv.status_code, 200)
-    ok_('path=dummy_renamed_dir' not in rv.data.decode('utf-8'))
-    ok_('path=dummy.txt' in rv.data.decode('utf-8'))
-
-
-def test_modal_edit():
-    # bootstrap 2 - test edit_modal
-    app_bs2 = Flask(__name__)
-    admin_bs2 = Admin(app_bs2, template_mode="bootstrap2")
-
-    class EditModalOn(fileadmin.FileAdmin):
-        edit_modal = True
-        editable_extensions = ('txt',)
-
-    class EditModalOff(fileadmin.FileAdmin):
-        edit_modal = False
-        editable_extensions = ('txt',)
-
-    path = op.join(op.dirname(__file__), 'files')
-    edit_modal_on = EditModalOn(path, '/files/', endpoint='edit_modal_on')
-    edit_modal_off = EditModalOff(path, '/files/', endpoint='edit_modal_off')
-
-    admin_bs2.add_view(edit_modal_on)
-    admin_bs2.add_view(edit_modal_off)
-
-    client_bs2 = app_bs2.test_client()
-
-    # bootstrap 2 - ensure modal window is added when edit_modal is enabled
-    rv = client_bs2.get('/admin/edit_modal_on/')
-    eq_(rv.status_code, 200)
-    data = rv.data.decode('utf-8')
-    ok_('fa_modal_window' in data)
-
-    # bootstrap 2 - test edit modal disabled
-    rv = client_bs2.get('/admin/edit_modal_off/')
-    eq_(rv.status_code, 200)
-    data = rv.data.decode('utf-8')
-    ok_('fa_modal_window' not in data)
-
-    # bootstrap 3
-    app_bs3 = Flask(__name__)
-    admin_bs3 = Admin(app_bs3, template_mode="bootstrap3")
-
-    admin_bs3.add_view(edit_modal_on)
-    admin_bs3.add_view(edit_modal_off)
-
-    client_bs3 = app_bs3.test_client()
-
-    # bootstrap 3 - ensure modal window is added when edit_modal is enabled
-    rv = client_bs3.get('/admin/edit_modal_on/')
-    eq_(rv.status_code, 200)
-    data = rv.data.decode('utf-8')
-    ok_('fa_modal_window' in data)
-
-    # bootstrap 3 - test modal disabled
-    rv = client_bs3.get('/admin/edit_modal_off/')
-    eq_(rv.status_code, 200)
-    data = rv.data.decode('utf-8')
-    ok_('fa_modal_window' not in data)
+    def fileadmin_args(self):
+        return (self._test_files_root, '/files'), {}

--- a/flask_admin/tests/fileadmin/test_fileadmin_azure.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin_azure.py
@@ -1,0 +1,37 @@
+import os.path as op
+from os import getenv
+from uuid import uuid4
+
+from nose import SkipTest
+
+from flask_admin.contrib.fileadmin import azure
+
+from .test_fileadmin import Base
+
+
+class AzureFileAdminTests(Base.FileAdminTests):
+    _test_storage = getenv('AZURE_STORAGE_CONNECTION_STRING')
+
+    def setUp(self):
+        if not azure.BlockBlobService:
+            raise SkipTest('AzureFileAdmin dependencies not installed')
+
+        self._container_name = 'fileadmin-tests-%s' % uuid4()
+
+        if not self._test_storage or not self._container_name:
+            raise SkipTest('AzureFileAdmin test credentials not set')
+
+        client = azure.BlockBlobService(connection_string=self._test_storage)
+        client.create_container(self._container_name)
+        dummy = op.join(self._test_files_root, 'dummy.txt')
+        client.create_blob_from_path(self._container_name, 'dummy.txt', dummy)
+
+    def tearDown(self):
+        client = azure.BlockBlobService(connection_string=self._test_storage)
+        client.delete_container(self._container_name)
+
+    def fileadmin_class(self):
+        return azure.AzureFileAdmin
+
+    def fileadmin_args(self):
+        return (self._container_name, self._test_storage), {}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ nose
 coveralls
 pylint
 sqlalchemy-citext
+azure-storage-blob

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,12 @@ def grep(attrname):
     return strval
 
 
+extras_require = {
+    'aws': ['boto'],
+    'azure': ['azure-storage-blob']
+}
+
+
 install_requires = [
     'Flask>=0.7',
     'wtforms'
@@ -49,6 +55,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
+    extras_require=extras_require,
     install_requires=install_requires,
     tests_require=[
         'nose>=1.0',

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ max_line_length = 120
 ignore = E402,E722
 
 [testenv]
+setenv =
+    AZURE_STORAGE_CONNECTION_STRING = DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 usedevelop = true
 deps =
     WTForms1: WTForms==1.0.5


### PR DESCRIPTION
This pull request implements a file-admin based on [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/). The implementation is modeled on the existing [S3 file admin](https://github.com/flask-admin/flask-admin/blob/7fa26ab227868ff7512bb25c26a30fd7d69184bc/flask_admin/contrib/fileadmin/s3.py).

To make the Azure and S3 file-admins easier to consume, their dependencies were included as extra dependencies on the file-admin package (see edfb07e).

This pull request also adds unit tests for the new file-admin implementation by generalizing the unit tests for the local file-admin (see b3ccfd4). During CI, the unit tests are run against an emulated blob storage service provided by [Azurite](https://github.com/Azure/Azurite).

Generalizing the unit tests for the new file-admin implementation revealed two assumptions in the BaseFileAdmin class:

1) During the content editing workflow, file-system access was assumed. This was fixed by introducing two new methods on the FileStorage interface: `read_file` and `write_file` (see a2ddd99).

2) When listing files, a valid last modified time for all items including folders was assumed. This was fixed by making the files sorting method more robust (see 3452d1d).

In addition to the unit tests, the new file-admin backend was also manually verified against a live Azure Blob Storage account via a [test app](https://github.com/flask-admin/flask-admin/files/2245631/app.py.txt).
