### PR TITLE
error discription in red color

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -151,7 +151,7 @@
       {%- endif -%}
       {% if direct_error %}
         <div class="invalid-feedback">
-          <ul class="form-text text-muted {% if field.widget.input_type == 'checkbox' %}mt-0{% endif %}">
+          <ul class="form-text text-danger {% if field.widget.input_type == 'checkbox' %}mt-0{% endif %}">
           {% for e in field.errors if e is string %}
             <li>{{ e }}</li>
           {% endfor %}


### PR DESCRIPTION
In form views like create and edit forms, I Think Error description messages should be presented in red color `text-danger` to be distinguished from the field description