### PR TITLE
Fixed AJAX data separator for select2

### DIFF
--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -52,6 +52,7 @@ class AjaxSelect2Widget(object):
             kwargs['value'] = separator.join(ids)
             kwargs['data-json'] = json.dumps(result)
             kwargs['data-multiple'] = u'1'
+            kwargs['data-separator'] = separator
         else:
             data = field.loader.format(field.data)
 
@@ -64,6 +65,8 @@ class AjaxSelect2Widget(object):
 
         minimum_input_length = int(field.loader.options.get('minimum_input_length', 1))
         kwargs.setdefault('data-minimum-input-length', minimum_input_length)
+
+        kwargs.setdefault('data-separator', ',')
 
         return Markup('<input %s>' % html_params(name=field.name, **kwargs))
 

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -13,6 +13,7 @@
           width: 'resolve',
           minimumInputLength: $el.attr('data-minimum-input-length'),
           placeholder: 'data-placeholder',
+          separator: $el.attr('data-separator'),
           ajax: {
             url: $el.attr('data-url'),
             data: function(term, page) {


### PR DESCRIPTION
`select2` needs the `separator` option to properly parse the AJAX results when using custom data separators, so the separator needs to be propagated to the field. 

jQuery 3.5.1 and select2 3.5.2 use `separator` option, but if select2 is updated the `tokenSeparator` array option will be needed instead.
