### PR TITLE
style: fix annotation for LinkRowAction

### DIFF
--- a/flask_admin/model/template.py
+++ b/flask_admin/model/template.py
@@ -31,7 +31,12 @@ class BaseListRowAction:
 
 
 class LinkRowAction(BaseListRowAction):
-    def __init__(self, icon_class: str, url: str, title: str | None = None) -> None:
+    def __init__(
+        self,
+        icon_class: str,
+        url: str | t.Callable[["LinkRowAction", str, t.Any], str],
+        title: str | None = None,
+    ) -> None:
         super().__init__(title=title)
 
         self.url = url


### PR DESCRIPTION
The source code for `LinkRowAction` indicates that the `url` parameter could be a callable that returns a URL. However, the current annotation limits it to a string.

https://github.com/pallets-eco/flask-admin/blob/4975a0315f7f4cef30ccdf56ee38d10c442c8444/flask_admin/model/template.py#L33-L46