### PR TITLE
Docs + Example: Switch to maintained version of flask-security

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -124,7 +124,7 @@ Using Flask-Security
 --------------------
 
 If you want a more polished solution, you could
-use `Flask-Security <https://pythonhosted.org/Flask-Security/>`_,
+use `Flask-Security <https://flask-security-too.readthedocs.io/>`_,
 which is a higher-level library. It comes with lots of built-in views for doing
 common things like user registration, login, email address confirmation, password resets, etc.
 

--- a/examples/auth/app.py
+++ b/examples/auth/app.py
@@ -2,8 +2,8 @@ import os
 from flask import Flask, url_for, redirect, render_template, request, abort
 from flask_sqlalchemy import SQLAlchemy
 from flask_security import Security, SQLAlchemyUserDatastore, \
-    UserMixin, RoleMixin, login_required, current_user
-from flask_security.utils import encrypt_password
+    UserMixin, RoleMixin, current_user
+from flask_security.utils import hash_password
 import flask_admin
 from flask_admin.contrib import sqla
 from flask_admin import helpers as admin_helpers
@@ -42,6 +42,7 @@ class User(db.Model, UserMixin):
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
                             backref=db.backref('users', lazy='dynamic'))
+    fs_uniquifier = db.Column(db.String(64), unique=True, nullable=False)
 
     def __str__(self):
         return self.email
@@ -121,8 +122,8 @@ def build_sample_db():
 
         test_user = user_datastore.create_user(
             first_name='Admin',
-            email='admin',
-            password=encrypt_password('admin'),
+            email='admin@example.com',
+            password=hash_password('admin'),
             roles=[user_role, super_user_role]
         )
 
@@ -144,7 +145,7 @@ def build_sample_db():
                 first_name=first_names[i],
                 last_name=last_names[i],
                 email=tmp_email,
-                password=encrypt_password(tmp_pass),
+                password=hash_password(tmp_pass),
                 roles=[user_role, ]
             )
         db.session.commit()

--- a/examples/auth/requirements.txt
+++ b/examples/auth/requirements.txt
@@ -1,5 +1,5 @@
 Flask
 Flask-Admin
 Flask-SQLAlchemy
-Flask-Security>=1.7.5
+flask-security-too
 email_validator

--- a/examples/auth/templates/admin/index.html
+++ b/examples/auth/templates/admin/index.html
@@ -14,7 +14,7 @@
             {% if not current_user.is_authenticated %}
             <p>You can register as a regular user, or log in as a superuser with the following credentials:
             <ul>
-                <li>email: <b>admin</b></li>
+                <li>email: <b>admin@example.com</b></li>
                 <li>password: <b>admin</b></li>
             </ul>
             <p>


### PR DESCRIPTION
As stated in the README of `Flask-Security`:
> This project is non maintained anymore. Consider the Flask-Security-Too project as an alternative.

It is therefore not compatible with recent versions of Flask, which leads to issues with the example, as described in #2370 .
This PR changes the documentation and the example from `Flask-Security` to the maintained `Flask-Security-Too`.