### PR TITLE
Fix KeyError exception when flask-babel is installed but not used

### DIFF
--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -1,7 +1,14 @@
+from flask import current_app, has_app_context
+
 try:
     from flask_babel import Domain
 
-except ImportError:
+    if has_app_context():
+        current_app().extensions['babel']
+    else:
+        raise KeyError
+
+except (KeyError, ImportError):
     def gettext(string, **variables):
         return string % variables
 


### PR DESCRIPTION
flask-babel's gettext() expects a Babel object to have been created.

Otherwise an exception is raised.

```
  File "/usr/lib/python3.12/site-packages/flask_babel/__init__.py", line 46, in get_babel
    return app.extensions['babel']
           ~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'babel'
```

---

Not completely convinced by this, but at least it illustrates the issue.
