### PR TITLE
Primary key field name not included in inline models form columns

### DIFF
--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -120,17 +120,19 @@ class InlineModelFormField(FormField):
 
     def get_pk(self):
         """Get the primary key value from the form"""
+        try:
+            if isinstance(self._pk, (tuple, list)):
+                return tuple(getattr(self.form, pk).data for pk in self._pk)
 
-        if self._pk not in self.form:
-            raise AttributeError(
-                'Primary key field "%s" not included in the inline_models "form_columns": %s'
-                % (self._pk, self.form._fields.keys())
-            )
+            return getattr(self.form, self._pk).data
+        except AttributeError:
+            if self._pk not in self.form:
+                raise AttributeError(
+                    'Primary key field "%s" is required in inline_models "form_columns". Available form fields: %s'
+                    % (self._pk, self.form._fields.keys())
+                )
+            raise
 
-        if isinstance(self._pk, (tuple, list)):
-            return tuple(getattr(self.form, pk).data for pk in self._pk)
-
-        return getattr(self.form, self._pk).data
 
     def populate_obj(self, obj, name):
         for name, field in iteritems(self.form._fields):

--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -119,6 +119,13 @@ class InlineModelFormField(FormField):
         self.form_opts = form_opts
 
     def get_pk(self):
+        """Get the primary key value from the form"""
+
+        if self._pk not in self.form:
+            raise AttributeError(
+                'Primary key field "%s" not included in the inline_models "form_columns": %s'
+                % (self._pk, self.form._fields.keys())
+            )
 
         if isinstance(self._pk, (tuple, list)):
             return tuple(getattr(self.form, pk).data for pk in self._pk)


### PR DESCRIPTION
When creating or editing an inline model, the inline model's `form_columns` MUST contain the primary key field's name, otherwise there's an AttributeError and the user has no idea what went wrong... I've just added a (hopefully) helpful error message so users can quickly fix the problem and move on with minimal frustration

Based on this error:
https://stackoverflow.com/questions/34313253/flask-admin-inline-modelling-passing-form-arguments-throws-attributeerror