### PR TITLE
Fix pymongo test count deprecation warning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongo:
-        image: mongo:5.0.4-focal
+        image: mongo:5.0.14-focal
         ports:
           - 27017:27017
       azurite:

--- a/flask_admin/tests/pymongo/test_basic.py
+++ b/flask_admin/tests/pymongo/test_basic.py
@@ -78,4 +78,4 @@ def test_model():
     url = '/admin/testview/delete/?id=%s' % model['_id']
     rv = client.post(url)
     assert rv.status_code == 302
-    assert db.test.count() == 0
+    assert db.test.estimated_document_count() == 0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ Flask-SQLAlchemy<3.0.0
 peewee
 wtf-peewee
 mongoengine<=0.21.0
-pymongo
+pymongo>=3.7.0
 flask-mongoengine==0.8.2
 pillow>=3.3.2
 Babel<=2.9.1


### PR DESCRIPTION
DeprecationWarning: count is deprecated. Use estimated_document_count or count_documents instead.

Minimum pymongo version already changed to 3.7 with:
11d3ae43 ("upgraded to latest pymongo api", 2022-06-20)

Update MongoDB image for database count command:
https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.estimated_document_count