### PR TITLE
fix Markup import in examples/forms-files-images

### DIFF
--- a/examples/forms-files-images/app.py
+++ b/examples/forms-files-images/app.py
@@ -7,7 +7,7 @@ from redis import Redis
 from wtforms import fields, widgets
 
 from sqlalchemy.event import listens_for
-from MarkupSafe import Markup
+from markupsafe import Markup
 
 from flask_admin import Admin, form
 from flask_admin.form import rules


### PR DESCRIPTION
Broken import prevented running of example, simple fix to typo. 