### PR TITLE
Migrate deprecated access to flask application jinja environment

### DIFF
--- a/flask_admin/form/widgets.py
+++ b/flask_admin/form/widgets.py
@@ -1,5 +1,5 @@
 from wtforms import widgets
-from flask.globals import _request_ctx_stack
+from flask import current_app
 from flask_admin.babel import gettext, ngettext
 from flask_admin import helpers as h
 
@@ -89,9 +89,6 @@ class RenderTemplateWidget(object):
         self.template = template
 
     def __call__(self, field, **kwargs):
-        ctx = _request_ctx_stack.top
-        jinja_env = ctx.app.jinja_env
-
         kwargs.update({
             'field': field,
             '_gettext': gettext,
@@ -99,5 +96,5 @@ class RenderTemplateWidget(object):
             'h': h,
         })
 
-        template = jinja_env.get_template(self.template)
+        template = current_app.jinja_env.get_template(self.template)
         return template.render(kwargs)


### PR DESCRIPTION
Implements more-or-less the fix suggested by @tgross35 in #2284.

Resolves #2284.

Note: As of the current latest release of `flask-admin` ([1.6.0](https://github.com/flask-admin/flask-admin/releases/tag/v1.6.0)), this library [depends on `Flask>=0.7`](https://github.com/flask-admin/flask-admin/blob/3f9bda85b3a6040ee0327474fbf5e3515467b58a/setup.py#L41).  In Flask 0.7 (minimum-supported), both the [`flask.current_app` global](https://github.com/pallets/flask/blob/fb1482d3bb1b95803d25247479eb8ca8317a3219/flask/__init__.py#L25) and  [`Flask.jinja_env` property](https://github.com/pallets/flask/blob/fb1482d3bb1b95803d25247479eb8ca8317a3219/flask/app.py#L428-L443) were already available, so I _think_ that the change should be safe without updating dependency markers (but I haven't tested compatibility).