### PR TITLE
docs: Fix a few typos

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -62,7 +62,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         return self.session.query(self.model)
 
     def get_one(self, pk):
-        # prevent autoflush from occuring during populate_obj
+        # prevent autoflush from occurring during populate_obj
         with self.session.no_autoflush:
             return self.get_query().get(pk)
 

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -69,7 +69,7 @@ def has_multiple_pks(model):
 def tuple_operator_in(model_pk, ids):
     """The tuple_ Operator only works on certain engines like MySQL or Postgresql. It does not work with sqlite.
 
-    The function returns an or_ - operator, that containes and_ - operators for every single tuple in ids.
+    The function returns an or_ - operator, that contains and_ - operators for every single tuple in ids.
 
     Example::
 

--- a/flask_admin/static/bootstrap/bootstrap4/js/bootstrap.bundle.js
+++ b/flask_admin/static/bootstrap/bootstrap4/js/bootstrap.bundle.js
@@ -2505,7 +2505,7 @@
 
     this.disableEventListeners();
 
-    // remove the popper if user explicity asked for the deletion on destroy
+    // remove the popper if user explicitly asked for the deletion on destroy
     // do not use `remove` because IE11 doesn't support it
     if (this.options.removeOnDestroy) {
       this.popper.parentNode.removeChild(this.popper);
@@ -2836,7 +2836,7 @@
       styles[sideB] = 0;
       styles.willChange = 'transform';
     } else {
-      // othwerise, we use the standard `top`, `left`, `bottom` and `right` properties
+      // otherwise, we use the standard `top`, `left`, `bottom` and `right` properties
       var invertTop = sideA === 'bottom' ? -1 : 1;
       var invertLeft = sideB === 'right' ? -1 : 1;
       styles[sideA] = top * invertTop;


### PR DESCRIPTION
There are small typos in:
- flask_admin/contrib/sqla/ajax.py
- flask_admin/contrib/sqla/tools.py
- flask_admin/static/bootstrap/bootstrap4/js/bootstrap.bundle.js

Fixes:
- Should read `otherwise` rather than `othwerise`.
- Should read `occurring` rather than `occuring`.
- Should read `explicitly` rather than `explicity`.
- Should read `contains` rather than `containes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md