### PR TITLE
[Travis] Pin MongoEngine version to prevent syntax error on Python 3.5 (black arguments change)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ Flask>=0.7
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee
-mongoengine
+mongoengine<=0.21.0
 pymongo
 flask-mongoengine==0.8.2
 pillow>=3.3.2

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'pymongo',
         'wtf-peewee',
         'sqlalchemy',
-        'flask-mongoengine',
+        'flask-mongoengine<=0.21.0',
         'flask-sqlalchemy',
         'flask-babelex',
         'shapely',


### PR DESCRIPTION
From version 0.21.0, MongoEngine added an ending comma after `**kwargs` in the argument list (with black), it throws syntax error on Python 3.5:

```pytb
ERROR: Failure: SyntaxError (invalid syntax (connection.py, line 57))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/imp.py", line 245, in load_module
    return load_package(name, filename)
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/imp.py", line 217, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 697, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/travis/build/flask-admin/flask-admin/flask_admin/tests/mongoengine/__init__.py", line 9, in <module>
    from flask_mongoengine import MongoEngine
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/flask_mongoengine/__init__.py", line 6, in <module>
    import mongoengine
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/mongoengine/__init__.py", line 2, in <module>
    from mongoengine import connection
  File "/home/travis/build/flask-admin/flask-admin/.tox/py35-WTForms2/lib/python3.5/site-packages/mongoengine/connection.py", line 57
    **kwargs,
            ^
SyntaxError: invalid syntax
```

[Travis Job detail](https://travis-ci.org/github/flask-admin/flask-admin/jobs/750526712)