### PR TITLE
Removed lowering the whole command in the rediscli.py

### DIFF
--- a/flask_admin/contrib/rediscli.py
+++ b/flask_admin/contrib/rediscli.py
@@ -196,7 +196,7 @@ class RedisCli(BaseView):
             AJAX API.
         """
         try:
-            cmd = request.form.get('cmd').lower()
+            cmd = request.form.get('cmd')
             if not cmd:
                 return self._error('Cli: Empty command.')
 


### PR DESCRIPTION
The `lower()` method sets the whole command to lowercase. This means that also the value of a Redis key gets set to lowercase. This can be fatal in some cases.