### PR TITLE
make application context available to db function

### DIFF
--- a/examples/auth-flask-login/app.py
+++ b/examples/auth-flask-login/app.py
@@ -214,7 +214,8 @@ if __name__ == '__main__':
     app_dir = os.path.realpath(os.path.dirname(__file__))
     database_path = os.path.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
-        build_sample_db()
+        with app.app_context():
+            build_sample_db()
 
     # Start app
     app.run(debug=True)

--- a/examples/auth-flask-login/app.py
+++ b/examples/auth-flask-login/app.py
@@ -56,8 +56,8 @@ class User(db.Model):
 
 # Define login and registration forms (for flask-login)
 class LoginForm(form.Form):
-    login = fields.StringField(validators=[validators.required()])
-    password = fields.PasswordField(validators=[validators.required()])
+    login = fields.StringField(validators=[validators.InputRequired()])
+    password = fields.PasswordField(validators=[validators.InputRequired()])
 
     def validate_login(self, field):
         user = self.get_user()
@@ -76,9 +76,9 @@ class LoginForm(form.Form):
 
 
 class RegistrationForm(form.Form):
-    login = fields.StringField(validators=[validators.required()])
+    login = fields.StringField(validators=[validators.InputRequired()])
     email = fields.StringField()
-    password = fields.PasswordField(validators=[validators.required()])
+    password = fields.PasswordField(validators=[validators.InputRequired()])
 
     def validate_login(self, field):
         if db.session.query(User).filter_by(login=self.login.data).count() > 0:

--- a/examples/auth-mongoengine/app.py
+++ b/examples/auth-mongoengine/app.py
@@ -51,8 +51,8 @@ class User(db.Document):
 
 # Define login and registration forms (for flask-login)
 class LoginForm(form.Form):
-    login = fields.StringField(validators=[validators.required()])
-    password = fields.PasswordField(validators=[validators.required()])
+    login = fields.StringField(validators=[validators.InputRequired()])
+    password = fields.PasswordField(validators=[validators.InputRequired()])
 
     def validate_login(self, field):
         user = self.get_user()
@@ -68,9 +68,9 @@ class LoginForm(form.Form):
 
 
 class RegistrationForm(form.Form):
-    login = fields.StringField(validators=[validators.required()])
+    login = fields.StringField(validators=[validators.InputRequired()])
     email = fields.StringField()
-    password = fields.PasswordField(validators=[validators.required()])
+    password = fields.PasswordField(validators=[validators.InputRequired()])
 
     def validate_login(self, field):
         if User.objects(login=self.login.data):

--- a/examples/auth/app.py
+++ b/examples/auth/app.py
@@ -156,7 +156,8 @@ if __name__ == '__main__':
     app_dir = os.path.realpath(os.path.dirname(__file__))
     database_path = os.path.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
-        build_sample_db()
+        with app.app_context():
+            build_sample_db()
 
     # Start app
     app.run(debug=True)

--- a/examples/babel/app.py
+++ b/examples/babel/app.py
@@ -84,7 +84,8 @@ if __name__ == '__main__':
     admin.add_view(sqla.ModelView(Post, db.session))
 
     # Create DB
-    db.create_all()
+    with app.app_context():
+        db.create_all()
 
     # Start app
     app.run(debug=True)

--- a/examples/bootstrap4/app.py
+++ b/examples/bootstrap4/app.py
@@ -150,7 +150,8 @@ if __name__ == '__main__':
     app_dir = op.realpath(os.path.dirname(__file__))
     database_path = op.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
-        build_sample_db()
+        with app.app_context():
+            build_sample_db()
 
     # Start app
     app.run(debug=True)

--- a/examples/custom-layout/app.py
+++ b/examples/custom-layout/app.py
@@ -143,7 +143,8 @@ if __name__ == '__main__':
     app_dir = op.realpath(os.path.dirname(__file__))
     database_path = op.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
-        build_sample_db()
+        with app.app_context():
+            build_sample_db()
 
     # Start app
     app.run(debug=True)

--- a/examples/forms-files-images/app.py
+++ b/examples/forms-files-images/app.py
@@ -294,7 +294,8 @@ if __name__ == '__main__':
     app_dir = op.realpath(os.path.dirname(__file__))
     database_path = op.join(app_dir, app.config['DATABASE_FILE'])
     if not os.path.exists(database_path):
-        build_sample_db()
+        with app.app_context():
+            build_sample_db()
         
     # Start app
     app.run(debug=True)

--- a/examples/forms-files-images/app.py
+++ b/examples/forms-files-images/app.py
@@ -7,7 +7,7 @@ from redis import Redis
 from wtforms import fields, widgets
 
 from sqlalchemy.event import listens_for
-from MarkupSafe import Markup
+from markupsafe import Markup
 
 from flask_admin import Admin, form
 from flask_admin.form import rules

--- a/examples/sqla-association_proxy/app.py
+++ b/examples/sqla-association_proxy/app.py
@@ -94,15 +94,17 @@ admin.add_view(KeywordAdmin(Keyword, db.session))
 if __name__ == '__main__':
 
     # Create DB
-    db.create_all()
+    with app.app_context():
+        db.create_all()
 
     # Add sample data
     user = User('log')
     for kw in (Keyword('new_from_blammo'), Keyword('its_big')):
         user.keywords.append(kw)
 
-    db.session.add(user)
-    db.session.commit()
+    with app.app_context():
+        db.session.add(user)
+        db.session.commit()
 
     # Start app
     app.run(debug=True)

--- a/examples/sqla-custom-inline-forms/requirements.txt
+++ b/examples/sqla-custom-inline-forms/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 Flask-SQLAlchemy
-WTForms==1.0.5
+WTForms==2.3.3

--- a/examples/sqla/run_server.py
+++ b/examples/sqla/run_server.py
@@ -7,7 +7,8 @@ import os.path as op
 app_dir = op.join(op.realpath(os.path.dirname(__file__)), 'admin')
 database_path = op.join(app_dir, app.config['DATABASE_FILE'])
 if not os.path.exists(database_path):
-    build_sample_db()
+    with app.app_context():
+        build_sample_db()
 
 if __name__ == '__main__':
     # Start app


### PR DESCRIPTION
Some of the calls to db functions on example projects required access to the application context, so I added the line to fix this.
I also replaced validators.required with validators.InputRequired in several projects, as per the changes to wtforms, shown in docs here: https://wtforms.readthedocs.io/en/stable/changes/#version-1-0-2
Several other minor changes were made which should be clear from the commit history. Let me know if there are any issues with these modifications.