### PR TITLE
Fix for loading association proxy results

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -69,7 +69,9 @@ class QueryAjaxModelLoader(AjaxModelLoader):
     def get_list(self, term, offset=0, limit=DEFAULT_PAGE_SIZE):
         query = self.get_query()
 
-        filters = (cast(field, String).ilike(u'%%%s%%' % term) for field in self._cached_fields)
+        # no type casting to string if a ColumnAssociationProxyInstance is given
+        filters = (field.ilike(u'%%%s%%' % term) if is_association_proxy(field) 
+                   else cast(field, String).ilike(u'%%%s%%' % term) for field in self._cached_fields)
         query = query.filter(or_(*filters))
 
         if self.filters:

--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -70,7 +70,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         query = self.get_query()
 
         # no type casting to string if a ColumnAssociationProxyInstance is given
-        filters = (field.ilike(u'%%%s%%' % term) if is_association_proxy(field) 
+        filters = (field.ilike(u'%%%s%%' % term) if is_association_proxy(field)
                    else cast(field, String).ilike(u'%%%s%%' % term) for field in self._cached_fields)
         query = query.filter(or_(*filters))
 

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -216,4 +216,6 @@ def is_relationship(attr):
 
 
 def is_association_proxy(attr):
+    if hasattr(attr, 'parent'):
+        attr = attr.parent
     return hasattr(attr, 'extension_type') and attr.extension_type == ASSOCIATION_PROXY


### PR DESCRIPTION
When searching/filtering on a value from an association proxied column in a form, Flask-Admin was trying to cast a ColumnAssociationProxyInstance to String, resulting in an error:

`sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) can't adapt type 'ColumnAssociationProxyInstance'
`

Now, a field is only casted if it is not an association proxy result. 

This PR implements the proposed fix for the views from https://github.com/flask-admin/flask-admin/issues/1906 and fixes the error above in the forms. 