### PR TITLE
Update bool_formatter for FontAwesome 5

### DIFF
--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -36,8 +36,8 @@ def bool_formatter(view, value):
             Value to check
     """
     glyph = 'ok-circle' if value else 'minus-sign'
-    fa = 'check-circle' if value else 'circle-o'
-    return Markup('<span class="fa fa-%s glyphicon glyphicon-%s icon-%s"></span>' % (fa, glyph, glyph))
+    fa = 'fa fa-check-circle' if value else 'far facircle'
+    return Markup('<span class="%s glyphicon glyphicon-%s icon-%s"></span>' % (fa, glyph, glyph))
 
 
 def list_formatter(view, values):

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -36,7 +36,7 @@ def bool_formatter(view, value):
             Value to check
     """
     glyph = 'ok-circle' if value else 'minus-sign'
-    fa = 'fa fa-check-circle' if value else 'far fa-circle'
+    fa = 'fas fa-check-circle' if value else 'far fa-circle'
     return Markup('<span class="%s glyphicon glyphicon-%s icon-%s"></span>' % (fa, glyph, glyph))
 
 

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -36,7 +36,7 @@ def bool_formatter(view, value):
             Value to check
     """
     glyph = 'ok-circle' if value else 'minus-sign'
-    fa = 'fa fa-check-circle' if value else 'far facircle'
+    fa = 'fa fa-check-circle' if value else 'far fa-circle'
     return Markup('<span class="%s glyphicon glyphicon-%s icon-%s"></span>' % (fa, glyph, glyph))
 
 


### PR DESCRIPTION
FontAwesome 5 moved some icons around, including the open circle used to denote `False` in models. This update fixes the `bool_formatter` to rectify this using the new classes for the open circle.

FontAwesome 5 was released in December 2017.