### PR TITLE
Fix Navbar

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/base.html
+++ b/flask_admin/templates/bootstrap4/admin/base.html
@@ -50,7 +50,7 @@
                 <a class="navbar-brand" href="{{ admin_view.admin.url }}">{{ admin_view.admin.name }}</a>
             {% endblock %}
             {% block main_menu %}
-                <ul class="navbar-nav mr-auto">
+                <ul class="nav navbar-nav mr-auto">
                     {{ layout.menu() }}
                 </ul>
             {% endblock %}


### PR DESCRIPTION
`nav` is missing which does cause the problem of the view links to expand the container (see screenshot):
![image](https://user-images.githubusercontent.com/76752051/156468787-f8902f60-acc2-4401-b292-cc70fb6da39a.png)

After adding `nav`:
![image](https://user-images.githubusercontent.com/76752051/156468903-e3a0ecfc-6356-46ac-b8b7-6598ec55ad95.png)

`nav` is only missing in bootstrap4. In bootstrap3, `nav` is there:
https://github.com/flask-admin/flask-admin/blob/3f9bda85b3a6040ee0327474fbf5e3515467b58a/flask_admin/templates/bootstrap3/admin/base.html#L56

Might be forgotten during the migration.