### PR TITLE
Fixed date field just allows to pick date <= 2015

### DIFF
--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -455,7 +455,14 @@
                 processLeafletWidget($el, name);
                 return true;
             case 'x-editable':
-                $el.editable({params: overrideXeditableParams});
+                $el.editable({
+                    params: overrideXeditableParams,
+                    combodate: {
+                        // prevent minutes from showing in 5 minute increments
+                        minuteStep: 1,
+                        maxYear: 2030,
+                    }                    
+                });
                 return true;
             case 'x-editable-combodate':
                 $el.editable({


### PR DESCRIPTION
Using the type `db.Date` produces a date-picker just working until the year 2015. Following pull request fixed this behavior and allows to pick until 2030.

![error](https://user-images.githubusercontent.com/39189805/57534284-fa3dd180-733f-11e9-88fa-403c2088accd.png)
