### PR TITLE
In contrib/geoa factor out tileLayer(...).addTo(map) and update mapbox attributes

### DIFF
--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -7,16 +7,23 @@ from sqlalchemy import func
 
 
 def geom_formatter(view, value):
-    params = html_params(**{
+    kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",
         "data-width": 100,
         "data-height": 70,
         "data-geometry-type": to_shape(value).geom_type,
         "data-zoom": 15,
-        "data-tile-layer-url": view.tile_layer_url,
-        "data-tile-layer-attribution": view.tile_layer_attribution
-    })
+    }
+    # html_params will serialize None as a string literal "None" so only put tile-layer-url
+    # and tile-layer-attribution in kwargs when they have a meaningful value.
+    # flask_admin/static/admin/js/form.js uses its default values when these are not passed
+    # as textarea attributes.
+    if view.tile_layer_url:
+        kwargs["data-tile-layer-url"] = view.tile_layer_url
+    if view.tile_layer_attribution:
+        kwargs["data-tile-layer-attribution"] = view.tile_layer_attribution
+    params = html_params(**kwargs)
 
     if value.srid == -1:
         value.srid = 4326

--- a/flask_admin/contrib/geoa/view.py
+++ b/flask_admin/contrib/geoa/view.py
@@ -5,5 +5,7 @@ from flask_admin.contrib.geoa import form, typefmt
 class ModelView(SQLAModelView):
     model_form_converter = form.AdminModelConverter
     column_type_formatters = typefmt.DEFAULT_FORMATTERS
+    # tile_layer_url is prefixed with '//' in flask_admin/static/admin/js/form.js
+    # Leave it as None or set it to a string starting with a hostname, NOT "http".
     tile_layer_url = None
     tile_layer_attribution = None

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -157,20 +157,16 @@
         }
 
         // set up tiles
-        if($el.data('tile-layer-url')){
-          var attribution = $el.data('tile-layer-attribution') || ''
-          L.tileLayer('//'+$el.data('tile-layer-url'), {
-            attribution: attribution,
-            maxZoom: 18
-          }).addTo(map)
-        } else {
-          var mapboxUrl = 'https://api.mapbox.com/styles/v1/mapbox/'+window.MAPBOX_MAP_ID+'/tiles/{z}/{x}/{y}?access_token='+window.MAPBOX_ACCESS_TOKEN
-          L.tileLayer(mapboxUrl, {
-            attribution: 'Map data &copy; <a href="//openstreetmap.org">OpenStreetMap</a> contributors, <a href="//creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="//mapbox.com">Mapbox</a>',
-            maxZoom: 18
-          }).addTo(map);
-        }
-
+        var mapboxHostnameAndPath = $el.data('tile-layer-url') || 'api.mapbox.com/styles/v1/mapbox/'+window.MAPBOX_MAP_ID+'/tiles/{z}/{x}/{y}?access_token={accessToken}';
+        var attribution = $el.data('tile-layer-attribution') || 'Map data &copy; <a href="//openstreetmap.org">OpenStreetMap</a> contributors, <a href="//creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="//mapbox.com">Mapbox</a>';
+        L.tileLayer('//' + mapboxHostnameAndPath, {
+          // Attributes from https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/
+          attribution: attribution,
+          maxZoom: 18,
+          tileSize: 512,
+          zoomOffset: -1,
+          accessToken: window.MAPBOX_ACCESS_TOKEN
+        }).addTo(map);
 
         // everything below here is to set up editing, so if we're not editable,
         // we can just return early.


### PR DESCRIPTION
This change fixes [issue 2352](https://github.com/flask-admin/flask-admin/issues/2352).

Details: 
* updates the mapbox attributes at match https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/
* Factors out the two calls to `L.tileLayer` into one
* Fixes `geom_formatter` to no longer return `<textarea data-tile-layer-url="None" ...` when `view.tile_layer_url` is None.

## Tested

Setup postgis and ran the demo app following `examples/geo_alchemy/README.rst` then created an object in the polygon table. Without this change http://127.0.0.1:5000/admin/polygon/ doesn't show tiles and with it tiles appear.