### PR TITLE
Pin werkzeug to <1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ extras_require = {
 
 install_requires = [
     'Flask>=0.7',
+    'werkzeug<1',
     'wtforms'
 ]
 


### PR DESCRIPTION
The latest release of werkzeug (v1) has removed deprecated features including `werkzeug.secure_filename` which this library relies upon.

This commit pins the dependency to anything lower than v1 so the latest release will stop breaking until a patch can be submitted to support v1 and above.

This references #1951 