### PR TITLE
Letting the edit html inherit from right source in form-files-field example

### DIFF
--- a/examples/forms-files-images/templates/edit_page.html
+++ b/examples/forms-files-images/templates/edit_page.html
@@ -1,4 +1,4 @@
-{% extends 'admin/model/create.html' %}
+{% extends 'admin/model/edit.html' %}
 
 {% block tail %}
     {{ super() }}


### PR DESCRIPTION
Just a small fix in one of the examples, even though it does not make in functionality in the example, it's a bit cleaner like this. 