### PR TITLE
Add the "row" class to form groups in bootstrap 4 templates.

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -119,7 +119,7 @@
   {% set direct_error = h.is_field_error(field.errors) %}
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
-  <div class="form-group {{ kwargs.get('column_class', '') }}">
+  <div class="form-group row {{ kwargs.get('column_class', '') }}">
     <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block"{% endif %}>{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
           <strong style="color: red">&#42;</strong>
@@ -220,7 +220,7 @@
         {% endif %}
   {% else %}
     <hr>
-    <div class="form-group">
+    <div class="form-group row">
       <div class="col-md-offset-2 col-md-10 submit-row">
         <input type="submit" class="btn btn-primary" value="{{ _gettext('Save') }}" />
         {% if extra %}


### PR DESCRIPTION
In bootstrap 4, `.form-group` no longer applies styles from the `.row` via mixin, so `.row` is now required for horizontal grid layouts (e.g., `<div class="form-group row">`).

See https://getbootstrap.com/docs/4.2/migration/#forms-1 for more details.