### PR TITLE
Remove Outdated Imports

### DIFF
--- a/flask_admin/_backwards.py
+++ b/flask_admin/_backwards.py
@@ -11,6 +11,7 @@ import warnings
 try:
     from wtforms.widgets import HTMLString as Markup
 except ImportError:
+    # WTForms 2.3.0
     from markupsafe import Markup  # noqa: F401
 
 

--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -45,10 +45,7 @@ else:
     ngettext = domain.ngettext
     lazy_gettext = domain.lazy_gettext
 
-    try:
-        from wtforms.i18n import messages_path
-    except ImportError:
-        from wtforms.ext.i18n.utils import messages_path
+    from wtforms.i18n import messages_path
 
     wtforms_domain = Domain(messages_path(), domain='wtforms')
 

--- a/flask_admin/contrib/mongoengine/fields.py
+++ b/flask_admin/contrib/mongoengine/fields.py
@@ -3,11 +3,7 @@ from mongoengine.base import get_document
 from werkzeug.datastructures import FileStorage
 
 from wtforms import fields
-
-try:
-    from wtforms.fields.core import _unset_value as unset_value
-except ImportError:
-    from wtforms.utils import unset_value
+from wtforms.utils import unset_value
 
 from . import widgets
 from flask_admin.model.fields import InlineFormField

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -4,12 +4,8 @@
 import operator
 
 from wtforms.fields import SelectFieldBase, StringField
+from wtforms.utils import unset_value
 from wtforms.validators import ValidationError
-
-try:
-    from wtforms.fields import _unset_value as unset_value
-except ImportError:
-    from wtforms.utils import unset_value
 
 from .tools import get_primary_key
 from flask_admin._compat import text_type, string_types, iteritems

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -3,6 +3,8 @@
 """
 import operator
 
+from sqlalchemy.orm.util import identity_key
+
 from wtforms.fields import SelectFieldBase, StringField
 from wtforms.utils import unset_value
 from wtforms.validators import ValidationError
@@ -13,12 +15,6 @@ from flask_admin.contrib.sqla.widgets import CheckboxListInput
 from flask_admin.form import FormOpts, BaseForm, Select2Widget
 from flask_admin.model.fields import InlineFieldList, InlineModelFormField
 from flask_admin.babel import lazy_gettext
-
-try:
-    from sqlalchemy.orm.util import identity_key
-    has_identity_key = True
-except ImportError:
-    has_identity_key = False
 
 
 class QuerySelectField(SelectFieldBase):
@@ -60,8 +56,6 @@ class QuerySelectField(SelectFieldBase):
         self.query_factory = query_factory
 
         if get_pk is None:
-            if not has_identity_key:
-                raise Exception(u'The sqlalchemy identity_key function could not be imported.')
             self.get_pk = get_pk_from_identity
         else:
             self.get_pk = get_pk

--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -1,10 +1,7 @@
 from sqlalchemy.orm.exc import NoResultFound
 
 from wtforms import ValidationError
-try:
-    from wtforms.validators import InputRequired
-except ImportError:
-    from wtforms.validators import Required as InputRequired
+from wtforms.validators import InputRequired
 
 from flask_admin._compat import filter_list
 

--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -5,12 +5,8 @@ from werkzeug.utils import secure_filename
 from werkzeug.datastructures import FileStorage
 
 from wtforms import ValidationError, fields, __version__ as wtforms_version
+from wtforms.utils import unset_value
 from wtforms.widgets import html_params
-
-try:
-    from wtforms.fields.core import _unset_value as unset_value
-except ImportError:
-    from wtforms.utils import unset_value
 
 from flask_admin.babel import gettext
 from flask_admin.helpers import get_url

--- a/flask_admin/model/fields.py
+++ b/flask_admin/model/fields.py
@@ -2,11 +2,7 @@ import itertools
 
 from wtforms.validators import ValidationError
 from wtforms.fields import FieldList, FormField, SelectFieldBase
-
-try:
-    from wtforms.fields import _unset_value as unset_value
-except ImportError:
-    from wtforms.utils import unset_value
+from wtforms.utils import unset_value
 
 from flask_admin._compat import iteritems
 from .widgets import (InlineFieldListWidget, InlineFormWidget,

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -1,11 +1,8 @@
+from enum import Enum
 import json
 
 from markupsafe import Markup
 from flask_admin._compat import text_type
-try:
-    from enum import Enum
-except ImportError:
-    Enum = None
 
 
 def null_formatter(view, value, name):
@@ -91,7 +88,6 @@ DETAIL_FORMATTERS = {
     dict: dict_formatter,
 }
 
-if Enum is not None:
-    BASE_FORMATTERS[Enum] = enum_formatter
-    EXPORT_FORMATTERS[Enum] = enum_formatter
-    DETAIL_FORMATTERS[Enum] = enum_formatter
+BASE_FORMATTERS[Enum] = enum_formatter
+EXPORT_FORMATTERS[Enum] = enum_formatter
+DETAIL_FORMATTERS[Enum] = enum_formatter

--- a/flask_admin/tests/fileadmin/test_fileadmin.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import os
 import os.path as op
 import unittest
@@ -7,11 +8,6 @@ from flask_admin import Admin
 from flask import Flask
 
 from . import setup
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 class Base:

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -1,9 +1,6 @@
 from flask import Flask
 
-try:
-    from werkzeug.middleware.dispatcher import DispatcherMiddleware
-except ImportError:
-    from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.test import Client
 
 from wtforms import fields


### PR DESCRIPTION
Imports no longer used since WTForms 2.0, Python 3, SQLAlchemy 1.3 and Werkzeug 0.15.0.

