### PR TITLE
remove useless brackets

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -55,7 +55,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         if not model:
             return None
 
-        return (getattr(model, self.pk), as_unicode(model))
+        return getattr(model, self.pk), as_unicode(model)
 
     def get_one(self, pk):
         # prevent autoflush from occuring during populate_obj


### PR DESCRIPTION
Hey,
It seems like [here](https://github.com/flask-admin/flask-admin/blob/master/flask_admin/contrib/sqla/ajax.py#L58) the brackets are pretty useless, tuple will be returned any way