### PR TITLE
Fix `el is not defined` in x-editable-combodate popover handler

### DIFF
--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -465,8 +465,10 @@
                 });
                 return true;
             case 'x-editable-combodate':
-                let template  = $el.data('template')
-                el.removeAttribute('data-template')
+                // Fixes bootstrap4 issue where data-template breaks bs4 popover.
+                // https://github.com/flask-admin/flask-admin/issues/2022
+                let template = $el.data('template');
+                $el.removeAttr('data-template');
                 $el.editable({
                     params: overrideXeditableParams,
                     template: template,


### PR DESCRIPTION
[Previously suggested PR](https://github.com/flask-admin/flask-admin/pull/2035) to fix issue #2022 is incorrect (inevitably breaks JS on page). See [this comment](https://github.com/flask-admin/flask-admin/issues/2022#issuecomment-890404115) for more info.

This PR fixes the issue, making `x-editable-combodate` usable again. 