### PR TITLE
Allow subdomain argument in app factory constructor

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -674,7 +674,7 @@ class Admin(object):
         return self._menu_categories.get(name)
 
     def init_app(self, app, index_view=None,
-                 endpoint=None, url=None):
+                 endpoint=None, url=None, subdomain=None):
         """
             Register all views with the Flask application.
 
@@ -682,6 +682,7 @@ class Admin(object):
                 Flask application instance
         """
         self.app = app
+        self.subdomain = subdomain
 
         self._init_extension()
 


### PR DESCRIPTION
Adds the `subdomain` argument to the app factory `init_app` constructor, rather than having to pass it to the class constructor on init with `admin = Admin(subdomain='...')`. This is helpful if you prefer to separate your extension init and configuration logic.