### PR TITLE
Remove use of deprecated query.get()

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -1116,7 +1116,7 @@ class ModelView(BaseModelView):
             :param id:
                 Model id
         """
-        return self.session.query(self.model).get(tools.iterdecode(id))
+        return self.session.get(self.model, tools.iterdecode(id))
 
     # Error handler
     def handle_view_exception(self, exc):


### PR DESCRIPTION
SQLAlchemy has deprecated the use of `query.get()`

https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.get