### PR TITLE
Update import location for SQLAlchemy project reorganization.

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -1,7 +1,12 @@
 import types
 
 from sqlalchemy import tuple_, or_, and_, inspect
-from sqlalchemy.orm.clsregistry import _class_resolver
+try:
+    # Attempt _class_resolver import from SQLALchemy 1.4/2.0 module architecture.
+    from sqlalchemy.orm.clsregistry import _class_resolver
+except ImportError:
+    # If 1.4/2.0 module import fails, fall back to <1.3.x architecture.
+    from sqlalchemy.ext.declarative.clsregistry import _class_resolver
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
 from sqlalchemy.sql.operators import eq

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -1,7 +1,7 @@
 import types
 
 from sqlalchemy import tuple_, or_, and_, inspect
-from sqlalchemy.ext.declarative.clsregistry import _class_resolver
+from sqlalchemy.orm.clsregistry import _class_resolver
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
 from sqlalchemy.sql.operators import eq


### PR DESCRIPTION
For the pending 1.4 SQLAlchemy release, the `_class_resolver` class is moving to the `orm` module [here](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/orm/clsregistry.py#L317-L354). This PR updates the module import path for one of the dependencies.