### PR TITLE
Resolve test_multi_pk.py Flask-SQLAlchemy Model DeprecationWarning

### DIFF
--- a/flask_admin/tests/sqla/test_multi_pk.py
+++ b/flask_admin/tests/sqla/test_multi_pk.py
@@ -1,6 +1,10 @@
 from .test_basic import CustomModelView
 
-from flask_sqlalchemy import Model
+try:
+    # Flask-SQLAlchemy 3
+    from flask_sqlalchemy.model import Model
+except ImportError:
+    from flask_sqlalchemy import Model
 from sqlalchemy.ext.declarative import declarative_base
 
 


### PR DESCRIPTION
Now an error that prevents test collection when using Flask-SQLAlchemy 3.1.1:

```
 ___________ ERROR collecting flask_admin/tests/sqla/test_multi_pk.py ___________
ImportError while importing test module '/home/runner/work/flask-admin/flask-admin/flask_admin/tests/sqla/test_multi_pk.py'. Hint: make sure your test modules/packages have valid Python names. Traceback:
/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
flask_admin/tests/sqla/test_multi_pk.py:3: in <module>
    from flask_sqlalchemy import Model
E   ImportError: cannot import name 'Model' from 'flask_sqlalchemy' (/home/runner/work/flask-admin/flask-admin/.tox/py312-flask3-wtforms3/lib/python3.12/site-packages/flask_sqlalchemy/__init__.py). Did you mean: 'model'?
```
