### PR TITLE
Fixed columns being editable when can_edit is False, but column_editable_list is set

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1466,7 +1466,7 @@ class BaseModelView(BaseView, ActionsMixin):
             :param name:
                 Column name.
         """
-        return name in self.column_editable_list
+        return name in self.column_editable_list and self.can_edit
 
     def _get_column_by_idx(self, idx):
         """


### PR DESCRIPTION
- Added additional check to `BaseModelView.is_editable`

Closes #2129