### PR TITLE
Fix usage of now-deprecated textual coercion in SqlAlchemy 1.3+

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -70,7 +70,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         query = query.filter(or_(*filters))
 
         if self.filters:
-            filters = [text("%s.%s") % (self.model.__tablename__.lower(), value) for value in self.filters]
+            filters = [text("%s.%s" % (self.model.__tablename__.lower(), value)) for value in self.filters]
             query = query.filter(and_(*filters))
 
         if self.order_by:

--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -1,4 +1,4 @@
-from sqlalchemy import or_, and_, cast
+from sqlalchemy import or_, and_, cast, text
 from sqlalchemy.types import String
 
 from flask_admin._compat import as_unicode, string_types
@@ -70,7 +70,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         query = query.filter(or_(*filters))
 
         if self.filters:
-            filters = ["%s.%s" % (self.model.__tablename__.lower(), value) for value in self.filters]
+            filters = [text("%s.%s") % (self.model.__tablename__.lower(), value) for value in self.filters]
             query = query.filter(and_(*filters))
 
         if self.order_by:


### PR DESCRIPTION
Since version 1.3, SqlAlchemy [removed coercion of string SQL fragments to text()](https://docs.sqlalchemy.org/en/13/changelog/migration_13.html#change-4481), which breaks filters in `form_ajax_refs`.

For a filter such as `is_alive IS TRUE` the error looks like this:
```
Textual SQL expression 'user.is_alive IS TRUE' should be explicitly declared as text('user.is_alive IS TRUE')
```

This fixes the issue by wrapping filters in `text()` explicitly.