### PR TITLE
Fix broken rendering when user specifies any endpoint other than 'admin'

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/static.html
+++ b/flask_admin/templates/bootstrap2/admin/static.html
@@ -1,3 +1,3 @@
 {% macro url() -%}
-    {{ get_url('admin.static', *varargs, **kwargs) }}
+    {{ get_url('{admin_endpoint}.static'.format(admin_endpoint=admin_view.admin.endpoint), *varargs, **kwargs) }}
 {%- endmacro %}

--- a/flask_admin/templates/bootstrap3/admin/static.html
+++ b/flask_admin/templates/bootstrap3/admin/static.html
@@ -1,3 +1,3 @@
 {% macro url() -%}
-    {{ get_url('admin.static', *varargs, **kwargs) }}
+    {{ get_url('{admin_endpoint}.static'.format(admin_endpoint=admin_view.admin.endpoint), *varargs, **kwargs) }}
 {%- endmacro %}

--- a/flask_admin/templates/bootstrap4/admin/static.html
+++ b/flask_admin/templates/bootstrap4/admin/static.html
@@ -1,3 +1,3 @@
 {% macro url() -%}
-    {{ get_url('admin.static', *varargs, **kwargs) }}
+    {{ get_url('{admin_endpoint}.static'.format(admin_endpoint=admin_view.admin.endpoint), *varargs, **kwargs) }}
 {%- endmacro %}


### PR DESCRIPTION
The blueprint endpoint `admin` is hard-coded in the `url()` macro in `flask_admin/templates/bootstrap{2,3,4}/admin/static.html`, causing Jinja to fail when trying to resolve static files needed to render the templates.

To replicate, set up Flask-Admin, but give it a custom endpoint:
```python
admin = admin.Admin(app, name='Example: SQLAlchemy', template_mode='bootstrap4', endpoint='foo')
```
The result is a Jinja trace that ends with: 
```
werkzeug.routing.BuildError: Could not build url for endpoint 'admin.static' with values ['filename', 'v']. Did you mean 'static' instead?
```

This issue is most commonly encountered by users (myself included) when another blueprint—not otherwise associated with Flask-Admin—already uses the `admin` endpoint. This creates a collision in the blueprint namespace, which most folks try to get around by customizing Flask-Admin's endpoint when initializing the extension. But with the hard-coded reference to the `admin` endpoint in the template code, Flask-Admin will not render correctly without hacking the template code so that `admin.static` reflects the user's desired endpoint (eg. `foo.static`).

This PR replaces the hard-coded value with the `admin_view.admin.endpoint` variable in the `static.html` template code for all three Bootstrap template themes.

Resolves #1342
Resolves #1530 
Resolves #1815 
Resolves #1849