### PR TITLE
fix cast failed VARCHAR2 in oracle

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -1,5 +1,4 @@
 from sqlalchemy import or_, and_, cast
-from sqlalchemy.types import String
 
 from flask_admin._compat import as_unicode, string_types
 from flask_admin.model.ajax import AjaxModelLoader, DEFAULT_PAGE_SIZE
@@ -66,7 +65,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
     def get_list(self, term, offset=0, limit=DEFAULT_PAGE_SIZE):
         query = self.session.query(self.model)
 
-        filters = (cast(field, String).ilike(u'%%%s%%' % term) for field in self._cached_fields)
+        filters = (cast(field, field.type).ilike(u'%%%s%%' % term) for field in self._cached_fields)
         query = query.filter(or_(*filters))
 
         if self.filters:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -8,7 +8,6 @@ from sqlalchemy.sql.expression import desc
 from sqlalchemy import Boolean, Table, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import cast
-from sqlalchemy import Unicode
 
 from flask import current_app, flash
 
@@ -928,11 +927,11 @@ class ModelView(BaseModelView):
                                                                                    inner_join=False)
 
                 column = field if alias is None else getattr(alias, field.key)
-                filter_stmt.append(cast(column, Unicode).ilike(stmt))
+                filter_stmt.append(cast(column, column.type).ilike(stmt))
 
                 if count_filter_stmt is not None:
                     column = field if count_alias is None else getattr(count_alias, field.key)
-                    count_filter_stmt.append(cast(column, Unicode).ilike(stmt))
+                    count_filter_stmt.append(cast(column, column.type).ilike(stmt))
 
             query = query.filter(or_(*filter_stmt))
 


### PR DESCRIPTION
A field in Oracle table declared as:
>  DESCRIPTION	VARCHAR2(2048 BYTE)

Access db code like:
```python
from sqlalchemy.dialects.oracle import VARCHAR2

description = Column(VARCHAR2(2048), nullable=True)

# add this in admin.py
column_searchable_list = ('description',)
```

exception caught in search:

> sqlalchemy.exc.DatabaseError: (cx_Oracle.DatabaseError) ORA-00906:  missing left parenthesis [SQL: SELECT count(:count_2) AS count_1 FROM t_event_log WHERE lower(CAST(t_event_log.description AS `VARCHAR2`)) LIKE lower(:param_1)] [parameters: {'count_2': '*', 'param_1': '%100003%'}] (Background on this error at: http://sqlalche.me/e/4xp6)

The SQL should be 
```sql
CAST(t_event_log.description AS VARCHAR2(2048))
```

'(2048)' is missing in SQL which cause error.

This PR fixed this.