### PR TITLE
use circle-o for rendering unchecked booleans

### DIFF
--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -36,7 +36,7 @@ def bool_formatter(view, value):
             Value to check
     """
     glyph = 'ok-circle' if value else 'minus-sign'
-    fa = 'check-circle' if value else 'minus-circle'
+    fa = 'check-circle' if value else 'circle-o'
     return Markup('<span class="fa fa-%s glyphicon glyphicon-%s icon-%s"></span>' % (fa, glyph, glyph))
 
 


### PR DESCRIPTION
I think `fa-circle-o` is visually better and clearer than `fa-minus-circle` for unselected booleans.

## Before
<img width="197" alt="Screen Shot 2019-08-15 at 10 21 00 PM" src="https://user-images.githubusercontent.com/522344/63145177-35891580-bfab-11e9-83da-e69219c93153.png">

## After
<img width="195" alt="Screen Shot 2019-08-15 at 10 21 14 PM" src="https://user-images.githubusercontent.com/522344/63145179-3ae66000-bfab-11e9-9545-994d98352407.png">

Any thoughts or objections?