### PR TITLE
use Markupsafe to support WTForms 3

### DIFF
--- a/flask_admin/_backwards.py
+++ b/flask_admin/_backwards.py
@@ -8,6 +8,11 @@
 import sys
 import warnings
 
+try:
+    from wtforms.widgets import HTMLString as Markup
+except ImportError:
+    from markupsafe import Markup
+
 
 def get_property(obj, name, old_name, default=None):
     """

--- a/flask_admin/contrib/mongoengine/widgets.py
+++ b/flask_admin/contrib/mongoengine/widgets.py
@@ -1,9 +1,10 @@
-from wtforms.widgets import HTMLString, html_params
+from wtforms.widgets import html_params
 
 from jinja2 import escape
 
 from mongoengine.fields import GridFSProxy, ImageGridFsProxy
 
+from flask_admin._backwards import Markup
 from flask_admin.helpers import get_url
 from . import helpers
 
@@ -31,7 +32,7 @@ class MongoFileInput(object):
                 'marker': '_%s-delete' % field.name
             }
 
-        return HTMLString('%s<input %s>' % (placeholder,
+        return Markup('%s<input %s>' % (placeholder,
                                             html_params(name=field.name,
                                                         type='file',
                                                         **kwargs)))
@@ -46,7 +47,8 @@ class MongoImageInput(object):
                 ' <input type="checkbox" name="%(marker)s">Delete</input>'
                 '</div>')
 
-    def __call__(self, field, **kwargs):
+
+def __call__(self, field, **kwargs):
         kwargs.setdefault('id', field.id)
 
         placeholder = ''
@@ -57,7 +59,7 @@ class MongoImageInput(object):
                 'marker': '_%s-delete' % field.name
             }
 
-        return HTMLString('%s<input %s>' % (placeholder,
+        return Markup('%s<input %s>' % (placeholder,
                                             html_params(name=field.name,
                                                         type='file',
                                                         **kwargs)))

--- a/flask_admin/contrib/sqla/widgets.py
+++ b/flask_admin/contrib/sqla/widgets.py
@@ -1,4 +1,6 @@
-from wtforms.widgets.core import HTMLString, escape
+from wtforms.widgets.core import escape
+
+from flask_admin._backwards import Markup
 
 
 class CheckboxListInput:
@@ -26,4 +28,4 @@ class CheckboxListInput:
                 'selected': ' checked' if selected else '',
             }
             items.append(self.template % args)
-        return HTMLString(''.join(items))
+        return Markup(''.join(items))

--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -5,7 +5,7 @@ from werkzeug import secure_filename
 from werkzeug.datastructures import FileStorage
 
 from wtforms import ValidationError, fields
-from wtforms.widgets import HTMLString, html_params
+from wtforms.widgets import html_params
 
 try:
     from wtforms.fields.core import _unset_value as unset_value
@@ -15,6 +15,7 @@ except ImportError:
 from flask_admin.babel import gettext
 from flask_admin.helpers import get_url
 
+from flask_admin._backwards import Markup
 from flask_admin._compat import string_types, urljoin
 
 
@@ -59,7 +60,7 @@ class FileUploadInput(object):
         else:
             value = field.data or ''
 
-        return HTMLString(template % {
+        return Markup(template % {
             'text': html_params(type='text',
                                 readonly='readonly',
                                 value=value,
@@ -108,7 +109,7 @@ class ImageUploadInput(object):
         else:
             template = self.empty_template
 
-        return HTMLString(template % args)
+        return Markup(template % args)
 
     def get_url(self, field):
         if field.thumbnail_size:

--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -1,7 +1,8 @@
 from flask import json
 from jinja2 import escape
-from wtforms.widgets import HTMLString, html_params
+from wtforms.widgets import html_params
 
+from flask_admin._backwards import Markup
 from flask_admin._compat import as_unicode, text_type
 from flask_admin.babel import gettext
 from flask_admin.helpers import get_url
@@ -64,7 +65,7 @@ class AjaxSelect2Widget(object):
         minimum_input_length = int(field.loader.options.get('minimum_input_length', 1))
         kwargs.setdefault('data-minimum-input-length', minimum_input_length)
 
-        return HTMLString('<input %s>' % html_params(name=field.name, **kwargs))
+        return Markup('<input %s>' % html_params(name=field.name, **kwargs))
 
 
 class XEditableWidget(object):
@@ -93,7 +94,7 @@ class XEditableWidget(object):
 
         kwargs = self.get_kwargs(field, kwargs)
 
-        return HTMLString(
+        return Markup(
             '<a %s>%s</a>' % (html_params(**kwargs),
                               escape(display_value))
         )


### PR DESCRIPTION
WTForms unreleased 3.0 removes `widgets.core.HTMLString`:

https://github.com/wtforms/wtforms/blob/master/CHANGES.rst

This PR supports both old `HTMLString` and new `Markupsafe`.