### PR TITLE
Change Markup import in example to MarkupSafe

### DIFF
--- a/examples/forms-files-images/app.py
+++ b/examples/forms-files-images/app.py
@@ -7,7 +7,7 @@ from redis import Redis
 from wtforms import fields, widgets
 
 from sqlalchemy.event import listens_for
-from jinja2 import Markup
+from MarkupSafe import Markup
 
 from flask_admin import Admin, form
 from flask_admin.form import rules


### PR DESCRIPTION
jinja2's Markup will be deprecated soon. It was changed everywhere except in this example