### PR TITLE
Add documentation and example for using flask-security-too with Flask-Admin

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -119,6 +119,42 @@ at https://github.com/flask-admin/Flask-Admin/tree/master/examples/auth-flask-lo
 The main drawback is that you still need to implement all of the relevant login,
 registration, and account management views yourself.
 
+Using Flask-Security-Too
+-------------------------
+
+If you want a more polished solution, you could
+use `Flask-Security-Too <https://flask-security-too.readthedocs.io/en/stable/>`_,
+which is a higher-level library. Key features include:
+
+  * API endpoints for registration, login,
+    change/reset password, and confirmation
+  * Full support for JSON and/or form input
+  * Support for handling CSRF
+  * Authorization decorators for protecting your endpoints
+  * And more!
+
+As explained in `Customizing <https://flask-security-too.readthedocs.io/en/stable/customizing.html>`_
+the built-in views are great to get started, but will need modification to integrate smoothly with the
+Flask-Admin templates. To do this, start with a Flask-Admin template and cut-n-paste the appropriate form
+information from the default Flask-Security-Too templates.
+
+Now, you'll need to manually pass in some context variables for the Flask-Admin
+templates to render correctly when they're being called from the Flask-Security views.
+Defining a `security_context_processor` function will take care of this for you::
+
+    def security_context_processor():
+        return dict(
+            admin_base_template=admin.base_template,
+            admin_view=admin.index_view,
+            h=admin_helpers,
+        )
+
+For a working example of using Flask-Security-Too with Flask-Admin, have a look at
+https://github.com/flask-admin/Flask-Admin/tree/master/examples/auth-fs-too.
+
+The example has templates for `register`, `login`, `forgot_password`, `change_password`
+and `reset_password` views. Furthermore, the example shows how to utilize Flask-Security-Too's
+translations within your views.
 
 Using Flask-Security
 --------------------

--- a/examples/auth-fs-too/README.rst
+++ b/examples/auth-fs-too/README.rst
@@ -1,0 +1,29 @@
+This example shows how to integrate Flask-Security-Too (https://pypi.org/project/Flask-Security-Too/) with Flask-Admin using the SQLAlchemy backend. It implements
+the 'login', 'register', 'change password', and 'forgot password' views. In addition, it shows how to utilize Flask-Security-Too's language translations in locally
+modified form templates.
+
+To run this example:
+
+1. Clone the repository::
+
+     git clone https://github.com/flask-admin/flask-admin.git
+     cd flask-admin
+
+2. Create and activate a virtual environment::
+
+     virtualenv env
+     source env/bin/activate
+
+3. Install requirements::
+
+     pip install -r 'examples/auth-fs-too/requirements.txt'
+
+4. Run the application::
+
+     python examples/auth-fs-too/app.py
+
+The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
+comment the following lines in app.py:::
+
+     if not os.path.exists(database_path):
+         build_sample_db()

--- a/examples/auth-fs-too/app.py
+++ b/examples/auth-fs-too/app.py
@@ -1,0 +1,185 @@
+"""
+A complete but simple application utilizing Flask-Security-Too for authorization
+and authentication.
+
+Supports i18n by adding ?lang=xx.
+Since this is session based - lang is only evaluated on FIRST request - even after
+logout. So to change languages you probably need to delete the session cookie.
+"""
+
+
+import os
+from flask import Flask, flash, url_for, redirect, render_template, request, session, abort
+from flask_babelex import Babel
+from flask_sqlalchemy import SQLAlchemy
+from flask_security import Security, SQLAlchemyUserDatastore, \
+    current_user, hash_password, reset_password_instructions_sent
+
+from flask_security.models import fsqla
+import flask_admin
+from flask_admin.contrib import sqla
+from flask_admin import helpers as admin_helpers
+
+
+# Create Flask application
+app = Flask(__name__)
+app.config.from_pyfile('config.py')
+
+db = SQLAlchemy(app)
+fsqla.FsModels.set_db_info(db)
+
+
+# Define models
+class Role(db.Model, fsqla.FsRoleMixin):
+    def __str__(self):
+        return self.name
+    pass
+
+
+class User(db.Model, fsqla.FsUserMixin):
+    first_name = db.Column(db.String(255))
+    last_name = db.Column(db.String(255))
+
+    def __str__(self):
+        return self.email
+    pass
+
+
+# Setup Babel
+babel = Babel(app)
+
+# Setup Flask-Security
+user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+security = Security(app, user_datastore)
+
+
+@babel.localeselector
+def get_locale():
+    # Mostly for testing for a given session - set lang based on first request.
+    # Honor explicit url request first
+    if "lang" not in session:
+        locale = request.args.get("lang", None)
+        if not locale:
+            locale = request.accept_languages.best
+        if locale:
+            session["lang"] = locale
+    return session.get("lang", "en").replace("-", "_")
+
+
+# Create customized model view class
+class MyModelView(sqla.ModelView):
+    def is_accessible(self):
+        return (current_user.is_active and
+                current_user.is_authenticated and
+                current_user.has_role('superuser')
+        )
+
+    def _handle_view(self, name, **kwargs):
+        """
+        Override builtin _handle_view in order to redirect users when a view is not accessible.
+        """
+        if not self.is_accessible():
+            if current_user.is_authenticated:
+                # permission denied
+                abort(403)
+            else:
+                # login
+                return redirect(url_for('security.login', next=request.url))
+
+# Flask views
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+# Create admin
+admin = flask_admin.Admin(
+    app,
+    'Example: Auth Flask-Security-Too',
+    base_template='my_master.html',
+    template_mode='bootstrap3',
+)
+
+# Add model views
+admin.add_view(MyModelView(Role, db.session))
+admin.add_view(MyModelView(User, db.session))
+
+# define a context processor for merging flask-admin's template context into the
+# flask-security views.
+@security.context_processor
+def security_context_processor():
+    return dict(
+        admin_base_template=admin.base_template,
+        admin_view=admin.index_view,
+        h=admin_helpers,
+        get_url=url_for
+    )
+
+
+@reset_password_instructions_sent.connect_via(app)
+def on_reset(myapp, user, token):
+    # Since we don't have email - just flash the token!
+    # Normal path is the email has this URL in it, and user clicks on it.
+    flash("Go to /admin/reset/{}".format(token))
+
+
+def build_sample_db():
+    """
+    Populate a small db with some example entries.
+    """
+
+    import string
+    import random
+
+    db.drop_all()
+    db.create_all()
+
+    with app.app_context():
+        user_role = Role(name='user')
+        super_user_role = Role(name='superuser')
+        db.session.add(user_role)
+        db.session.add(super_user_role)
+        db.session.commit()
+
+        test_user = user_datastore.create_user(
+            first_name='Admin',
+            email='admin@example.com',
+            password=hash_password('admin'),
+            roles=[user_role, super_user_role]
+        )
+
+        first_names = [
+            'Harry', 'Amelia', 'Oliver', 'Jack', 'Isabella', 'Charlie', 'Sophie', 'Mia',
+            'Jacob', 'Thomas', 'Emily', 'Lily', 'Ava', 'Isla', 'Alfie', 'Olivia', 'Jessica',
+            'Riley', 'William', 'James', 'Geoffrey', 'Lisa', 'Benjamin', 'Stacey', 'Lucy'
+        ]
+        last_names = [
+            'Brown', 'Smith', 'Patel', 'Jones', 'Williams', 'Johnson', 'Taylor', 'Thomas',
+            'Roberts', 'Khan', 'Lewis', 'Jackson', 'Clarke', 'James', 'Phillips', 'Wilson',
+            'Ali', 'Mason', 'Mitchell', 'Rose', 'Davis', 'Davies', 'Rodriguez', 'Cox', 'Alexander'
+        ]
+
+        for i in range(len(first_names)):
+            tmp_email = first_names[i].lower() + "." + last_names[i].lower() + "@example.com"
+            tmp_pass = ''.join(random.choice(string.ascii_lowercase + string.digits) for i in range(10))
+            user_datastore.create_user(
+                first_name=first_names[i],
+                last_name=last_names[i],
+                email=tmp_email,
+                password=hash_password(tmp_pass),
+                roles=[user_role, ]
+            )
+        db.session.commit()
+    return
+
+
+if __name__ == '__main__':
+
+    # Build a sample db on the fly, if one does not exist yet.
+    app_dir = os.path.realpath(os.path.dirname(__file__))
+    database_path = os.path.join(app_dir, app.config['DATABASE_FILE'])
+    if not os.path.exists(database_path):
+        build_sample_db()
+
+    # Start app
+    app.run(debug=True)

--- a/examples/auth-fs-too/config.py
+++ b/examples/auth-fs-too/config.py
@@ -1,0 +1,36 @@
+# Create secret key so we can use sessions
+# python3: secrets.token_urlsafe()
+SECRET_KEY = 'R-Y2m0AMBcWXK2BV-uYO7WTmarL-M3X9-FeU4k0n4u8'
+
+# Create in-memory database
+DATABASE_FILE = 'sample_db.sqlite'
+SQLALCHEMY_DATABASE_URI = 'sqlite:///' + DATABASE_FILE
+# For debug - show every DB query
+SQLALCHEMY_ECHO = True
+
+# Flask-Security config
+SECURITY_URL_PREFIX = "/admin"
+SECURITY_PASSWORD_HASH = "pbkdf2_sha512"
+SECURITY_PASSWORD_SALT = "ATGUOHAELKiubahiughaerGOJAEGj"
+
+# Flask-Security URLs, overridden because they don't put a / at the end
+SECURITY_LOGIN_URL = "/login/"
+SECURITY_LOGOUT_URL = "/logout/"
+SECURITY_REGISTER_URL = "/register/"
+
+SECURITY_POST_LOGIN_VIEW = "/admin/"
+SECURITY_POST_LOGOUT_VIEW = "/admin/"
+SECURITY_POST_REGISTER_VIEW = "/admin/"
+SECURITY_POST_RESET_VIEW = "/admin/"
+
+# Flask-Security features
+SECURITY_REGISTERABLE = True
+SECURITY_CHANGEABLE = True
+SECURITY_RECOVERABLE = True
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+# For demo - no email
+SECURITY_SEND_REGISTER_EMAIL = False
+SECURITY_SEND_PASSWORD_CHANGE_EMAIL = False
+SECURITY_SEND_PASSWORD_RESET_EMAIL = False
+SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL = False

--- a/examples/auth-fs-too/requirements.txt
+++ b/examples/auth-fs-too/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-Admin
+Flask-BabelEx
+Flask-SQLAlchemy
+Flask-Security-Too>=3.3.1

--- a/examples/auth-fs-too/templates/admin/index.html
+++ b/examples/auth-fs-too/templates/admin/index.html
@@ -1,0 +1,30 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+{{ super() }}
+<div class="container">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1">
+            <h1>Flask-Admin example</h1>
+            <p class="lead">
+                Authentication
+            </p>
+            <p>
+                This example shows how you can use <a href="https://flask-security-too.readthedocs.io/en/stable/" target="_blank">Flask-Security-Too</a> for authentication.
+            </p>
+            {% if not current_user.is_authenticated %}
+            <p>You can register as a regular user, or log in as a superuser with the following credentials:
+            <ul>
+                <li>{{ _fsdomain('Email Address') }}: <b>admin@example.com</b></li>
+                <li>{{ _fsdomain('Password') }}: <b>admin</b></li>
+            </ul>
+            <p>
+                <a class="btn btn-primary" href="{{ url_for('security.login') }}">{{ _fsdomain('Login') }}</a> <a class="btn btn-default" href="{{ url_for('security.register') }}">{{ _fsdomain('Register') }}</a>
+            </p>
+            {% endif %}
+            <p>
+                <a class="btn btn-primary" href="/"><i class="glyphicon glyphicon-chevron-left"></i> Back</a>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock body %}

--- a/examples/auth-fs-too/templates/index.html
+++ b/examples/auth-fs-too/templates/index.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <div>
+            <a href="{{ url_for('admin.index') }}">Go to admin!</a>
+        </div>
+    </body>
+</html>

--- a/examples/auth-fs-too/templates/my_master.html
+++ b/examples/auth-fs-too/templates/my_master.html
@@ -1,0 +1,19 @@
+{% extends 'admin/base.html' %}
+
+{% block access_control %}
+{% if current_user.is_authenticated %}
+<div class="navbar-text btn-group pull-right">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+        <i class="glyphicon glyphicon-user"></i>
+        {% if current_user.first_name -%}
+        {{ current_user.first_name }}
+        {% else -%}
+        {{ current_user.email }}
+        {%- endif %}<span class="caret"></span></a>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href="{{ url_for('security.logout') }}">Log out</a></li>
+        <li><a href="{{ url_for('security.change_password') }}">{{  _fsdomain('Change Password') }}</a></li>
+    </ul>
+</div>
+{% endif %}
+{% endblock %}

--- a/examples/auth-fs-too/templates/security/_macros.html
+++ b/examples/auth-fs-too/templates/security/_macros.html
@@ -1,0 +1,27 @@
+{% macro render_field_with_errors(field) %}
+
+<div class="form-group">
+    {{ field.label }} {{ field(class_='form-control', **kwargs)|safe }}
+    {% if field.errors %}
+    <ul>
+        {% for error in field.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+{% endmacro %}
+
+{% macro render_field(field) %}
+<p>{{ field(class_='form-control', **kwargs)|safe }}</p>
+{% endmacro %}
+
+{% macro render_checkbox_field(field) -%}
+<div class="form-group">
+    <div class="checkbox">
+        <label>
+            {{ field(type='checkbox', **kwargs) }} {{ field.label }}
+        </label>
+    </div>
+</div>
+{%- endmacro %}

--- a/examples/auth-fs-too/templates/security/change_password.html
+++ b/examples/auth-fs-too/templates/security/change_password.html
@@ -1,0 +1,17 @@
+{% extends "admin/master.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% block body %}
+{{ super() }}
+<div class="row-fluid">
+    <div class="col-sm-8 col-sm-offset-2">
+        <h1>{{ _fsdomain('Change password') }}</h1>
+        <form action="{{ url_for_security('change_password') }}" method="POST" name="change_password_form">
+          {{ change_password_form.hidden_tag() }}
+          {{ render_field_with_errors(change_password_form.password) }}
+          {{ render_field_with_errors(change_password_form.new_password) }}
+          {{ render_field_with_errors(change_password_form.new_password_confirm) }}
+          {{ render_field(change_password_form.submit, class="btn btn-primary") }}
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/examples/auth-fs-too/templates/security/forgot_password.html
+++ b/examples/auth-fs-too/templates/security/forgot_password.html
@@ -1,0 +1,16 @@
+{% extends "admin/master.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block body %}
+{{ super() }}
+<div class="row-fluid">
+    <div class="col-sm-8 col-sm-offset-2">
+        <h1>{{ _fsdomain('Send password reset instructions') }}</h1>
+        <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
+          {{ forgot_password_form.hidden_tag() }}
+          {{ render_field_with_errors(forgot_password_form.email) }}
+          {{ render_field(forgot_password_form.submit, class="btn btn-primary") }}
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/examples/auth-fs-too/templates/security/login_user.html
+++ b/examples/auth-fs-too/templates/security/login_user.html
@@ -1,0 +1,22 @@
+{% extends 'admin/master.html' %}
+{% from "security/_macros.html" import render_field, render_field_with_errors, render_checkbox_field %}
+{% block body %}
+{{ super() }}
+<div class="row-fluid">
+    <div class="col-sm-8 col-sm-offset-2">
+        <h1>{{ _fsdomain('Login') }}</h1>
+        <div class="well">
+            <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+                {{ login_user_form.hidden_tag() }}
+                {{ render_field_with_errors(login_user_form.email) }}
+                {{ render_field_with_errors(login_user_form.password) }}
+                {{ render_checkbox_field(login_user_form.remember) }}
+                {{ render_field(login_user_form.next) }}
+                {{ render_field(login_user_form.submit, class="btn btn-primary") }}
+            </form>
+            <p>Not yet signed up? Please <a href="{{ url_for_security("register") }}">register for an account</a>.</p>
+            <p><a href="{{  url_for_security("forgot_password") }}">{{ _fsdomain("Forgot password") }}</a></p>
+        </div>
+    </div>
+</div>
+{% endblock body %}

--- a/examples/auth-fs-too/templates/security/register_user.html
+++ b/examples/auth-fs-too/templates/security/register_user.html
@@ -1,0 +1,22 @@
+{% extends 'admin/master.html' %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% block body %}
+{{ super() }}
+<div class="row-fluid">
+    <div class="col-sm-8 col-sm-offset-2">
+        <h1>{{ _fsdomain("Register") }}</h1>
+        <div class="well">
+            <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form">
+                {{ register_user_form.hidden_tag() }}
+                {{ render_field_with_errors(register_user_form.email) }}
+                {{ render_field_with_errors(register_user_form.password) }}
+                {% if register_user_form.password_confirm %}
+                {{ render_field_with_errors(register_user_form.password_confirm) }}
+                {% endif %}
+                {{ render_field(register_user_form.submit, class="btn btn-primary") }}
+            </form>
+            <p>Already signed up? Please <a href="{{ url_for_security('login') }}">log in</a>.</p>
+        </div>
+    </div>
+</div>
+{% endblock body %}

--- a/examples/auth-fs-too/templates/security/reset_password.html
+++ b/examples/auth-fs-too/templates/security/reset_password.html
@@ -1,0 +1,17 @@
+{% extends "admin/master.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block body %}
+{{ super() }}
+<div class="row-fluid">
+    <div class="col-sm-8 col-sm-offset-2">
+        <h1>{{ _fsdomain('Reset password') }}</h1>
+        <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="POST" name="reset_password_form">
+          {{ reset_password_form.hidden_tag() }}
+          {{ render_field_with_errors(reset_password_form.password) }}
+          {{ render_field_with_errors(reset_password_form.password_confirm) }}
+          {{ render_field(reset_password_form.submit, class="btn btn-primary") }}
+        </form>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION

Flask-Security-Too is a maintained and improved fork of the original Flask-Security.

The example is more full-functioned - providing all major views adapted to the current
Flask-Admin templates.

The example also makes use of the new more batteries included patterns introduced in recent
versions of Flask-Security-Too.

It also shows how to localize - utilizing a new jinja method to allow the new
templates to access existing flask-security-too translations.