### PR TITLE
Fixes #1728

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -624,10 +624,10 @@ class ModelView(BaseModelView):
         for searchable in self.column_searchable_list:
             if isinstance(searchable, InstrumentedAttribute):
                 placeholders.append(
-                    self.column_labels.get(searchable.key, searchable.key))
+                    str(self.column_labels.get(searchable.key, searchable.key)))
             else:
                 placeholders.append(
-                    self.column_labels.get(searchable, searchable))
+                    str(self.column_labels.get(searchable, searchable)))
 
         return u', '.join(placeholders)
 

--- a/flask_admin/form/rules.py
+++ b/flask_admin/form/rules.py
@@ -106,7 +106,7 @@ class NestedRule(BaseRule):
         result = []
 
         for r in self.rules:
-            result.append(r(form, form_opts, field_args))
+            result.append(str(r(form, form_opts, field_args)))
 
         return Markup(self.separator.join(result))
 


### PR DESCRIPTION
Correct a bug when lazy_gettext is used for translations, since it returns the lazy string class instead of a string, causing the join to fail. Evaluate them to strings before trying to join them.