### PR TITLE
Revert "Adding missing dependency on email_validator package"

### DIFF
--- a/examples/auth/requirements.txt
+++ b/examples/auth/requirements.txt
@@ -2,4 +2,3 @@ Flask
 Flask-Admin
 Flask-SQLAlchemy
 Flask-Security>=1.7.5
-email_validator


### PR DESCRIPTION
Reverts flask-admin/flask-admin#2094

`email_validator` is only used in a docs example, not in this package.