### PR TITLE
Add add_category method to flask_admin.Admin

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -582,6 +582,29 @@ class Admin(object):
         for view in args:
             self.add_view(view)
 
+    def add_category(self, name, class_name=None, icon_type=None, icon_value=None):
+        """
+            Add a category of a given name
+
+            :param name:
+                The name of the new menu category.
+            :param class_name:
+                The class name for the new menu category.
+            :param icon_type:
+                The icon name for the new menu category.
+            :param icon_value:
+                The icon value for the new menu category.
+        """
+        cat_text = as_unicode(name)
+
+        category = self.get_category_menu_item(name)
+        if category:
+            return
+
+        category = MenuCategory(name, class_name=class_name, icon_type=icon_type, icon_value=icon_value)
+        self._menu_categories[cat_text] = category
+        self._menu.append(category)
+
     def add_sub_category(self, name, parent_name):
 
         """

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -225,6 +225,33 @@ def test_add_views():
     eq_(len(admin.menu()), 3)
 
 
+def test_add_category():
+    app = Flask(__name__)
+    admin = base.Admin(app)
+
+    admin.add_category('Category1', 'class-name', 'icon-type', 'icon-value')
+    admin.add_view(MockView(name='Test 1', endpoint='test1', category='Category1'))
+    admin.add_view(MockView(name='Test 2', endpoint='test2', category='Category2'))
+
+    eq_(len(admin.menu()), 3)
+
+    # Test 1 should be underneath Category1
+    eq_(admin.menu()[1].name, 'Category1')
+    eq_(admin.menu()[1].get_class_name(), 'class-name')
+    eq_(admin.menu()[1].get_icon_type(), 'icon-type')
+    eq_(admin.menu()[1].get_icon_value(), 'icon-value')
+    eq_(len(admin.menu()[1].get_children()), 1)
+    eq_(admin.menu()[1].get_children()[0].name, 'Test 1')
+
+    # Test 2 should be underneath Category2
+    eq_(admin.menu()[2].name, 'Category2')
+    eq_(admin.menu()[2].get_class_name(), None)
+    eq_(admin.menu()[2].get_icon_type(), None)
+    eq_(admin.menu()[2].get_icon_value(), None)
+    eq_(len(admin.menu()[2].get_children()), 1)
+    eq_(admin.menu()[2].get_children()[0].name, 'Test 2')
+
+
 @raises(Exception)
 def test_no_default():
     app = Flask(__name__)


### PR DESCRIPTION
This commit resolve following problems.

- `flask_admin.Admin.add_menu_item` can't set icon_type and icon_value to category