### PR TITLE
[peewee] Fix (and add example for) using a Python function as a default value.

### DIFF
--- a/examples/peewee/app.py
+++ b/examples/peewee/app.py
@@ -1,10 +1,10 @@
-from flask import Flask
+import uuid
 
 import peewee
+from flask import Flask
 
 import flask_admin as admin
 from flask_admin.contrib.peewee import ModelView
-
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = '123456790'
@@ -36,6 +36,7 @@ class UserInfo(BaseModel):
 
 
 class Post(BaseModel):
+    id = peewee.UUIDField(primary_key=True, default=uuid.uuid4)
     title = peewee.CharField(max_length=120)
     text = peewee.TextField(null=False)
     date = peewee.DateTimeField()
@@ -80,6 +81,7 @@ def index():
 
 if __name__ == '__main__':
     import logging
+
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)
 

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -453,7 +453,7 @@ class ModelView(BaseModelView):
             model = self.model()
             form.populate_obj(model)
             self._on_model_change(form, model, True)
-            model.save()
+            model.save(force_insert=True)
 
             # For peewee have to save inline forms after model was saved
             save_inline(form, model)


### PR DESCRIPTION
This should fix #1833.

When a primary key has a default value supplied by a Python function, the current flask-admin implementation will fail to create new records in the admin GUI for that model. This pull request fixes that by explicitly sending `force_insert=True` to `model.save()` inside `ModelView.create_model`.

EDIT: To clarify, this is a peewee-specific problem.