### PR TITLE
Fixed bs4_filters.js to allow dynamic filter form to function correctly

### DIFF
--- a/flask_admin/static/admin/js/bs4_filters.js
+++ b/flask_admin/static/admin/js/bs4_filters.js
@@ -193,5 +193,6 @@ var AdminFilters = function(element, filtersElement, filterGroups, activeFilters
                 JSON.parse($('#active-filters-data').text())
             );
         }
-    })
+    });
+    $(document).trigger('adminFormReady');  // trigger event to allow dynamic filter form to function properly
 })(jQuery);


### PR DESCRIPTION
Added a manual event trigger after bs4_filters.js loads in order to fix dynamic filter form generation when template_mode="bootstrap4". Without this, nothing happens when clicking any of the filters from the "Add Filter" dropdown.

Closes #2199