### PR TITLE
Tuple field_flags are deprecated

### DIFF
--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -18,7 +18,7 @@ class Unique(object):
     :param message:
         The error message.
     """
-    field_flags = ('unique', )
+    field_flags = {'unique': True}
 
     def __init__(self, db_session, model, column, message=None):
         self.db_session = db_session

--- a/flask_admin/form/validators.py
+++ b/flask_admin/form/validators.py
@@ -8,7 +8,7 @@ class FieldListInputRequired(object):
         Validates that at least one item was provided for a FieldList
     """
 
-    field_flags = ('required',)
+    field_flags = {'required': True}
 
     def __call__(self, form, field):
         if len(field.entries) == 0:


### PR DESCRIPTION
WTForms has deprecated the use of `tuples` for field flags.

https://github.com/wtforms/wtforms/blob/master/src/wtforms/fields/core.py#L131