### PR TITLE
Update requirements.txt

### DIFF
--- a/examples/sqla/requirements.txt
+++ b/examples/sqla/requirements.txt
@@ -7,6 +7,7 @@ enum34; python_version < '3.0'
 sqlalchemy_utils
 arrow
 colour
+email-validator
 
 # note: for local development, replace 'Flask-Admin' above with a reference to
 # your local copy of the repo e.g. '-e .' if you're installing this from the


### PR DESCRIPTION
adding a requirement for local development as it was giving error 
<pre>
Exception: Install 'email_validator' for email validation support.
</pre>
in ubuntu 18.04

the resource used: [link](https://stackoverflow.com/questions/61356834/wtforms-install-email-validator-for-email-validation-support)