### PR TITLE
Bootstrap 4 form checklists more compact and standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ env
 *.egg
 .eggs
 .tox/
+.env

--- a/examples/forms-files-images/app.py
+++ b/examples/forms-files-images/app.py
@@ -66,6 +66,7 @@ class User(db.Model):
     city = db.Column(db.Unicode(128))
     country = db.Column(db.Unicode(128))
     notes = db.Column(db.UnicodeText)
+    is_admin = db.Column(db.Boolean, default=False)
 
 
 class Page(db.Model):
@@ -170,7 +171,7 @@ class UserView(sqla.ModelView):
     """
     form_create_rules = [
         # Header and four fields. Email field will go above phone field.
-        rules.FieldSet(('first_name', 'last_name', 'email', 'phone'), 'Personal'),
+        rules.FieldSet(('first_name', 'last_name', 'email', 'phone', 'is_admin'), 'Personal'),
         # Separate header and few fields
         rules.Header('Location'),
         rules.Field('city'),
@@ -185,6 +186,10 @@ class UserView(sqla.ModelView):
 
     create_template = 'create_user.html'
     edit_template = 'edit_user.html'
+
+    column_descriptions = {
+        "is_admin": "Is this an admin user?",
+    }
 
 
 # Flask views
@@ -290,6 +295,6 @@ if __name__ == '__main__':
     database_path = op.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
         build_sample_db()
-
+        
     # Start app
     app.run(debug=True)

--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -120,7 +120,7 @@
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
   <div class="form-group {{ kwargs.get('column_class', '') }}">
-    <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block"{% endif %}>{{ field.label.text }}
+    <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block; margin-bottom: 0"{% endif %}>{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
           <strong style="color: red">&#42;</strong>
         {%- else -%}
@@ -136,7 +136,7 @@
       {%- endif -%}
     {% endif %}
       {% if field.widget.input_type == 'checkbox' %}
-        {% set _class = kwargs.setdefault('class', 'form-control-lg') %}
+        {% set _class = kwargs.setdefault('class', '') %}
       {% elif field.widget.input_type == 'file' %}
         {% set _class = kwargs.setdefault('class', 'form-control-file') %}
       {% else %}
@@ -151,14 +151,16 @@
       {%- endif -%}
       {% if direct_error %}
         <div class="invalid-feedback">
-          <ul class="help-block">
+          <ul class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
           {% for e in field.errors if e is string %}
             <li>{{ e }}</li>
           {% endfor %}
           </ul>
         </div>
       {% elif field.description %}
-        <div class="help-block">{{ field.description|safe }}</div>
+        <small class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
+            {{ field.description|safe }}
+        </small>
       {% endif %}
     {% if prepend or append %}
     </div>


### PR DESCRIPTION
Previously the Bootstrap 4 checklists in the edit form had too much whitespace above the input (below the label) and above the help text. It was hard to tell which one I was clicking on, if several of them were back-to-back.

Also changed the help-text to Bootstrap 4 standard