### PR TITLE
Drop SQLAlchemy 1.x support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,10 +29,6 @@ jobs:
             tox: 'py39-min'
           - python: '3.13'
             tox: 'py313-noflaskbabel'
-          - python: '3.9'
-            tox: 'py39-sqlalchemy1'
-          - python: '3.13'
-            tox: 'py313-sqlalchemy1'
     services:
       # Label used to access the service container
       postgres:

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -5,34 +5,25 @@ from sqlalchemy import and_
 from sqlalchemy import inspect
 from sqlalchemy import or_
 from sqlalchemy import tuple_
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.associationproxy import AssociationProxyExtensionType
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.clsregistry import _class_resolver
 from sqlalchemy.orm.properties import ColumnProperty
+from sqlalchemy.sql.operators import eq
 from sqlalchemy.sql.schema import Column
 from sqlalchemy.sql.schema import Table
 
-from flask_admin._types import T_ORM_MODEL
-from flask_admin._types import T_SQLALCHEMY_MODEL
-
-try:
-    # SQLAlchemy 2.0
-    from sqlalchemy.ext.associationproxy import AssociationProxyExtensionType
-
-    ASSOCIATION_PROXY = AssociationProxyExtensionType.ASSOCIATION_PROXY
-except ImportError:
-    from sqlalchemy.ext.associationproxy import (  # type: ignore[attr-defined, no-redef]
-        ASSOCIATION_PROXY,
-    )
-
-from sqlalchemy.exc import DBAPIError
-from sqlalchemy.sql.operators import eq
-
 from flask_admin._compat import filter_list
 from flask_admin._compat import string_types
+from flask_admin._types import T_ORM_MODEL
+from flask_admin._types import T_SQLALCHEMY_MODEL
 from flask_admin.tools import escape  # noqa: F401
 from flask_admin.tools import iterdecode  # noqa: F401
 from flask_admin.tools import iterencode  # noqa: F401
+
+ASSOCIATION_PROXY = AssociationProxyExtensionType.ASSOCIATION_PROXY
 
 
 def parse_like_term(term: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 sqlalchemy = [
     "flask-sqlalchemy>=3",
-    "sqlalchemy>=1.4",
+    "sqlalchemy>=2.0",
 ]
 sqlalchemy-with-utils = [
     "Flask-Admin[sqlalchemy]",
@@ -261,7 +261,6 @@ order-by-type = false
 [tool.tox]
 env_list = [
     "py39", "py310", "py311", "py312", "py313",
-    "py39-sqlalchemy1", "py313-sqlalchemy1",
     "py313-noflaskbabel",
     "py39-min",
     "style",
@@ -317,32 +316,6 @@ commands = [
         "tablib==3.0.0",
         "redis==4.0.0",
     ],
-    [
-        "pytest", "-v", "--tb=short", "--basetemp={env_tmp_dir}",
-        {replace = "posargs", default = [], extend = true},
-    ],
-]
-
-[tool.tox.env.py39-sqlalchemy1]
-description = "pytest with SQLAlchemy 1.x on Python 3.9"
-base = ["env_run_base"]
-base_python = ["3.9"]
-commands = [
-    ["uv", "pip", "install", "sqlalchemy>=1.4,<2"],
-    ["uv", "pip", "install", "flask-sqlalchemy<=3.0.5"],
-    [
-        "pytest", "-v", "--tb=short", "--basetemp={env_tmp_dir}",
-        {replace = "posargs", default = [], extend = true},
-    ],
-]
-
-[tool.tox.env.py313-sqlalchemy1]
-description = "pytest with SQLAlchemy 1.x on Python 3.13"
-base = ["env_run_base"]
-base_python = ["3.13"]
-commands = [
-    ["uv", "pip", "install", "sqlalchemy>=1.4,<2"],
-    ["uv", "pip", "install", "flask-sqlalchemy<=3.0.5"],
     [
         "pytest", "-v", "--tb=short", "--basetemp={env_tmp_dir}",
         {replace = "posargs", default = [], extend = true},

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -829,7 +829,7 @@ requires-dist = [
     { name = "pymongo", marker = "extra == 'pymongo'", specifier = ">=3.10.0" },
     { name = "redis", marker = "extra == 'rediscli'", specifier = ">=4.0.0" },
     { name = "shapely", marker = "extra == 'geoalchemy'", specifier = ">=2" },
-    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0" },
     { name = "sqlalchemy-citext", marker = "extra == 'sqlalchemy-with-utils'", specifier = ">=1.8.0" },
     { name = "sqlalchemy-utils", marker = "extra == 'sqlalchemy-with-utils'", specifier = ">=0.38.0" },
     { name = "tablib", marker = "extra == 'export'", specifier = ">=3.0.0" },


### PR DESCRIPTION
With the aim to release Flask-Admin v2 shortly, now is a reasonable time to drop some out-dated dependencies to help improve maintainability into the future. SQLAlchemy v2 was released in [January 2023](https://www.sqlalchemy.org/blog/2023/01/26/sqlalchemy-2.0.0-released/), 2.5ish years ago.