### PR TITLE
Add Jinja3 support

### DIFF
--- a/flask_admin/_compat.py
+++ b/flask_admin/_compat.py
@@ -90,3 +90,8 @@ try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
+
+try:
+    from jinja2 import pass_context
+except ImportError:
+    from jinja2 import contextfunction as pass_context

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -1,5 +1,5 @@
 from flask_admin.contrib.sqla.typefmt import DEFAULT_FORMATTERS as BASE_FORMATTERS
-from jinja2 import Markup
+from markupsafe import Markup
 from wtforms.widgets import html_params
 from geoalchemy2.shape import to_shape
 from geoalchemy2.elements import WKBElement

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -1,5 +1,4 @@
-from jinja2 import escape
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from mongoengine.base import BaseList
 from mongoengine.fields import GridFSProxy, ImageGridFsProxy

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -1,4 +1,5 @@
-from jinja2 import Markup, escape
+from jinja2 import escape
+from markupsafe import Markup
 
 from mongoengine.base import BaseList
 from mongoengine.fields import GridFSProxy, ImageGridFsProxy

--- a/flask_admin/contrib/mongoengine/widgets.py
+++ b/flask_admin/contrib/mongoengine/widgets.py
@@ -1,6 +1,6 @@
 from wtforms.widgets import html_params
 
-from jinja2 import escape
+from markupsafe import escape
 
 from mongoengine.fields import GridFSProxy, ImageGridFsProxy
 

--- a/flask_admin/contrib/rediscli.py
+++ b/flask_admin/contrib/rediscli.py
@@ -4,7 +4,7 @@ import warnings
 
 from flask import request
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 from flask_admin.base import BaseView, expose
 from flask_admin.babel import gettext

--- a/flask_admin/form/rules.py
+++ b/flask_admin/form/rules.py
@@ -1,4 +1,4 @@
-from jinja2 import Markup
+from markupsafe import Markup
 
 from flask_admin._compat import string_types
 from flask_admin import helpers

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -1,9 +1,8 @@
 from re import sub, compile
-from jinja2 import contextfunction
 from flask import g, request, url_for, flash
 from wtforms.validators import DataRequired, InputRequired
 
-from flask_admin._compat import urljoin, urlparse, iteritems
+from flask_admin._compat import iteritems, pass_context, urljoin, urlparse
 
 from ._compat import string_types
 
@@ -109,7 +108,7 @@ def flash_errors(form, message):
         flash(gettext(message, error=str(errors)), 'error')
 
 
-@contextfunction
+@pass_context
 def resolve_ctx(context):
     """
         Resolve current Jinja2 context and store it for general consumption.

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -9,7 +9,6 @@ from werkzeug.utils import secure_filename
 
 from flask import (current_app, request, redirect, flash, abort, json,
                    Response, get_flashed_messages, stream_with_context)
-from jinja2 import contextfunction
 try:
     import tablib
 except ImportError:
@@ -29,7 +28,7 @@ from flask_admin.helpers import (get_form_data, validate_form_on_submit,
 from flask_admin.tools import rec_getattr
 from flask_admin._backwards import ObsoleteAttr
 from flask_admin._compat import (iteritems, itervalues, OrderedDict,
-                                 as_unicode, csv_encode, text_type)
+                                 as_unicode, csv_encode, text_type, pass_context)
 from .helpers import prettify_name, get_mdict_item_or_list
 from .ajax import AjaxModelLoader
 
@@ -1851,7 +1850,7 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return value
 
-    @contextfunction
+    @pass_context
     def get_list_value(self, context, model, name):
         """
             Returns the value to be displayed in the list view
@@ -1871,7 +1870,7 @@ class BaseModelView(BaseView, ActionsMixin):
             self.column_type_formatters,
         )
 
-    @contextfunction
+    @pass_context
     def get_detail_value(self, context, model, name):
         """
             Returns the value to be displayed in the detail view

--- a/flask_admin/model/template.py
+++ b/flask_admin/model/template.py
@@ -1,6 +1,4 @@
-from jinja2 import contextfunction
-
-from flask_admin._compat import string_types, reduce
+from flask_admin._compat import pass_context, string_types, reduce
 from flask_admin.babel import gettext
 
 
@@ -11,7 +9,7 @@ class BaseListRowAction(object):
     def render(self, context, row_id, row):
         raise NotImplementedError()
 
-    @contextfunction
+    @pass_context
     def render_ctx(self, context, row_id, row):
         return self.render(context, row_id, row)
 

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -1,6 +1,6 @@
 import json
 
-from jinja2 import Markup
+from markupsafe import Markup
 from flask_admin._compat import text_type
 try:
     from enum import Enum

--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -1,5 +1,5 @@
 from flask import json
-from jinja2 import escape
+from markupsafe import escape
 from wtforms.widgets import html_params
 
 from flask_admin._backwards import Markup


### PR DESCRIPTION
In jinja3, `contextfunction` is renamed to `pass_context`, so I added this import to `_compat.py` file, and changed imports in other places. Now project is compatible with new jinja version.