### PR TITLE
Add `-U` argument to tox.ini to ensure that requirements are updated/re-installed if needed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ usedevelop = true
 deps =
     WTForms1: WTForms==1.0.5
     WTForms2: WTForms>=2.0
-    -r{toxinidir}/requirements-dev.txt
+    -Ur{toxinidir}/requirements-dev.txt
 commands =
     pytest -v flask_admin/tests --cov=flask_admin --cov-report=html
 


### PR DESCRIPTION
Found this while debugging test issues related to newer versions of `Shapely`.

This also helps ensure env parity between environments (and also CI).