### PR TITLE
Fixed editable column fields showing "Empty" in bs4 list views

### DIFF
--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -492,7 +492,9 @@
                     display: function(value) {
                         // override to display text instead of ids on list view
                         var html = [];
-                        var data = $.fn.editableutils.itemsByValue(value, $el.data('source'), 'id');
+                        // temporary patch to provide bs3 & bs4 compatibility
+                        var data = $.fn.editableutils.itemsByValue(value, $el.data('source'), 'id') +
+                            $.fn.editableutils.itemsByValue(value, $el.data('source'), 'value');
 
                         if(data.length) {
                             $.each(data, function(i, v) { html.push($.fn.editableutils.escape(v.text)); });


### PR DESCRIPTION
Added logic to grab items either id or value. Probably not the best approach, but unless we can locate the change that occurred between bs3 and bs4 this will at least maintain cross-compatibility.

closes #2130
closes #1864