### PR TITLE
Remove navbar from container

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/base.html
+++ b/flask_admin/templates/bootstrap2/admin/base.html
@@ -33,9 +33,8 @@
   </head>
   <body>
     {% block page_body %}
-    <div class="container{%if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
-      <div class="navbar">
-        <div class="navbar-inner">
+    <div class="navbar">
+      <div class="navbar-inner">
           {% block brand %}
           <a class="brand" href="{{ admin_view.admin.url }}">{{ admin_view.admin.name }}</a>
           {% endblock %}
@@ -53,18 +52,19 @@
           {% endblock %}
         </div>
       </div>
-
+      
+    <div class="container{%if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
       {% block messages %}
       {{ layout.messages() }}
       {% endblock %}
-
+      
       {# store the jinja2 context for form_rules rendering logic #}
       {% set render_ctx = h.resolve_ctx() %}
-
+      
       {% block body %}{% endblock %}
     </div>
     {% endblock %}
-
+    
     {% block tail_js %}
     <script src="{{ admin_static.url(filename='vendor/jquery.min.js', v='3.5.1') }}" type="text/javascript"></script>
     <script src="{{ admin_static.url(filename='bootstrap/bootstrap2/js/bootstrap.min.js', v='2.3.2') }}" type="text/javascript"></script>

--- a/flask_admin/templates/bootstrap3/admin/base.html
+++ b/flask_admin/templates/bootstrap3/admin/base.html
@@ -36,9 +36,8 @@
   </head>
   <body>
     {% block page_body %}
-    <div class="container{%if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
-      <nav class="navbar navbar-default" role="navigation">
-        <!-- Brand and toggle get grouped for better mobile display -->
+    <nav class="navbar navbar-default" role="navigation">
+      <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">
           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#admin-navbar-collapse">
             <span class="sr-only">Toggle navigation</span>
@@ -67,11 +66,12 @@
           {% endblock %}
         </div>
       </nav>
-
+      
+    <div class="container{%if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
       {% block messages %}
       {{ layout.messages() }}
       {% endblock %}
-
+      
       {# store the jinja2 context for form_rules rendering logic #}
       {% set render_ctx = h.resolve_ctx() %}
 

--- a/flask_admin/templates/bootstrap4/admin/base.html
+++ b/flask_admin/templates/bootstrap4/admin/base.html
@@ -37,38 +37,38 @@
   </head>
 <body>
 {% block page_body %}
-    <div class="container{% if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-2" role="navigation">
-            <!-- Brand and toggle get grouped for better mobile display -->
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-2" role="navigation">
+    <!-- Brand and toggle get grouped for better mobile display -->
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#admin-navbar-collapse"
-                    aria-controls="admin-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <!-- navbar content -->
+            aria-controls="admin-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <!-- navbar content -->
             <div class="collapse navbar-collapse" id="admin-navbar-collapse">
-            {% block brand %}
+                {% block brand %}
                 <a class="navbar-brand" href="{{ admin_view.admin.url }}">{{ admin_view.admin.name }}</a>
-            {% endblock %}
-            {% block main_menu %}
+                {% endblock %}
+                {% block main_menu %}
                 <ul class="nav navbar-nav mr-auto">
                     {{ layout.menu() }}
                 </ul>
-            {% endblock %}
-
+                {% endblock %}
+                
                 {% block menu_links %}
                 <ul class="nav navbar-nav navbar-right">
                     {{ layout.menu_links() }}
                 </ul>
                 {% endblock %}
-            {% block access_control %}
-            {% endblock %}
+                {% block access_control %}
+                {% endblock %}
             </div>
         </nav>
-
+        
+    <div class="container{% if config.get('FLASK_ADMIN_FLUID_LAYOUT', False) %}-fluid{% endif %}">
         {% block messages %}
-            {{ layout.messages() }}
+        {{ layout.messages() }}
         {% endblock %}
-
+        
         {# store the jinja2 context for form_rules rendering logic #}
         {% set render_ctx = h.resolve_ctx() %}
 


### PR DESCRIPTION
Hello,

Currently the navbar is inside the bootstrap "container" class. Without "container-fluid" the navbar only take the half of the screen and with "container-fluid" there is padding on his side : see screenshots  
Without fluid : 
![navbar-in-container](https://user-images.githubusercontent.com/15265745/218991112-22d25a0b-3311-4d3f-abdf-b8ac4c6ff145.png)
with fluid : 
![navbarfluidwithcontainer](https://user-images.githubusercontent.com/15265745/218991261-5a4bf2c7-5e01-403c-b2d0-63a33a5bfee0.png)

My proposition remove the navbar from the container in order to take always the full width of the screen : 

![fluidwithoutcontainer](https://user-images.githubusercontent.com/15265745/218992334-c0bf2b06-157c-40ca-b289-bf9bc35f5ae6.png)

![notfluidwithoutcontainer](https://user-images.githubusercontent.com/15265745/218992358-ccaf3f24-51c5-4c21-a348-37cf69537544.png)

Done for bootstrap 2, 3 and 4

BTW: thanks for the great job you do on this package ;)