### PR TITLE
Fixed DateTimeField format compatibility with WTForms 3.0. Fixes #2189

### DIFF
--- a/flask_admin/form/fields.py
+++ b/flask_admin/form/fields.py
@@ -36,9 +36,8 @@ class DateTimeField(fields.DateTimeField):
             :param kwargs:
                 Any additional parameters
         """
-        super(DateTimeField, self).__init__(label, validators, **kwargs)
-
-        self.format = format or '%Y-%m-%d %H:%M:%S'
+        super(DateTimeField, self).__init__(
+            label, validators, format or '%Y-%m-%d %H:%M:%S', **kwargs)
 
 
 class TimeField(fields.Field):


### PR DESCRIPTION
This simple change in the `DateTimeField` constructor passes the used `format` to the parent constructor and fixes the incompatibility with WTForms 3.0. Fixes #2189.