### PR TITLE
Use col-form-label instead of control-label in bootstrap4 templates.

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -120,7 +120,7 @@
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
   <div class="form-group {{ kwargs.get('column_class', '') }}">
-    <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block"{% endif %}>{{ field.label.text }}
+    <label for="{{ field.id }}" class="col-form-label" {% if field.widget.input_type == 'checkbox' %}style="display: block"{% endif %}>{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
           <strong style="color: red">&#42;</strong>
         {%- else -%}


### PR DESCRIPTION
`.control-label` has been renamed to `.col-form-label.` in bootstrap 4.

See the migration guide here : https://getbootstrap.com/docs/4.5/migration/#forms-1