### PR TITLE
Add ability to use form_ajax_refs fields as editable columns

### DIFF
--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -78,11 +78,6 @@ class XEditableWidget(object):
     def __call__(self, field, **kwargs):
         display_value = kwargs.pop('display_value', '')
         kwargs.setdefault('data-value', display_value)
-
-        lazy_load = field.type in ('AjaxSelectField', 'AjaxSelectMultipleField')
-        if lazy_load:
-            kwargs.setdefault('data-url-lookup', get_url('.ajax_lookup', name=field.loader.name))
-
         kwargs.setdefault('data-role', 'x-editable')
         kwargs.setdefault('data-url', './ajax/update/')
 
@@ -90,7 +85,8 @@ class XEditableWidget(object):
         kwargs.setdefault('name', field.name)
         kwargs.setdefault('href', '#')
 
-        if lazy_load:
+        if field.type in ('AjaxSelectField', 'AjaxSelectMultipleField'):
+            kwargs.setdefault('data-url-lookup', get_url('.ajax_lookup', name=field.loader.name))
             kwargs.setdefault('type', 'hidden')
             kwargs.setdefault(
                 'data-placeholder',

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -462,6 +462,10 @@
                         minuteStep: 1,
                         maxYear: 2030,
                     },
+                    ajaxOptions: {
+                        // prevents keys with the same value from getting converted into arrays
+                        traditional: $el.attr("data-multiple") == "1"
+                    },
                     select2: {
                         minimumInputLength: $el.attr("data-minimum-input-length"),
                         placeholder: "data-placeholder",

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -467,8 +467,9 @@
                         traditional: $el.attr("data-multiple") == "1"
                     },
                     select2: {
-                        minimumInputLength: $el.attr("data-minimum-input-length"),
+                        dropdownAutoWidth: true,
                         placeholder: "data-placeholder",
+                        minimumInputLength: $el.attr("data-minimum-input-length"),
                         allowClear: $el.attr("data-allow-blank") == "1",
                         multiple: $el.attr("data-multiple") == "1",
                         closeOnSelect: $el.attr("data-multiple") != "1",

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -461,6 +461,36 @@
                         // prevent minutes from showing in 5 minute increments
                         minuteStep: 1,
                         maxYear: 2030,
+                    },
+                    select2: {
+                        minimumInputLength: $el.attr("data-minimum-input-length"),
+                        placeholder: "data-placeholder",
+                        allowClear: $el.attr("data-allow-blank") == "1",
+                        multiple: $el.attr("data-multiple") == "1",
+                        ajax: {
+                            // Special data-url just for the GET request
+                            url: $el.attr("data-url-lookup"),
+                            data: function (term, page) {
+                                return {
+                                    query: term,
+                                    offset: (page - 1) * 10,
+                                    limit: 10,
+                                };
+                            },
+                            results: function (data, page) {
+                                var results = [];
+
+                                for (var k in data) {
+                                    var v = data[k];
+                                    results.push({ id: v[0], text: v[1] });
+                                }
+
+                                return {
+                                    results: results,
+                                    more: results.length == 10,
+                                };
+                            },
+                        },
                     }
                 });
                 return true;

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -471,6 +471,7 @@
                         placeholder: "data-placeholder",
                         allowClear: $el.attr("data-allow-blank") == "1",
                         multiple: $el.attr("data-multiple") == "1",
+                        closeOnSelect: $el.attr("data-multiple") != "1",
                         ajax: {
                             // Special data-url just for the GET request
                             url: $el.attr("data-url-lookup"),
@@ -495,6 +496,27 @@
                                 };
                             },
                         },
+                        initSelection: function(_, callback) {
+                            var value = jQuery.parseJSON($el.attr('data-json'));
+                            var result = null;
+
+                            if (value) {
+                                if ($el.attr("data-multiple") == "1") {
+                                    result = [];
+
+                                    for (var k in value) {
+                                        var v = value[k];
+                                        result.push({id: v[0], text: v[1]});
+                                    }
+
+                                    callback(result);
+                                } else {
+                                    result = {id: value[0], text: value[1]};
+                                }
+                            }
+
+                            callback(result);
+                        }
                     }
                 });
                 return true;

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -529,12 +529,14 @@
                         },
                     },
                     display: function(selections) {
-                        // TODO 1: Fix persistence from table cell to select2 modal after being set from select2 modal (without refresh)
-                        // TODO 2: Fix deletions persistence from select2 modal to table cell (without refresh)
-                        // NOTE 1: When a pk is present in selections and the text is not, that means it was added
-                        // NOTE 2: When a value is present in selections and the pk is not, that means either:
+                        // TODO: Fix deletions persistence from select2 modal to table cell (without refresh)
+                        // NOTE: When a value is present in selections and the pk is not, that means either:
                         //   1) It is a value provided during initialization/page-load
                         //   2) It was deleted
+                        var uniqueArrays = (value, index, self) =>{
+                            var findIndex = (element) => element[0] == value[0];
+                            return self.findIndex(findIndex) === index;
+                        }
                         var escapedValue;
                         var updatedDataJson = [];
                         if (Array.isArray(selections)) {
@@ -557,27 +559,25 @@
                             $(this).html(html.join(', '));
                             $(this).attr('data-value', html.join(','));
                             if (updatedDataJson.length)
+                                updatedDataJson = updatedDataJson.filter(uniqueArrays);
                                 $(this).attr('data-json', JSON.stringify(updatedDataJson));
-                                $(this).prop('value', updatedDataJson.map(function(value){
+                                $(this).attr('value', updatedDataJson.map(function(value){
                                     return value[0];
                                 }).join(','));
                         } else if (selections) {
                             if (selections in choices){
                                 escapedValue = $.fn.editableutils.escape(choices[selections]);
-
                                 updatedDataJson.push([parseInt(selections), escapedValue]);
-
                             } else {
                                 escapedValue = $.fn.editableutils.escape(selections);
-
-                                //if (text_to_pk[selections])
                                 updatedDataJson.push([text_to_pk[selections], escapedValue]);
                             }
                             $(this).html(escapedValue);
                             $(this).attr('data-value', escapedValue);
                             if (updatedDataJson.length)
+                                updatedDataJson = updatedDataJson.filter(uniqueArrays);
                                 $(this).attr('data-json', JSON.stringify(updatedDataJson));
-                                $(this).prop('value', updatedDataJson.map(function(value){
+                                $(this).attr('value', updatedDataJson.map(function(value){
                                     return value[0];
                                 }).join(','));
                         } else {

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -503,7 +503,7 @@
                             },
                         },
                         initSelection: function(_, callback) {
-                            var value = jQuery.parseJSON($el.attr('data-json'));
+                            var value = JSON.parse($el.attr('data-json'));
                             var result = null;
 
                             if (value) {

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -455,6 +455,7 @@
                 processLeafletWidget($el, name);
                 return true;
             case 'x-editable':
+                var choices = {};
                 $el.editable({
                     params: overrideXeditableParams,
                     combodate: {
@@ -467,6 +468,9 @@
                         traditional: $el.attr("data-multiple") == "1"
                     },
                     select2: {
+                        // institute delay and cache ajax calls to prevent overloading server
+                        delay: 250,
+                        cacheDatasource: true,
                         dropdownAutoWidth: true,
                         placeholder: "data-placeholder",
                         minimumInputLength: $el.attr("data-minimum-input-length"),
@@ -488,6 +492,7 @@
 
                                 for (var k in data) {
                                     var v = data[k];
+                                    choices[v[0]] = v[1];
                                     results.push({ id: v[0], text: v[1] });
                                 }
 
@@ -507,6 +512,7 @@
 
                                     for (var k in value) {
                                         var v = value[k];
+                                        choices[v[0]] = v[1];
                                         result.push({id: v[0], text: v[1]});
                                     }
 
@@ -517,6 +523,33 @@
                             }
 
                             callback(result);
+                        },
+                    },
+                    display: function(selections) {
+                        var escapedValue;
+                        if(Array.isArray(selections)) {
+                            var html = []
+                            $.each(selections, function(i, v) {
+                                if (v in choices){
+                                    escapedValue = $.fn.editableutils.escape(choices[v]);
+                                } else {
+                                    // initial values, already present in table (text instead of pk)
+                                    escapedValue = $.fn.editableutils.escape(v);
+                                }
+                                if (!html.includes(escapedValue))
+                                    html.push(escapedValue);
+                            });
+                            $(this).html(html.join(', '));
+                        } else if (selections) {
+                            if (selections in choices){
+                                escapedValue = $.fn.editableutils.escape(choices[selections]);
+                            } else {
+                                // initial values, already present in table (text instead of pk)
+                                escapedValue = $.fn.editableutils.escape(selections);
+                            }
+                            $(this).html(escapedValue);
+                        } else {
+                            $(this).empty();
                         }
                     }
                 });


### PR DESCRIPTION
Adds support for inline-editing of form_ajax_refs fields from `list.html` views:
- One-to-one relationship
  - [x] Ajax search
  - [x] Select2 field
  - [x] Selections/adjustments persist/are saved to db
  - [x] Editable field reflects the updated/selected value from the modal
- One-to-many relationship
  - [x] Ajax search
  - [x] Select2 multiple field
  - [x] Selections/adjustments persist/are saved to db
  - [x] Editable field does not always reflect the updated (multiple) values once clicking save in the modal. Changes do reflect on refresh though.
 
🐛 Both single and multi-select inline editable fields are unable to have **all** their values deleted from the inline select2 field in the `list.html` views. This relates to #357 and should be addressed when that issue is addressed.

Closes #1627 
Closes #2063 
Closes #2157 