### PR TITLE
Change edit_view `Save and continue` url

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -2144,7 +2144,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 if '_add_another' in request.form:
                     return redirect(self.get_url('.create_view', url=return_url))
                 elif '_continue_editing' in request.form:
-                    return redirect(request.url)
+                    return redirect(self.get_url('.edit_view', id=self.get_pk_value(model)))
                 else:
                     # save button
                     return redirect(self.get_save_return_url(model, is_created=False))


### PR DESCRIPTION
Fixes #2183.

When using flask_admin behind reverse proxy, working in the edit view, the Save and continue button uses `request.url` which is missing the prefix.

This works ok in the create_view, We need to use the `self.get_url('.edit_view')` so the correct url is returned.
