### PR TITLE
CheckboxListField: alternative field for many-to-many relationship

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -15,6 +15,7 @@ API
    mod_actions
 
    mod_contrib_sqla
+   mod_contrib_sqla_fields
    mod_contrib_mongoengine
    mod_contrib_mongoengine_fields
    mod_contrib_peewee

--- a/doc/api/mod_contrib_sqla_fields.rst
+++ b/doc/api/mod_contrib_sqla_fields.rst
@@ -1,0 +1,13 @@
+``flask_admin.contrib.sqla.fields``
+===================================
+
+.. automodule:: flask_admin.contrib.sqla.fields
+
+	.. autoclass:: QuerySelectField
+		:members:
+
+	.. autoclass:: QuerySelectMultipleField
+		:members:
+
+	.. autoclass:: CheckboxListField
+		:members:

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from .tools import get_primary_key
 from flask_admin._compat import text_type, string_types, iteritems
+from flask_admin.contrib.sqla.widgets import CheckboxListInput
 from flask_admin.form import FormOpts, BaseForm, Select2Widget
 from flask_admin.model.fields import InlineFieldList, InlineModelFormField
 from flask_admin.babel import lazy_gettext
@@ -179,6 +180,30 @@ class QuerySelectMultipleField(QuerySelectField):
             for v in self.data:
                 if v not in obj_list:
                     raise ValidationError(self.gettext(u'Not a valid choice'))
+
+
+class CheckboxListField(QuerySelectMultipleField):
+    """
+    Alternative field for many-to-many relationships.
+
+    Can be used instead of `QuerySelectMultipleField`.
+    Appears as the list of checkboxes.
+    Example::
+
+        class MyView(ModelView):
+            form_columns = (
+                'languages',
+            )
+            form_args = {
+                'languages': {
+                    'query_factory': Language.query,
+                },
+            }
+            form_overrides = {
+                'languages': CheckboxListField,
+            }
+    """
+    widget = CheckboxListInput()
 
 
 class HstoreForm(BaseForm):

--- a/flask_admin/contrib/sqla/widgets.py
+++ b/flask_admin/contrib/sqla/widgets.py
@@ -1,4 +1,4 @@
-from wtforms.widgets.core import HTMLString, escape_html
+from wtforms.widgets.core import HTMLString, escape
 
 
 class CheckboxListInput:
@@ -22,7 +22,7 @@ class CheckboxListInput:
             args = {
                 'id': val,
                 'name': field.name,
-                'label': escape_html(label, quote=False),
+                'label': escape(label),
                 'selected': ' checked' if selected else '',
             }
             items.append(self.template % args)

--- a/flask_admin/contrib/sqla/widgets.py
+++ b/flask_admin/contrib/sqla/widgets.py
@@ -1,0 +1,29 @@
+from wtforms.widgets.core import HTMLString, escape_html
+
+
+class CheckboxListInput:
+    """
+    Alternative widget for many-to-many relationships.
+
+    Appears as the list of checkboxes.
+    """
+    template = (
+        '<div class="checkbox">'
+        ' <label>'
+        '  <input id="%(id)s" name="%(name)s" value="%(id)s" '
+        'type="checkbox"%(selected)s>%(label)s'
+        ' </label>'
+        '</div>'
+    )
+
+    def __call__(self, field, **kwargs):
+        items = []
+        for val, label, selected in field.iter_choices():
+            args = {
+                'id': val,
+                'name': field.name,
+                'label': escape_html(label, quote=False),
+                'selected': ' checked' if selected else '',
+            }
+            items.append(self.template % args)
+        return HTMLString(''.join(items))


### PR DESCRIPTION
Greetings!

This is a new field which can be used instead of default `QuerySelectMultipleField` for many-to-many relationships. It looks like this:

![checkboxlist](https://user-images.githubusercontent.com/18066975/48485051-e1d57a00-e828-11e8-8de6-e56b2903bc0f.png)

Also made `flask_admin.contrib.sqla.fields` module visible in the documentation API index.