### PR TITLE
Enable testing of MongoEngine backend on Python 3

### DIFF
--- a/flask_admin/tests/mongoengine/__init__.py
+++ b/flask_admin/tests/mongoengine/__init__.py
@@ -1,11 +1,6 @@
 from nose.plugins.skip import SkipTest
 from wtforms import __version__ as wtforms_version
 
-# Skip test on PY3
-from flask_admin._compat import PY2
-if not PY2:
-    raise SkipTest('MongoEngine is not Python 3 compatible')
-
 if int(wtforms_version[0]) < 2:
     raise SkipTest('MongoEngine does not support WTForms 1.')
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -15,7 +15,7 @@ class CustomModelView(ModelView):
     def __init__(self, model,
                  name=None, category=None, endpoint=None, url=None,
                  **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
         super(CustomModelView, self).__init__(model,
@@ -49,20 +49,27 @@ def create_models(db):
 
 
 def fill_db(Model1, Model2):
-    Model1('test1_val_1', 'test2_val_1').save()
-    Model1('test1_val_2', 'test2_val_2').save()
-    Model1('test1_val_3', 'test2_val_3').save()
-    Model1('test1_val_4', 'test2_val_4').save()
-    Model1(None, 'empty_obj').save()
+    Model1(test1='test1_val_1', test2='test2_val_1').save()
+    Model1(test1='test1_val_2', test2='test2_val_2').save()
+    Model1(test1='test1_val_3', test2='test2_val_3').save()
+    Model1(test1='test1_val_4', test2='test2_val_4').save()
+    Model1(test1=None, test2='empty_obj').save()
 
-    Model2('string_field_val_1', None, None, True).save()
-    Model2('string_field_val_2', None, None, False).save()
-    Model2('string_field_val_3', 5000, 25.9).save()
-    Model2('string_field_val_4', 9000, 75.5).save()
-    Model2('string_field_val_5', 6169453081680413441).save()
+    Model2(string_field='string_field_val_1', int_field=None,
+           float_field=None, bool_field=True).save()
+    Model2(string_field='string_field_val_2', int_field=None,
+           float_field=None, bool_field=False).save()
+    Model2(string_field='string_field_val_3', int_field=5000,
+           float_field=25.9).save()
+    Model2(string_field='string_field_val_4', int_field=9000,
+           float_field=75.5).save()
+    Model2(string_field='string_field_val_5',
+           int_field=6169453081680413441).save()
 
-    Model1('datetime_obj1', datetime_field=datetime(2014, 4, 3, 1, 9, 0)).save()
-    Model1('datetime_obj2', datetime_field=datetime(2013, 3, 2, 0, 8, 0)).save()
+    Model1(test1='datetime_obj1',
+           datetime_field=datetime(2014, 4, 3, 1, 9, 0)).save()
+    Model1(test1='datetime_obj2',
+           datetime_field=datetime(2013, 3, 2, 0, 8, 0)).save()
 
 
 def test_model():
@@ -116,7 +123,7 @@ def test_model():
 
     rv = client.get('/admin/model1/')
     eq_(rv.status_code, 200)
-    ok_('test1large' in rv.data)
+    ok_(b'test1large' in rv.data)
 
     url = '/admin/model1/edit/?id=%s' % model.id
     rv = client.get(url)
@@ -977,7 +984,7 @@ def test_sortedlist_subdocument_validation():
     rv = client.post('/admin/model1/new/',
                      data={'test1': 'test1large', 'subdoc-0-name': '', 'subdoc-0-value': 'test'})
     eq_(rv.status_code, 200)
-    ok_('This field is required' in rv.data)
+    ok_(b'This field is required' in rv.data)
 
 
 def test_list_subdocument_validation():
@@ -1002,7 +1009,7 @@ def test_list_subdocument_validation():
     rv = client.post('/admin/model1/new/',
                      data={'test1': 'test1large', 'subdoc-0-name': '', 'subdoc-0-value': 'test'})
     eq_(rv.status_code, 200)
-    ok_('This field is required' in rv.data)
+    ok_(b'This field is required' in rv.data)
 
 
 def test_ajax_fk():
@@ -1056,7 +1063,7 @@ def test_ajax_fk():
     client = app.test_client()
 
     req = client.get(u'/admin/view/ajax/lookup/?name=model1&query=foo')
-    eq_(req.data, u'[["%s", "foo"]]' % model2.id)
+    eq_(req.data.decode('utf-8'), u'[["%s", "foo"]]' % model2.id)
 
     # Check submitting
     client.post('/admin/view/new/', data={u'model1': as_unicode(model.id)})

--- a/flask_admin/tests/pymongo/__init__.py
+++ b/flask_admin/tests/pymongo/__init__.py
@@ -1,4 +1,4 @@
-import pymongo
+from pymongo import MongoClient
 
 from flask import Flask
 from flask_admin import Admin
@@ -9,8 +9,8 @@ def setup():
     app.config['SECRET_KEY'] = '1'
     app.config['CSRF_ENABLED'] = False
 
-    conn = pymongo.Connection()
-    db = conn.tests
+    client = MongoClient()
+    db = client.tests
 
     admin = Admin(app)
 

--- a/flask_admin/tests/pymongo/test_basic.py
+++ b/flask_admin/tests/pymongo/test_basic.py
@@ -8,11 +8,13 @@ from . import setup
 
 
 class TestForm(form.Form):
+    __test__ = False
     test1 = fields.StringField('Test1')
     test2 = fields.StringField('Test2')
 
 
 class TestView(ModelView):
+    __test__ = False
     column_list = ('test1', 'test2', 'test3', 'test4')
     column_sortable_list = ('test1', 'test2')
 

--- a/flask_admin/tests/pymongo/test_basic.py
+++ b/flask_admin/tests/pymongo/test_basic.py
@@ -26,7 +26,7 @@ def test_model():
     admin.add_view(view)
 
     # Drop existing data (if any)
-    db.test.remove()
+    db.test.delete_many({})
 
     eq_(view.name, 'Test')
     eq_(view.endpoint, 'testview')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ Flask>=0.7
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee
-mongoengine<0.11.0
-pymongo==2.8
+mongoengine
+pymongo
 flask-mongoengine==0.8.2
 pillow>=3.3.2
 Babel<=1.3


### PR DESCRIPTION
Lets's see how this goes. flask-mongoengine are now testing newer versions of Python with few obvious changes. Maybe the pinned PyMongo 2.8 will be an issue.
