### PR TITLE
Call relationship property's "mapper" to materialize lazy direction

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -670,6 +670,13 @@ class InlineModelConverter(InlineModelConverterBase):
         reverse_prop = None
 
         for prop in target_mapper.iterate_properties:
+            try:
+                # Loading the mapper property will populate a lazy direction
+                # attribute
+                prop.mapper
+            except AttributeError:
+                continue
+
             if hasattr(prop, 'direction') and prop.direction.name in ('MANYTOONE', 'MANYTOMANY'):
                 if issubclass(model, prop.mapper.class_):
                     reverse_prop = prop


### PR DESCRIPTION
A Relationship property from a mapper may not have all expected attributes available immediately. Calling the `prop.mapper` property will cause these missing attributes to materialize.

I didn't do much investigation, and I'm sure there's probably a better way to do this. I just wanted to submit this in case it was useful at least for diagnosis.

### Models
```python
class UserModel(AuditBase):
    __tablename__ = "user"

    emails: Mapped[list[UserEmailModel]] = relationship(
        back_populates="user",
        lazy="selectin",
        order_by=(
            "[UserEmailModel.primary.desc(), UserEmailModel.active.desc(), UserEmailModel.email]"
        ),
    )

class UserEmailModel(AuditBase):
    __tablename__ = "user_email"

    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id"))
    user: Mapped[UserModel] = relationship(back_populates="emails")

    email: Mapped[str] = mapped_column(unique=True)
```

### IPython Session
```python
In [2]: model = UserEmailModel

In [3]: mapper = model._sa_class_manager.mapper

In [4]: prop = next(mapper.iterate_properties)

In [5]: prop
Out[5]: <Relationship at 0x7f3ba4d72ad0; user>

In [6]: hasattr(prop, "direction")
Out[6]: False

In [7]: prop.mapper
Out[7]: <Mapper at 0x7f3ba4d3b6d0; UserModel>

In [8]: hasattr(prop, "direction")
Out[8]: True
```