### PR TITLE
fix s3 cloud compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "python.testing.pytestArgs": [
-    "flask_admin"
-  ],
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "python.testing.pytestArgs": [
+    "flask_admin"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -52,8 +52,8 @@ if __name__ == "__main__":
             S3FileAdmin(
                 bucket_name=bucket_name,
                 s3_client=s3_client,
-                # explicitly set the OS based on the platform of s3-cloud 
-                on_windows = False
+                # explicitly set the OS based on the platform of s3-cloud
+                on_windows=False,
             )
         )
 

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
             S3FileAdmin(
                 bucket_name=bucket_name,
                 s3_client=s3_client,
-                # explicitly set the OS based on the platform of s3-cloud
+                # explicitly set the OS based on the platform of s3-cloud storage
                 on_windows=False,
             )
         )

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -52,6 +52,8 @@ if __name__ == "__main__":
             S3FileAdmin(
                 bucket_name=bucket_name,
                 s3_client=s3_client,
+                # explicitly set the OS based on the platform of s3-cloud 
+                on_windows = False
             )
         )
 

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -348,6 +348,9 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         :param storage:
             The storage backend that the `BaseFileAdmin` will use to operate on the
             files.
+        :param on_windows:
+            True if the operating system of the storage is. Use it only when the
+            current os is different than storage os.
         """
         self.base_url = base_url
         self.storage = storage
@@ -381,11 +384,11 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         """
         Return Normalize path compatible with the speicified platform
         """
-        normized = str(op.normpath(path))
+        noramlized = str(op.normpath(path))
         if self._on_windows:
-            return normized.replace("/", "\\")
+            return noramlized.replace("/", "\\")
         else:
-            return normized.replace("\\", "/")
+            return noramlized.replace("\\", "/")
 
     def is_accessible_path(self, path: str) -> bool:
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -327,7 +327,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         menu_icon_type: t.Optional[str] = None,
         menu_icon_value: t.Optional[str] = None,
         storage: t.Optional[LocalFileStorage] = None,
-        on_windows: t.Optional[bool] = None
+        on_windows: t.Optional[bool] = None,
     ) -> None:
         """
         Constructor.
@@ -355,9 +355,9 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         self.init_actions()
 
         if on_windows is not None:
-            self._on_windows = on_windows  
+            self._on_windows = on_windows
         else:
-            self._on_windows =platform.system() == "Windows"
+            self._on_windows = platform.system() == "Windows"
 
         # Convert allowed_extensions to set for quick validation
         if self.allowed_extensions and not isinstance(self.allowed_extensions, set):
@@ -386,7 +386,6 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             return normized.replace("/", "\\")
         else:
             return normized.replace("\\", "/")
-    
 
     def is_accessible_path(self, path: str) -> bool:
         """
@@ -629,7 +628,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         :param directory:
             Directory path to check
         """
-        return self._normpath(directory).startswith(base_path)  
+        return self._normpath(directory).startswith(base_path)
 
     def save_file(self, path: str, file_data: FileStorage) -> None:
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -629,7 +629,8 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         :param directory:
             Directory path to check
         """
-        return self._normpath(directory).startswith(base_path)  # type: ignore[arg-type]
+        normlized = self._normpath(directory) # type: ignore[arg-type]
+        return normlized.startswith(base_path)  
 
     def save_file(self, path: str, file_data: FileStorage) -> None:
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -354,7 +354,10 @@ class BaseFileAdmin(BaseView, ActionsMixin):
 
         self.init_actions()
 
-        self._on_windows = on_windows if on_windows != None else (platform.system() == "Windows")
+        if on_windows is not None:
+            self._on_windows = on_windows  
+        else:
+            self._on_windows =platform.system() == "Windows"
 
         # Convert allowed_extensions to set for quick validation
         if self.allowed_extensions and not isinstance(self.allowed_extensions, set):
@@ -374,11 +377,15 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             menu_icon_value=menu_icon_value,
         )
 
-    def _normpath(self, path: T_PATH_LIKE) -> str:
+    def _normpath(self, path: t.Optional[str]) -> str | bytes:
+        """
+        Return Normalize path compatible with the speicified platform
+        """
+        normized = str(op.normpath(path))
         if self._on_windows:
-            return op.normpath(path).replace("/", "\\")
+            return normized.replace("/", "\\")
         else:
-            return op.normpath(path).replace("\\", "/")
+            return normized.replace("\\", "/")
     
 
     def is_accessible_path(self, path: str) -> bool:

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -381,7 +381,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         """
         Return Normalize path compatible with the speicified platform
         """
-        normized = str(op.normpath(path))
+        normized = op.normpath(path)
         if self._on_windows:
             return normized.replace("/", "\\")
         else:

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -1,6 +1,7 @@
 import os
 import os.path as op
 import platform
+import posixpath
 import re
 import shutil
 import sys
@@ -384,11 +385,10 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         """
         Return Normalize path compatible with the speicified platform
         """
-        noramlized = str(op.normpath(path))
         if self._on_windows:
-            return noramlized.replace("/", "\\")
+            return op.normpath(path)
         else:
-            return noramlized.replace("\\", "/")
+            return posixpath.normpath(path)
 
     def is_accessible_path(self, path: str) -> bool:
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -629,8 +629,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         :param directory:
             Directory path to check
         """
-        normlized = self._normpath(directory) # type: ignore[arg-type]
-        return normlized.startswith(base_path)  
+        return self._normpath(directory).startswith(base_path)  
 
     def save_file(self, path: str, file_data: FileStorage) -> None:
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -381,7 +381,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         """
         Return Normalize path compatible with the speicified platform
         """
-        normized = op.normpath(path)
+        normized = str(op.normpath(path))
         if self._on_windows:
             return normized.replace("/", "\\")
         else:

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -327,7 +327,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         menu_icon_type: t.Optional[str] = None,
         menu_icon_value: t.Optional[str] = None,
         storage: t.Optional[LocalFileStorage] = None,
-        on_windows: bool = None
+        on_windows: t.Optional[bool] = None
     ) -> None:
         """
         Constructor.
@@ -377,7 +377,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             menu_icon_value=menu_icon_value,
         )
 
-    def _normpath(self, path: T_PATH_LIKE) -> t.Union[str, bytes]:
+    def _normpath(self, path: T_PATH_LIKE) -> t.Optional[str]:
         """
         Return Normalize path compatible with the speicified platform
         """

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -377,11 +377,11 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             menu_icon_value=menu_icon_value,
         )
 
-    def _normpath(self, path: t.Optional[str]) -> str | bytes:
+    def _normpath(self, path: T_PATH_LIKE) -> t.Union[str, bytes]:
         """
         Return Normalize path compatible with the speicified platform
         """
-        normized = str(op.normpath(path))
+        normized = op.normpath(path)
         if self._on_windows:
             return normized.replace("/", "\\")
         else:

--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -377,7 +377,7 @@ class BaseFileAdmin(BaseView, ActionsMixin):
             menu_icon_value=menu_icon_value,
         )
 
-    def _normpath(self, path: T_PATH_LIKE) -> t.Optional[str]:
+    def _normpath(self, path: T_PATH_LIKE):
         """
         Return Normalize path compatible with the speicified platform
         """

--- a/flask_admin/tests/fileadmin/test_fileadmin_s3.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin_s3.py
@@ -168,8 +168,6 @@ class TestS3FileAdmin(Base.FileAdminTests):
         assert rv.status_code == 200
         assert "successfully deleted" in rv.text
 
-
-
     def test_deep_browsing(self, app, admin, mock_s3_client):
         fileadmin_class = self.fileadmin_class()
         fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
@@ -178,10 +176,10 @@ class TestS3FileAdmin(Base.FileAdminTests):
             pass
 
         view_kwargs = dict(fileadmin_kwargs)
-        
-        # explicitly set the OS based on the platform of s3-cloud 
-        view_kwargs['on_windows'] = False
-        
+
+        # explicitly set the OS based on the platform of s3-cloud
+        view_kwargs["on_windows"] = False
+
         view_kwargs.setdefault("name", "Files")
         view = MyFileAdmin(*fileadmin_args, **view_kwargs)
 
@@ -190,10 +188,10 @@ class TestS3FileAdmin(Base.FileAdminTests):
         client = app.test_client()
 
         # create deep path
-        rv = client.post("/admin/myfileadmin/mkdir/", data={'name':'xx'})
-        rv = client.post("/admin/myfileadmin/mkdir/xx", data={'name':'yy'})
-        rv = client.post("/admin/myfileadmin/mkdir/xx/yy", data={'name':'zz'})
-        
+        rv = client.post("/admin/myfileadmin/mkdir/", data={"name": "xx"})
+        rv = client.post("/admin/myfileadmin/mkdir/xx", data={"name": "yy"})
+        rv = client.post("/admin/myfileadmin/mkdir/xx/yy", data={"name": "zz"})
+
         # Test access to deep path
         rv = client.get("/admin/myfileadmin/b/xx/yy/zz")
         assert rv.status_code == 200

--- a/flask_admin/tests/fileadmin/test_fileadmin_s3.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin_s3.py
@@ -167,3 +167,33 @@ class TestS3FileAdmin(Base.FileAdminTests):
         rv = client.get("/admin/myfileadmin/")
         assert rv.status_code == 200
         assert "successfully deleted" in rv.text
+
+
+
+    def test_deep_browsing(self, app, admin, mock_s3_client):
+        fileadmin_class = self.fileadmin_class()
+        fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
+
+        class MyFileAdmin(fileadmin_class):  # type: ignore[valid-type, misc]
+            pass
+
+        view_kwargs = dict(fileadmin_kwargs)
+        
+        # explicitly set the OS based on the platform of s3-cloud 
+        view_kwargs['on_windows'] = False
+        
+        view_kwargs.setdefault("name", "Files")
+        view = MyFileAdmin(*fileadmin_args, **view_kwargs)
+
+        admin.add_view(view)
+
+        client = app.test_client()
+
+        # create deep path
+        rv = client.post("/admin/myfileadmin/mkdir/", data={'name':'xx'})
+        rv = client.post("/admin/myfileadmin/mkdir/xx", data={'name':'yy'})
+        rv = client.post("/admin/myfileadmin/mkdir/xx/yy", data={'name':'zz'})
+        
+        # Test access to deep path
+        rv = client.get("/admin/myfileadmin/b/xx/yy/zz")
+        assert rv.status_code == 200


### PR DESCRIPTION
- this change needed whever the current os platform is different thn s3 cloud platform. In this case the os.path.pathnorm() will not work properly since it treats storage as it is placed in the current system.

- Before this PR, browsing deep path in FileAdmin view such as /admin/fileadmins3/b/xx/yy/zz responses 404 code. This can happend only when the current os is "Windows" and the cloud s3 is "non-Windows" and vise versa.


