### PR TITLE
TypeError: faForm is undefined when loading filters

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -185,8 +185,8 @@
       <div id="active-filters-data" style="display:none;">{{ active_filters|tojson|safe }}</div>
     {% endif %}
 
-    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
     {{ lib.form_js() }}
+    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -186,8 +186,8 @@
       <div id="active-filters-data" style="display:none;">{{ active_filters|tojson|safe }}</div>
     {% endif %}
 
-    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
     {{ lib.form_js() }}
+    <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,


### PR DESCRIPTION
Since very recently (right after upgrade to 1.5.3, I think), I've been getting this error in the list view every time there are filters applied on the page, coming from [here](https://github.com/flask-admin/flask-admin/blob/4ca0ef5f9cf58d231cdfca8ac6feaa83c85c903e/flask_admin/static/admin/js/filters-1.0.0.js#L94).

Couldn't find any recent commits that would look relevant to this (neither assets themselves nor parts of the templates where they are used were changed recently), but swapping the assets around fixes the problem.