### PR TITLE
Don't install tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include README.rst
 recursive-include flask_admin/static *
 recursive-include flask_admin/templates *
 recursive-include flask_admin/translations *
-recursive-include flask_admin/tests *
+recursive-exclude flask_admin/tests *
 recursive-exclude flask_admin *.pyc

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     author_email=grep('__email__'),
     description='Simple and extensible admin interface framework for Flask',
     long_description=desc(),
-    packages=find_packages(),
+    packages=find_packages(exclude=['*.tests', 'tests.*', '*.tests.*']),
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
Save installing over a hundred files per supported Python version that aren't normally used.

Exclude filter taken from setuptools docs.
