### PR TITLE
Fix incorrect docstrings in BaseModelView

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -964,8 +964,7 @@ class BaseModelView(BaseView, ActionsMixin):
             Return list of the model field names. Must be implemented in
             the child class.
 
-            Expected return format is list of tuples with field name and
-            display text. For example::
+            Expected return format is list of strings of the field names. For example::
 
                 ['name', 'first_name', 'last_name']
         """
@@ -1496,7 +1495,7 @@ class BaseModelView(BaseView, ActionsMixin):
     def get_list(self, page, sort_field, sort_desc, search, filters,
                  page_size=None):
         """
-            Return a paginated and sorted list of models from the data source.
+            Return a tuple of a count of results and a paginated and sorted list of models from the data source.
 
             Must be implemented in the child class.
 


### PR DESCRIPTION
Implementations of `get_list` suggest it's expecting a tuple of an in and a list to be returned, but the docstring just mentioned the list

Implementations of `scaffold_list_columns` are expecting a list of strings, but docstring suggests it's expecting a list of tuple of strings.

I have corrected the docstrings