### PR TITLE
Convert to real booleans for sqla bool filters

### DIFF
--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -163,11 +163,21 @@ class FilterNotInList(FilterInList):
 
 # Customized type filters
 class BooleanEqualFilter(FilterEqual, filters.BaseBooleanFilter):
-    pass
+    def clean(self, value: str) -> bool:
+        """
+        Convert string value to boolean for database comparison.
+        Required for compatibility with psycopg3 which is stricter about type coercion.
+        """
+        return value == "1"
 
 
 class BooleanNotEqualFilter(FilterNotEqual, filters.BaseBooleanFilter):
-    pass
+    def clean(self, value: str) -> bool:
+        """
+        Convert string value to boolean for database comparison.
+        Required for compatibility with psycopg3 which is stricter about type coercion.
+        """
+        return value == "1"
 
 
 class IntEqualFilter(FilterEqual, filters.BaseIntFilter):


### PR DESCRIPTION
psycopg(3)'s driver is more strict about types matching, and fails on doing a bool column to varchar "1"/"0" comparison.

Fixes https://github.com/pallets-eco/flask-admin/issues/2674