### PR TITLE
Drop testing Python 3.4 and add 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
       env: TOX_ENV=flake8
     - python: 2.7
       env: TOX_ENV=docs-html
-    - python: 3.4
-      env: TOX_ENV=py34-WTForms1
-    - python: 3.4
-      env: TOX_ENV=py34-WTForms2
     - python: 3.5
       env: TOX_ENV=py35-WTForms1
     - python: 3.5
@@ -22,6 +18,12 @@ matrix:
       env: TOX_ENV=py36-WTForms1
     - python: 3.6
       env: TOX_ENV=py36-WTForms2
+    - python: 3.7
+      env: TOX_ENV=py37-WTForms1
+    - python: 3.7
+      env: TOX_ENV=py37-WTForms2
+    - python: 3.8
+      env: TOX_ENV=py38-WTForms2
 
 addons:
   postgresql: "9.4"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}-WTForms{1,2}
+    py{27,35,36,37}-WTForms{1,2}
+    py38-WTForms2
     flake8
     docs-html
 skipsdist = true


### PR DESCRIPTION
Python 3.4 is EOL.

---

Tests pass for me, with PostgreSQL but skipping MongoDB.

Requested in https://github.com/flask-admin/flask-admin/issues/1961.
