### PR TITLE
Example authentication with OpenID Connect (combining Flask-Security + Authlib)

### DIFF
--- a/examples/auth-authlib-oidc/README.rst
+++ b/examples/auth-authlib-oidc/README.rst
@@ -1,0 +1,36 @@
+This example shows how to integrate Flask-Security (https://pythonhosted.org/Flask-Security/) with Flask-Admin using the SQLAlchemy backend, while relying on OpenID Connect authentication, based on authlib.
+Since authentication is delegated to an OIDC provider, there is no need for a login/register/forgot password/etc. views provided by Flask-Security.
+We'll replace those by simples login/logout views that will trigger OIDC authentication.
+
+
+To run this example:
+
+1. Clone the repository::
+
+     git clone https://github.com/flask-admin/flask-admin.git
+     cd flask-admin
+
+2. Create and activate a virtual environment::
+
+     virtualenv env
+     source env/bin/activate
+
+3. Install requirements::
+
+     pip install -r 'examples/auth-oidc-authlib/requirements.txt'
+
+4. Point the configuration to your own OIDC provider, in examples/auth-oidc-authlib/config.py::
+
+    OIDC_SAMPLE_SERVER_METADATA_URL = "https://your.oidc.com/.well-known/openid-configuration"
+    OIDC_SAMPLE_CLIENT_ID = "your_client_id"
+    OIDC_SAMPLE_CLIENT_SECRET = "your_client_secret"
+
+4. Run the application::
+
+     python examples/auth-authlib-oidc/app.py
+
+The first time you run this example, a sample sqlite database gets populated automatically. To suppress this behaviour,
+comment the following lines in app.py:::
+
+     if not os.path.exists(database_path):
+         build_sample_db()

--- a/examples/auth-authlib-oidc/app.py
+++ b/examples/auth-authlib-oidc/app.py
@@ -1,0 +1,179 @@
+import os
+
+from authlib.integrations.flask_client import OAuth
+from flask import Flask, url_for, redirect, render_template, request, abort
+from flask_login import login_user
+from flask_sqlalchemy import SQLAlchemy
+from flask_security import Security, SQLAlchemyUserDatastore, \
+    UserMixin, RoleMixin, login_required, current_user, logout_user
+from sqlalchemy.orm.exc import NoResultFound
+
+import flask_admin
+from flask_admin.contrib import sqla
+from flask_admin import helpers as admin_helpers
+
+
+# Create Flask application
+app = Flask(__name__)
+app.config.from_pyfile('config.py')
+db = SQLAlchemy(app)
+
+
+# Define models
+roles_users = db.Table(
+    'roles_users',
+    db.Column('user_id', db.Integer(), db.ForeignKey('user.id')),
+    db.Column('role_id', db.Integer(), db.ForeignKey('role.id'))
+)
+
+
+class Role(db.Model, RoleMixin):
+    id = db.Column(db.Integer(), primary_key=True)
+    name = db.Column(db.String(80), unique=True)
+    description = db.Column(db.String(255))
+
+    def __str__(self):
+        return self.name
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(255))
+    last_name = db.Column(db.String(255))
+    email = db.Column(db.String(255), unique=True)
+    active = db.Column(db.Boolean())
+    confirmed_at = db.Column(db.DateTime())
+    roles = db.relationship('Role', secondary=roles_users,
+                            backref=db.backref('users', lazy='dynamic'))
+
+    def __str__(self):
+        return self.email
+
+
+# Setup Flask-Security
+user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+security = Security(app, user_datastore, register_blueprint=False) # don't register the built-in login/logout/etc. views
+
+# setup authlib
+oauth = OAuth(app)
+oauth.register(
+    "oidc_sample",
+    server_metadata_url=app.config["OIDC_SAMPLE_SERVER_METADATA_URL"],
+    client_kwargs={"scope": "openid email profile", "code_challenge_method": "S256"},
+)
+
+
+@app.route("/login")
+def login():
+    redirect_uri = url_for("oauth_callback", _external=True)
+    return oauth.oidc_sample.authorize_redirect(redirect_uri)
+
+
+app.login_manager.login_view = (
+    "login"  # replace default form-based login page by OIDC based auth
+)
+
+
+@app.route("/oauth_callback")
+def oauth_callback():
+    token = oauth.oidc_sample.authorize_access_token()
+    user_claims = oauth.oidc_sample.parse_id_token(token)
+    email = user_claims.get("email")
+    try:
+        user = User.query.filter_by(email=email).one()
+    except NoResultFound: # to support just-in-time provisionning
+        user = User(first_name=user_claims.get("first_name"), last_name=user_claims.get("last_name"), email=email, active=True)
+        db.session.add(user)
+        db.session.commit()
+    login_user(user)
+    print(current_user.is_authenticated)
+    return redirect("/admin/")
+
+
+@app.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    return redirect("/admin/")
+
+
+# Create customized model view class
+class MyModelView(sqla.ModelView):
+    def is_accessible(self):
+        return (current_user.is_active and
+                current_user.is_authenticated and
+                current_user.has_role('superuser')
+        )
+
+    def _handle_view(self, name, **kwargs):
+        """
+        Override builtin _handle_view in order to redirect users when a view is not accessible.
+        """
+        if not self.is_accessible():
+            if current_user.is_authenticated:
+                # permission denied
+                abort(403)
+            else:
+                # login
+                return redirect(url_for('login', next=request.url))
+
+# Flask views
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+# Create admin
+admin = flask_admin.Admin(
+    app,
+    'Example: Auth with OIDC',
+    base_template='my_master.html',
+    template_mode='bootstrap3',
+)
+
+# Add model views
+admin.add_view(MyModelView(Role, db.session))
+admin.add_view(MyModelView(User, db.session))
+
+# define a context processor for merging flask-admin's template context into the
+# flask-security views.
+@security.context_processor
+def security_context_processor():
+    return dict(
+        admin_base_template=admin.base_template,
+        admin_view=admin.index_view,
+        h=admin_helpers,
+        get_url=url_for
+    )
+
+
+def build_sample_db():
+    """
+    Populate a small db with some example entries.
+    """
+
+    import string
+    import random
+
+    db.drop_all()
+    db.create_all()
+
+    with app.app_context():
+        user_role = Role(name='user')
+        super_user_role = Role(name='superuser')
+        db.session.add(user_role)
+        db.session.add(super_user_role)
+        db.session.commit()
+
+    return
+
+
+if __name__ == '__main__':
+
+    # Build a sample db on the fly, if one does not exist yet.
+    app_dir = os.path.realpath(os.path.dirname(__file__))
+    database_path = os.path.join(app_dir, app.config['DATABASE_FILE'])
+    if not os.path.exists(database_path):
+        build_sample_db()
+
+    # Start app
+    app.run(debug=True)

--- a/examples/auth-authlib-oidc/config.py
+++ b/examples/auth-authlib-oidc/config.py
@@ -1,0 +1,31 @@
+# Create dummy secrey key so we can use sessions
+SECRET_KEY = '123456790'
+
+# Create in-memory database
+DATABASE_FILE = 'sample_db.sqlite'
+SQLALCHEMY_DATABASE_URI = 'sqlite:///' + DATABASE_FILE
+SQLALCHEMY_ECHO = True
+
+# Flask-Security config
+SECURITY_URL_PREFIX = "/admin"
+SECURITY_PASSWORD_HASH = "pbkdf2_sha512"
+SECURITY_PASSWORD_SALT = "ATGUOHAELKiubahiughaerGOJAEGj"
+
+# Flask-Security URLs, overridden because they don't put a / at the end
+SECURITY_LOGIN_URL = "/login/"
+SECURITY_LOGOUT_URL = "/logout/"
+SECURITY_REGISTER_URL = "/register/"
+
+SECURITY_POST_LOGIN_VIEW = "/admin/"
+SECURITY_POST_LOGOUT_VIEW = "/admin/"
+SECURITY_POST_REGISTER_VIEW = "/admin/"
+
+# Flask-Security features
+SECURITY_REGISTERABLE = False
+SECURITY_SEND_REGISTER_EMAIL = False
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+# Point this to your own OIDC provider
+OIDC_SAMPLE_SERVER_METADATA_URL = "https://sample.oidc.com/.well-known/openid-configuration"
+OIDC_SAMPLE_CLIENT_ID = "your_client_id"
+OIDC_SAMPLE_CLIENT_SECRET = "your_client_secret"

--- a/examples/auth-authlib-oidc/requirements.txt
+++ b/examples/auth-authlib-oidc/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-Admin
+Flask-SQLAlchemy
+Flask-Security>=1.7.5
+authlib
+email_validator

--- a/examples/auth-authlib-oidc/templates/admin/index.html
+++ b/examples/auth-authlib-oidc/templates/admin/index.html
@@ -1,0 +1,29 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+{{ super() }}
+<div class="container">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1">
+            <h1>Flask-Admin example</h1>
+            <p class="lead">
+                Authentication
+            </p>
+            <p>
+                This example shows how you can use <a href="https://docs.authlib.org/">Authlib</a> for authentication, together with <a href="https://pythonhosted.org/Flask-Security/index.html" target="_blank">Flask-Security</a> for authorization.
+            </p>
+            {% if not current_user.is_authenticated %}
+            <p>
+                <a class="btn btn-primary" href="{{ url_for('login') }}">Login</a>
+            </p>
+            {% else %}
+            <p>
+                <a class="btn btn-primary" href="{{ url_for('logout') }}">Logout</a>
+            </p>
+            {% endif %}
+            <p>
+                <a class="btn btn-primary" href="/"><i class="glyphicon glyphicon-chevron-left"></i> Back</a>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock body %}

--- a/examples/auth-authlib-oidc/templates/index.html
+++ b/examples/auth-authlib-oidc/templates/index.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <div>
+            <a href="{{ url_for('admin.index') }}">Go to admin!</a>
+        </div>
+    </body>
+</html>

--- a/examples/auth-authlib-oidc/templates/my_master.html
+++ b/examples/auth-authlib-oidc/templates/my_master.html
@@ -1,0 +1,18 @@
+{% extends 'admin/base.html' %}
+
+{% block access_control %}
+{% if current_user.is_authenticated %}
+<div class="navbar-text btn-group pull-right">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+        <i class="glyphicon glyphicon-user"></i>
+        {% if current_user.first_name -%}
+        {{ current_user.first_name }}
+        {% else -%}
+        {{ current_user.email }}
+        {%- endif %}<span class="caret"></span></a>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href="{{ url_for('logout') }}">Log out</a></li>
+    </ul>
+</div>
+{% endif %}
+{% endblock %}

--- a/flask_admin/menu.py
+++ b/flask_admin/menu.py
@@ -140,7 +140,15 @@ class MenuLink(BaseMenu):
         self.endpoint = endpoint
 
     def get_url(self):
-        return self.url or url_for(self.endpoint)
+        if callable(self.url):
+            return self.url()
+        if self.url:
+            return self.url
+        if self.endpoint:
+            return url_for(self.endpoint)
+
+    def is_visible(self):
+        return bool(self.get_url())
 
 
 class SubMenuCategory(MenuCategory):


### PR DESCRIPTION
This example demonstrate authentication with OpenID Connect. 
It does so by leveraging authlib and keeping the familiar features from Flask-Security.
Since the user management is completely done by the OIDC provider, there is no need for login forms, password management/reset etc. views.
To run the example, your need an OpenID Connect (you can get one for free for testing with various provider, e.g. auth0)