### PR TITLE
ItemsRequired validator: do not include items marked for deletion in field item count

### DIFF
--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from wtforms.validators import Required as InputRequired
 
+from flask_admin._compat import filter_list
+
 
 class Unique(object):
     """Checks field value unicity against specified table field.
@@ -55,7 +57,8 @@ class ItemsRequired(InputRequired):
         self.min = min
 
     def __call__(self, form, field):
-        if len(field.data) < self.min:
+        items = filter_list(lambda e: not field.should_delete(e), field.entries)
+        if len(items) < self.min:
             if self.message is None:
                 message = field.ngettext(
                     u"At least %(num)d item is required",

--- a/flask_admin/tests/sqla/test_inlineform.py
+++ b/flask_admin/tests/sqla/test_inlineform.py
@@ -155,6 +155,17 @@ def test_inline_form_required():
     assert User.query.count() == 1
     assert UserEmail.query.count() == 1
 
+    # Attempted delete, prevented by ItemsRequired
+    data = {
+        'name': 'hasEmail',
+        'del-emails-0': 'on',
+        'emails-0-email': 'foo@bar.com',
+    }
+    rv = client.post('/admin/user/edit/?id=1', data=data)
+    assert rv.status_code == 200
+    assert User.query.count() == 1
+    assert UserEmail.query.count() == 1
+
 
 def test_inline_form_ajax_fk():
     app, db, admin = setup()


### PR DESCRIPTION
The [`ItemsRequired` validator](https://github.com/flask-admin/flask-admin/blob/73febb13a18b48ebb21d5927de944cd5edbae068/flask_admin/contrib/sqla/validators.py#L48-L68) offers the ability to require a minimum number of related items for a given field.

One factor that it doesn't currently consider is that during deletion of items, the submitted form field will contain entries for both the existing and deleted items -- so it may over-count the number of remaining items.

This changeset updates the logic so that only non-deleted entries are included in the item count.

Resolves #1930.