### PR TITLE
Test without sqlalchemy-citext

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ Fixes:
 
 * Jinja templates can now be loaded in StrictUndefined mode.
 * Remove an implicit dependency on `packaging`
+* Remove `sqlalchemy-citext1 from the optional dependencies. CITEXT supported by SQLAlchemy since 2.0.19.
 
 2.0.0a2
 -------

--- a/flask_admin/tests/sqla/test_postgres.py
+++ b/flask_admin/tests/sqla/test_postgres.py
@@ -1,4 +1,8 @@
-from citext import CIText
+try:
+    from citext import CIText as CITEXT
+except ImportError:
+    # SQLAlchemy >= 2.0.7, although there is an issue until 2.0.19
+    from sqlalchemy.dialects.postgresql import CITEXT  # type: ignore[attr-defined]
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import HSTORE
 from sqlalchemy.dialects.postgresql import JSON
@@ -94,7 +98,7 @@ def test_citext(app, postgres_db, postgres_admin):
             id = postgres_db.Column(
                 postgres_db.Integer, primary_key=True, autoincrement=True
             )
-            citext_test = postgres_db.Column(CIText)
+            citext_test = postgres_db.Column(CITEXT)
 
         with postgres_db.engine.begin() as connection:
             connection.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ sqlalchemy = [
 sqlalchemy-with-utils = [
     "Flask-Admin[sqlalchemy]",
     "sqlalchemy_utils>=0.38.0",
-    "sqlalchemy-citext>=1.8.0",
     "colour>=0.1.5",
     "email_validator>=2",
     "arrow>=0.13.0",

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ setenv =
     AZURE_STORAGE_CONNECTION_STRING = DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 deps =
     sqlalchemy1: sqlalchemy<2
+    sqlalchemy1: sqlalchemy-citext
     -r requirements/tests.txt
 commands_pre =
     noflaskbabel: pip uninstall -y flask-babel


### PR DESCRIPTION
The last sqlalchemy-citext update was in 2021 and it has various compatibility issues.

SQLAlchemy now has CITEXT support.
