### PR TITLE
Add missing class_name to bootstrap 2/3 menu items

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/layout.html
+++ b/flask_admin/templates/bootstrap2/admin/layout.html
@@ -61,8 +61,9 @@
 {% macro menu_links(links=None) %}
   {% if links is none %}{% set links = admin_view.admin.menu_links() %}{% endif %}
   {% for item in links %}
+    {% set class_name = item.get_class_name() %}
     {% if item.is_accessible() and item.is_visible() %}
-      <li>
+      <li{% if class_name %} class="{{ class_name }}"{% endif %}>
         <a href="{{ item.get_url() }}">{{ menu_icon(item) }}{{ item.name }}</a>
       </li>
     {% endif %}

--- a/flask_admin/templates/bootstrap3/admin/layout.html
+++ b/flask_admin/templates/bootstrap3/admin/layout.html
@@ -61,8 +61,9 @@
 {% macro menu_links(links=None) %}
   {% if links is none %}{% set links = admin_view.admin.menu_links() %}{% endif %}
   {% for item in links %}
+    {% set class_name = item.get_class_name() %}
     {% if item.is_accessible() and item.is_visible() %}
-      <li>
+      <li{% if class_name %} class="{{ class_name }}"{% endif %}>
         <a href="{{ item.get_url() }}">{{ menu_icon(item) }}{{ item.name }}</a>
       </li>
     {% endif %}


### PR DESCRIPTION
This is part of the code, but wasn't in the template.

https://github.com/flask-admin/flask-admin/blob/v1.5.2/flask_admin/menu.py#L133

This got it working for me.