### PR TITLE
Fix GitHub Workflow and add Python 3.11 Support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,10 @@ jobs:
         ports:
           - 10000:10000
     steps:
-      # Downloads a copy of the code in your repository before running CI tests
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgeos-c1v5
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up PostgreSQL hstore module

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         tox-version: [ 'WTForms2' ]
         include:
-          - python-version: 3.6
+          - python-version: 3.11
             tox-version: flake8
-          - python-version: 3.6
+          - python-version: 3.11
             tox-version: docs-html
     services:
       # Label used to access the service container

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         tox-version: [ 'WTForms2' ]
         include:
           - python-version: 3.11

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,11 @@
 name: Run tests
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-job:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,9 +50,7 @@ jobs:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install postgis
-        run: sudo apt-get install -y postgis postgresql-12-postgis-3 postgresql-12-postgis-3-scripts
-      - name: Setup postgis
+      - name: Set up PostgreSQL hstore module
         env:
           PGPASSWORD: postgres
         run: psql -U postgres -h localhost -c 'CREATE EXTENSION hstore;' flask_admin_test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,13 +49,13 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up PostgreSQL hstore module
         env:
           PGPASSWORD: postgres
         run: psql -U postgres -h localhost -c 'CREATE EXTENSION hstore;' flask_admin_test
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 flake8
 Flask<=2.0.0
+werkzeug<=2.0.0
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8
-Flask>=0.7
+Flask<=2.0.0
 Flask-SQLAlchemy>=0.15
 peewee
 wtf-peewee

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     test_suite='flask_admin.tests'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ usedevelop = true
 deps =
     WTForms1: WTForms==1.0.5
     WTForms2: WTForms>=2.0
-    -Ur{toxinidir}/requirements-dev.txt
+    -r requirements-dev.txt
 commands =
     pytest -v flask_admin/tests --cov=flask_admin --cov-report=html
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,5 @@ commands = flake8 flask_admin
 deps =
     sphinx
     sphinx-intl
+    -r requirements-dev.txt
 commands = sphinx-build -b html -d build/doctrees doc build/html


### PR DESCRIPTION
Please see individual commits for some details of the failures fixed.

To get tests to pass this does restrict Werkzeug/Flask to 2.0.0; I note #2316 and #2309?.

