### PR TITLE
Case-sensitive search for SQLAlchemy views

### DIFF
--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -51,8 +51,9 @@ class FilterNotEqual(BaseSQLAFilter):
 
 class FilterLike(BaseSQLAFilter):
     def apply(self, query, value, alias=None):
-        stmt = tools.parse_like_term(value)
-        return query.filter(self.get_column(alias).ilike(stmt))
+        oper, stmt = tools.parse_like_term(value)
+        search_operator = getattr(self.get_column(alias), oper)
+        return query.filter(search_operator(stmt))
 
     def operation(self):
         return lazy_gettext('contains')
@@ -60,8 +61,9 @@ class FilterLike(BaseSQLAFilter):
 
 class FilterNotLike(BaseSQLAFilter):
     def apply(self, query, value, alias=None):
-        stmt = tools.parse_like_term(value)
-        return query.filter(~self.get_column(alias).ilike(stmt))
+        oper, stmt = tools.parse_like_term(value)
+        search_operator = getattr(self.get_column(alias), oper)
+        return query.filter(~search_operator(stmt))
 
     def operation(self):
         return lazy_gettext('not contains')

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -13,6 +13,23 @@ from flask_admin.tools import iterencode, iterdecode, escape  # noqa: F401
 
 
 def parse_like_term(term):
+    """
+        Parse search term into (operation, term) tuple. Recognizes operators
+        in the beginning of the search term. Case insensitive is the default.
+
+        * = case sensitive (can precede other operators)
+        ^ = starts with
+        = = exact
+
+        :param term:
+            Search term
+    """
+    case_sensitive = term.startswith('*')
+    if case_sensitive:
+        term = term[1:]
+
+    oper = 'like' if case_sensitive else 'ilike'
+
     if term.startswith('^'):
         stmt = '%s%%' % term[1:]
     elif term.startswith('='):
@@ -20,7 +37,7 @@ def parse_like_term(term):
     else:
         stmt = '%%%s%%' % term
 
-    return stmt
+    return oper, stmt
 
 
 def filter_foreign_columns(base_table, columns):

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -109,7 +109,7 @@ class ModelView(BaseModelView):
 
         - If you prefix your search term with ``=``, it will perform an exact match.
           For example, if you entered ``=ZZZ``, the statement ``ILIKE 'ZZZ'`` will be used.
-        
+
         - If you prefix your search term with ``*``, it will perform case-sensitive search.
           For example, if you entered ``*ZZZ``, the statement ``LIKE 'ZZZ'`` will be used.
     """

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -109,6 +109,9 @@ class ModelView(BaseModelView):
 
         - If you prefix your search term with ``=``, it will perform an exact match.
           For example, if you entered ``=ZZZ``, the statement ``ILIKE 'ZZZ'`` will be used.
+        
+        - If you prefix your search term with ``*``, it will perform case-sensitive search.
+          For example, if you entered ``*ZZZ``, the statement ``LIKE 'ZZZ'`` will be used.
     """
 
     column_filters = None
@@ -911,7 +914,7 @@ class ModelView(BaseModelView):
             if not term:
                 continue
 
-            stmt = tools.parse_like_term(term)
+            oper, stmt = tools.parse_like_term(term)
 
             filter_stmt = []
             count_filter_stmt = []
@@ -928,11 +931,13 @@ class ModelView(BaseModelView):
                                                                                    inner_join=False)
 
                 column = field if alias is None else getattr(alias, field.key)
-                filter_stmt.append(cast(column, Unicode).ilike(stmt))
+                search_operator = getattr(cast(column, Unicode), oper)
+                filter_stmt.append(search_operator(stmt))
 
                 if count_filter_stmt is not None:
                     column = field if count_alias is None else getattr(count_alias, field.key)
-                    count_filter_stmt.append(cast(column, Unicode).ilike(stmt))
+                    search_operator = getattr(cast(column, Unicode), oper)
+                    count_filter_stmt.append(search_operator(stmt))
 
             query = query.filter(or_(*filter_stmt))
 


### PR DESCRIPTION
Greetings!

Case-sensitive search for SQLAlchemy views with the same syntax as for MongoEngine views: using `*` character as a prefix switches to `LIKE` SQL operator instead of `ILIKE`.