### PR TITLE
Fix extra args missing in bootstrap4

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/model/layout.html
@@ -62,6 +62,9 @@
         {% if page_size != default_page_size %}
             <input type="hidden" name="page_size" value="{{ page_size }}">
         {% endif %}
+        {% for arg_name, arg_value in extra_args.items() %}
+        <input type="hidden" name="{{ arg_name }}" value="{{ arg_value }}">
+        {% endfor %}
         {% if sort_column is not none %}
             <input type="hidden" name="sort" value="{{ sort_column }}">
         {% endif %}


### PR DESCRIPTION
**Issue:**
On https://github.com/pass-culture/pass-culture-api, we use flask admin as our back-office.
On one page, we use the extra args to make a custom filter on a subview for one model.

We upgraded from bootstrap3 to bootstrap4, the search form is missing a hidden input for extra args.
Since the upgrade, when a user search for particular fields, our custom extra args is deleted and the subview is not working anymore (https://github.com/pass-culture/pass-culture-api/blob/master/src/pcapi/admin/custom_views/offer_view.py#L181-L191)

**Expected behaviours**
Keep the extra args input so custom args are not deleted by a user search action

Thanks a lot for your time on this and for this library 🙏 