### PR TITLE
Ability to add menu divider

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -331,9 +331,13 @@ To nest related views within these drop-downs, use the `add_sub_category` method
 
     admin.add_sub_category(name="Links", parent_name="Team")
 
-And to add arbitrary hyperlinks to the menu::
+To add arbitrary hyperlinks to the menu::
 
   admin.add_link(MenuLink(name='Home Page', url='/', category='Links'))
+
+And to add a menu divider to separate menu items in the menu::
+
+  admin.add_menu_item(MenuDivider(), target_category='Links')
 
 
 Adding Your Own Views

--- a/examples/bootstrap4/main.py
+++ b/examples/bootstrap4/main.py
@@ -4,6 +4,7 @@ import os.path as op
 from flask import Flask
 from flask_admin import Admin
 from flask_admin.contrib.sqla import ModelView
+from flask_admin.menu import MenuDivider
 from flask_admin.menu import MenuLink
 from flask_admin.theme import Bootstrap4Theme
 from flask_sqlalchemy import SQLAlchemy
@@ -208,6 +209,7 @@ if __name__ == "__main__":
             menu_class_name="text-warning",
         )
     )
+    admin.add_menu_item(MenuDivider(), target_category="Menu")
     admin.add_view(CustomView(Page, db.session, category="Menu"))
     admin.add_view(
         CustomView(
@@ -254,6 +256,7 @@ if __name__ == "__main__":
             class_name="text-success",
         )
     )
+    admin.add_menu_item(MenuDivider(), target_category="Links")
     admin.add_link(
         MenuLink(name="External link", url="http://www.example.com/", category="Links")
     )

--- a/flask_admin/menu.py
+++ b/flask_admin/menu.py
@@ -181,3 +181,23 @@ class SubMenuCategory(MenuCategory):
     def __init__(self, *args: str, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
         self.class_name += " dropdown-submenu dropright"
+
+
+class MenuDivider(MenuLink):
+    """
+    Bootstrap Menu divider item
+    Usage:
+      admin = Admin(app, ...)
+      admin.add_menu_item(MenuDivider(), target_category='Category1')
+    """
+
+    def __init__(self, class_name=""):
+        class_name = "dropdown-divider" + (" " + class_name if class_name else "")
+        super().__init__("divider", class_name=class_name)
+
+    def get_url(self):
+        return None
+
+    def is_visible(self):
+        # Return True/False depending on your use-case
+        return True

--- a/flask_admin/templates/bootstrap4/admin/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/layout.html
@@ -22,42 +22,45 @@
       {% set children = item.get_children() %}
       {%- if children %}
         {% set class_name = item.get_class_name() or '' %}
-        {%- if item.is_active(admin_view) %}
-          <li class="active dropdown">
-            {% else -%}
-          <li class="dropdown">
-        {%- endif %}
-      <a class="dropdown-toggle {% if is_main_nav %}nav-link{% else %}dropdown-item{% endif %}" data-toggle="dropdown" href="javascript:void(0)">
-        <!-- show icon -->
-        {% if item.class_name %}<span class="{{ item.class_name }}"></span> {% endif %}
-        {{ menu_icon(item) }}{{ item.name }}
-        {%- if 'dropdown-submenu' in class_name -%}
-          <i class="glyphicon glyphicon-chevron-right small"></i>
-        {%- else -%}
-          <i class="glyphicon glyphicon-chevron-down small"></i>
-        {%- endif -%}
-      </a>
-      <ul class="dropdown-menu">
-        {%- for child in children -%}
-          {%- if child.is_category() -%}
-            {{ menu(menu_root=[child]) }}
-          {% else %}
-            {% set class_name = child.get_class_name() %}
-            <li>
-              {%- if child.is_active(admin_view) %}
-                <a class="dropdown-item active {{ class_name }} " href="{{ child.get_url() }}"{% if child.target %}
-                target="{{ child.target }}"{% endif %}>
-                  {{ menu_icon(child) }}{{ child.name }}</a>
+
+        <!-- just enhance the readability -->
+        <li class="{% if item.is_active(admin_view) %}active {% endif %}dropdown">
+
+          <a class="dropdown-toggle {% if is_main_nav %}nav-link{% else %}dropdown-item{% endif %}" data-toggle="dropdown" href="javascript:void(0)">
+            <!-- show icon -->
+            {% if item.class_name %}<span class="{{ item.class_name }}"></span> {% endif %}
+            {{ menu_icon(item) }}{{ item.name }}
+            {%- if 'dropdown-submenu' in class_name -%}
+              <i class="glyphicon glyphicon-chevron-right small"></i>
+            {%- else -%}
+              <i class="glyphicon glyphicon-chevron-down small"></i>
+            {%- endif -%}
+          </a>
+          <ul class="dropdown-menu">
+            {%- for child in children -%}
+              {%- if child.is_category() -%}
+                {{ menu(menu_root=[child]) }}
               {% else %}
-                <a class="dropdown-item {{ class_name }}" href="{{ child.get_url() }}"{% if child.target %}
-                target="{{ child.target }}"{% endif %}>
-                  {{ menu_icon(child) }}{{ child.name }}</a>
+                {% set class_name = child.get_class_name() %}
+                {% if 'dropdown-divider' in class_name %}
+                  <li class="{{ class_name }}"></li>
+                {% else %}
+                  <li>
+                    {%- if child.is_active(admin_view) %}
+                      <a class="dropdown-item active {{ class_name }} " href="{{ child.get_url() }}"{% if child.target %}
+                      target="{{ child.target }}"{% endif %}>
+                        {{ menu_icon(child) }}{{ child.name }}</a>
+                    {% else %}
+                      <a class="dropdown-item {{ class_name }}" href="{{ child.get_url() }}"{% if child.target %}
+                      target="{{ child.target }}"{% endif %}>
+                        {{ menu_icon(child) }}{{ child.name }}</a>
+                    {%- endif %}
+                  </li>
+                {%- endif %}
               {%- endif %}
-            </li>
-          {%- endif %}
-        {%- endfor %}
-      </ul>
-      </li>
+            {%- endfor %}
+          </ul>
+        </li>
       {% endif %}
     {%- else %}
       {%- if item.is_accessible() and item.is_visible() -%}


### PR DESCRIPTION
This PR enables developers to add a bootstrap menu divider.

Fixes #1745

**Docs and Tests**

- A test case is added on `flask-admin/tests/test_base.py` to make sure that the Menu divider is located in the right place within the HTML code.
- Docs are included with a snippet.
