### PR TITLE
Use SQLAlchemy.init_app() in tests and document

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -199,7 +199,8 @@ from the GeoAlchemy backend, rather than the usual SQLAlchemy backend::
     from flask_admin.contrib.geoa import ModelView
 
     # .. flask initialization
-    db = SQLAlchemy(app)
+    db = SQLAlchemy()
+    db.init_app(app)
 
     class Location(db.Model):
         id = db.Column(db.Integer, primary_key=True)

--- a/flask_admin/tests/geoa/__init__.py
+++ b/flask_admin/tests/geoa/__init__.py
@@ -11,7 +11,8 @@ def setup():
     app.config['SQLALCHEMY_ECHO'] = True
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    db = SQLAlchemy(app)
+    db = SQLAlchemy()
+    db.init_app(app)
     admin = Admin(app)
 
     app.app_context().push()

--- a/flask_admin/tests/geoa/__init__.py
+++ b/flask_admin/tests/geoa/__init__.py
@@ -14,4 +14,6 @@ def setup():
     db = SQLAlchemy(app)
     admin = Admin(app)
 
+    app.app_context().push()
+
     return app, db, admin

--- a/flask_admin/tests/geoa/test_basic.py
+++ b/flask_admin/tests/geoa/test_basic.py
@@ -23,15 +23,14 @@ def create_models(db):
         def __unicode__(self):
             return self.name
 
-    db.create_all()
-
     return GeoModel
 
 
 def test_model():
     app, db, admin = setup()
     GeoModel = create_models(db)
-    db.create_all()
+    with app.app_context():
+        db.create_all()
     GeoModel.query.delete()
     db.session.commit()
 
@@ -130,7 +129,8 @@ def test_model():
 def test_none():
     app, db, admin = setup()
     GeoModel = create_models(db)
-    db.create_all()
+    with app.app_context():
+        db.create_all()
     GeoModel.query.delete()
     db.session.commit()
 

--- a/flask_admin/tests/sqla/__init__.py
+++ b/flask_admin/tests/sqla/__init__.py
@@ -11,7 +11,8 @@ def setup():
     app.config['SQLALCHEMY_ECHO'] = True
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    db = SQLAlchemy(app)
+    db = SQLAlchemy()
+    db.init_app(app)
     admin = Admin(app)
 
     return app, db, admin
@@ -25,7 +26,8 @@ def setup_postgres():
     app.config['SQLALCHEMY_ECHO'] = True
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-    db = SQLAlchemy(app)
+    db = SQLAlchemy()
+    db.init_app(app)
     admin = Admin(app)
 
     return app, db, admin


### PR DESCRIPTION
As described in:

https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/quickstart/#configure-the-extension

Was only working by accident prior to Flask-SQLAlchemy 3:

https://github.com/pallets-eco/flask-sqlalchemy/pull/1151

Revealed that geoa tests were creating tables twice outside of an
application context.

---

This came to light when testing with WTForms 3, that is now showing a warning.

Relies on "Add app.app_context() inside SQLAlchemy setup for testing geoa" from #2309 which is included here. As #2309 already needs rebasing as a result of 5c89c59e (and possibly fixes its TODO), I don't think merging this would cause more work.
