### PR TITLE
Add missing package to requirements of auth example

### DIFF
--- a/examples/auth/requirements.txt
+++ b/examples/auth/requirements.txt
@@ -2,3 +2,4 @@ Flask
 Flask-Admin
 Flask-SQLAlchemy
 Flask-Security>=1.7.5
+email_validator


### PR DESCRIPTION
When trying to get the example `auth` running as described in `examples/auth/README.rst` the following exception is thrown:
```
(env) [a@b flask-admin]$ python examples/auth/app.py
Traceback (most recent call last):
  File "/home/m/dev/flask-admin/examples/auth/app.py", line 4, in <module>
    from flask_security import Security, SQLAlchemyUserDatastore, \
  File "/home/m/dev/flask-admin/env/lib/python3.9/site-packages/flask_security/__init__.py", line 13, in <module>
    from .core import Security, RoleMixin, UserMixin, AnonymousUser, current_user
  File "/home/m/dev/flask-admin/env/lib/python3.9/site-packages/flask_security/core.py", line 28, in <module>
    from .forms import ChangePasswordForm, ConfirmRegisterForm, \
  File "/home/m/dev/flask-admin/env/lib/python3.9/site-packages/flask_security/forms.py", line 69, in <module>
    email_validator = Email(message='INVALID_EMAIL_ADDRESS')
  File "/home/m/dev/flask-admin/env/lib/python3.9/site-packages/wtforms/validators.py", line 332, in __init__
    raise Exception("Install 'email_validator' for email validation support.")
```
With  `email_validator` is added to `requirements.txt` it works as expected.