### PR TITLE
Update lib.html to allow for horizontal forms in Bootstrap 4

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -119,56 +119,61 @@
   {% set direct_error = h.is_field_error(field.errors) %}
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
-  <div class="form-group {{ kwargs.get('column_class', '') }}">
-    <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block; margin-bottom: 0"{% endif %}>{{ field.label.text }}
-        {% if h.is_required_form_field(field) %}
-          <strong style="color: red">&#42;</strong>
-        {%- else -%}
-          &nbsp;
-        {%- endif %}
-    </label>
-    {% if prepend or append %}
-    <div class="input-group">
-      {%- if prepend -%}
-      <div class="input-group-prepend">
-        {{ prepend }}
-      </div>
-      {%- endif -%}
-    {% endif %}
-      {% if field.widget.input_type == 'checkbox' %}
-        {% set _class = kwargs.setdefault('class', '') %}
-      {% elif field.widget.input_type == 'file' %}
-        {% set _class = kwargs.setdefault('class', 'form-control-file') %}
-      {% else %}
-        {% set _class = kwargs.setdefault('class', 'form-control') %}
-      {% endif %}
-      {%- if direct_error %} {% set _ = kwargs.update({'class': kwargs['class'] ~ ' is-invalid'}) %} {% endif -%}
-      {{ field(**kwargs) | safe }}
-      {%- if append -%}
-      <div class="input-group-append">
-        {{ append }}
-      </div>
-      {%- endif -%}
-      {% if direct_error %}
-        <div class="invalid-feedback">
-          <ul class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
-          {% for e in field.errors if e is string %}
-            <li>{{ e }}</li>
-          {% endfor %}
-          </ul>
-        </div>
-      {% elif field.description %}
-        <small class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
-            {{ field.description|safe }}
-        </small>
-      {% endif %}
-    {% if prepend or append %}
+  {% set form_horizontal = config.get('FLASK_ADMIN_FORM_HORIZONTAL', False) %}
+<div class="form-group {{ kwargs.get('column_class', '') }} {% if form_horizontal %}row{% endif %}">
+  <label for="{{ field.id }}" class="control-label {% if form_horizontal %}col-sm-2 col-form-label{% endif %}" {% if field.widget.input_type == 'checkbox' %}style="display: block"{% endif %}>{{ field.label.text }}
+      {% if h.is_required_form_field(field) %}
+        <strong style="color: red">&#42;</strong>
+      {%- else -%}
+        &nbsp;
+      {%- endif %}
+  </label>
+  {% if form_horizontal %}
+  <div class="col-sm-10">
+  {% endif %}
+  {% if prepend or append %}
+  <div class="input-group">
+    {%- if prepend -%}
+    <div class="input-group-prepend">
+      {{ prepend }}
     </div>
+    {%- endif -%}
+  {% endif %}
+    {% if field.widget.input_type == 'checkbox' %}
+      {% set _class = kwargs.setdefault('class', 'form-control-lg') %}
+    {% elif field.widget.input_type == 'file' %}
+      {% set _class = kwargs.setdefault('class', 'form-control-file') %}
+    {% else %}
+      {% set _class = kwargs.setdefault('class', 'form-control') %}
     {% endif %}
-    {% if caller %}
-      {{ caller(form, field, direct_error, kwargs) }}
+    {%- if direct_error %} {% set _ = kwargs.update({'class': kwargs['class'] ~ ' is-invalid'}) %} {% endif -%}
+    {{ field(**kwargs) | safe }}
+    {%- if append -%}
+    <div class="input-group-append">
+      {{ append }}
+    </div>
+    {%- endif -%}
+    {% if direct_error %}
+      <div class="invalid-feedback">
+        <ul class="help-block">
+        {% for e in field.errors if e is string %}
+          <li>{{ e }}</li>
+        {% endfor %}
+        </ul>
+      </div>
+    {% elif field.description %}
+      <div class="help-block">{{ field.description|safe }}</div>
     {% endif %}
+  {% if prepend or append %}
   </div>
+  {% endif %}
+  {% if caller %}
+    {{ caller(form, field, direct_error, kwargs) }}
+  {% endif %}
+  {% if form_horizontal %}
+  </div>
+  {% endif %}
+</div>
 {% endmacro %}
 
 {% macro render_header(form, text) %}


### PR DESCRIPTION
Use the FLASK_ADMIN_FORM_HORIZONTAL setting to control using vertical (default) or horizontal forms.