### PR TITLE
Add support for Pillow 10

### DIFF
--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -21,6 +21,20 @@ from flask_admin._compat import string_types, urljoin
 
 try:
     from PIL import Image, ImageOps
+
+    # to support pillow < 9.1.0
+    if not hasattr(Image, 'Resampling'):
+        from enum import IntEnum
+
+        class Resampling(IntEnum):
+            NEAREST = 0
+            BOX = 4
+            BILINEAR = 2
+            HAMMING = 5
+            BICUBIC = 3
+            LANCZOS = 1
+
+        Image.Resampling = Resampling
 except ImportError:
     Image = None
     ImageOps = None
@@ -464,10 +478,10 @@ class ImageUploadField(FileUploadField):
 
         if image.size[0] > width or image.size[1] > height:
             if force:
-                return ImageOps.fit(self.image, (width, height), Image.ANTIALIAS)
+                return ImageOps.fit(self.image, (width, height), Image.Resampling.LANCZOS)
             else:
                 thumb = self.image.copy()
-                thumb.thumbnail((width, height), Image.ANTIALIAS)
+                thumb.thumbnail((width, height), Image.Resampling.LANCZOS)
                 return thumb
 
         return image


### PR DESCRIPTION
In Pillow 10, Image.ANTIALIAS was removed. The replacement is Image.Resampling.LANCZOS, but it does not exist until Pillow 9.1.0, so we stub it in that case. We can simplify this if bumping the minimum Pillow version is acceptable.