### PR TITLE
FIX: is_hybrid_property method attribute error on deeper relationship columns on filters

### DIFF
--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -259,9 +259,6 @@ def is_hybrid_property(model: type[T_SQLALCHEMY_MODEL], attr_name: str) -> bool:
                 last_model = model._decl_class_registry[last_model.arg]
             elif isinstance(last_model, types.FunctionType | types.MethodType):
                 last_model = last_model()
-            # Method failing when called by scaffold_filters method on ModelView class when adding a grandchild column name to column_filters
-            # e.g column_filters = ('children.grandchild.name')
-            # added aditional if statement to convert the last_model class back to a sqlalchemy model class
             elif getattr(last_model, 'is_mapper'):
                 last_model = last_model.class_
         last_name = names[-1]


### PR DESCRIPTION
is_hybrid_property method failing when called by scaffold_filters method on ModelView class when adding a grandchild column name to column_filters e.g column_filters = ('children.grandchild.name')

Added additional if statement to convert the last_model class back to a sqlalchemy model class

Noticed that this issue was raised on another pull request but poster hasn't responded: #2390

maintainer asks to add a test that fails without the changes and that passes with the changes, upon writing a test I found that it's due to the backref arg when defining relationships in the model, not sure where to put the test file so will add as an additional comment

