### PR TITLE
Pass datetime format instead of replacing it.

### DIFF
--- a/flask_admin/form/fields.py
+++ b/flask_admin/form/fields.py
@@ -36,9 +36,9 @@ class DateTimeField(fields.DateTimeField):
             :param kwargs:
                 Any additional parameters
         """
-        super(DateTimeField, self).__init__(label, validators, **kwargs)
+        format = format or '%Y-%m-%d %H:%M:%S'
+        super(DateTimeField, self).__init__(label, validators, format, **kwargs)
 
-        self.format = format or '%Y-%m-%d %H:%M:%S'
 
 
 class TimeField(fields.Field):


### PR DESCRIPTION
Resolves #2216.

Without this fix, DateTimePickers look like this:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/1836815/150691314-249608f3-ade5-492e-bd2f-1e371fffebc2.png">

With this fix, they become:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/1836815/150691334-ddef7bca-ce44-4e1d-b485-0b65e92ebf33.png">

I am not sure if this breaks older WTF versions. If so, it might be a good idea to add 
```
if not self.format:
    self.format = '%Y-%m-%d %H:%M:%S'
```
after the call to `super()`.