### PR TITLE
[Travis] Fix Travis flake8 style E203

### DIFF
--- a/flask_admin/contrib/fileadmin/s3.py
+++ b/flask_admin/contrib/fileadmin/s3.py
@@ -135,7 +135,7 @@ class S3Storage(object):
     def save_file(self, path, file_data):
         key = Key(self.bucket, path)
         headers = {
-            'Content-Type' : file_data.content_type,
+            'Content-Type': file_data.content_type,
         }
         key.set_contents_from_file(file_data.stream, headers=headers)
 


### PR DESCRIPTION
Remove E203 whitespace:

> flask_admin/contrib/fileadmin/s3.py:138:27: E203 whitespace before ':'

[Travis Job detail](https://travis-ci.org/github/flask-admin/flask-admin/jobs/750526709)