### PR TITLE
Make BaseView compatible with Flask 2.2.x

### DIFF
--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -365,7 +365,10 @@ class BaseView(with_metaclass(AdminViewMeta, BaseViewClass)):
             :param kwargs:
                 Arguments
         """
-        return fn(self, *args, **kwargs)
+        try:
+            return fn(self, *args, **kwargs)
+        except TypeError:
+            return fn(cls=self, **kwargs)
 
     def inaccessible_callback(self, name, **kwargs):
         """


### PR DESCRIPTION
The `as_view` method in the latest Flask version doesn't receive any positional argument, since this change:
https://github.com/pallets/flask/commit/6e23239567efde1c2e272db87c53444d6c22a1bb

This patch makes the code in base compatible with this new version, trying to call the view with the positional argument if present and in other case it's passed as `cls` named argument.

This fixes the `test_nested_flask_views` that was broken for this version.