### PR TITLE
Mongoengine column_filters allow str

### DIFF
--- a/examples/mongoengine/main.py
+++ b/examples/mongoengine/main.py
@@ -109,6 +109,7 @@ class TweetView(ModelView):
     column_sortable_list = ("name", "text")
 
     column_filters = (
+        "text",
         filters.FilterEqual("name", "Name"),
         filters.FilterNotEqual("name", "Name"),
         filters.FilterLike("name", "Name"),

--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -293,7 +293,9 @@ class FilterConverter(filters.BaseFilterConverter):
         filter_name = type_name.lower()
 
         if filter_name in self.converters:
-            return self.converters[filter_name](column, name)
+            if isinstance(column, str):
+                return self.converters[filter_name](column, name)
+            return self.converters[filter_name](column.name, name)
 
         return None
 

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -61,11 +61,13 @@ class ModelView(BaseModelView):
 
     column_filters: t.Collection[str | BaseMongoEngineFilter] | None = None
     """
-        Collection of the column filters.
+        Collection of column filters used in the list view.
 
-        Can contain either field names or instances of
-        :class:`flask_admin.contrib.mongoengine.filters.BaseMongoEngineFilter`
-        classes.
+        Can contain either:
+        - Field names (str): allow any appropriate filter operation based on the
+        field’s data type.
+        - Instances of :class:`~flask_admin.contrib.mongoengine.filters.BaseFilter`
+        classes: restrict or customize which filters are available for a specific field.
 
         Filters will be grouped by name when displayed in the drop-down.
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -28,6 +28,7 @@ class TestView(ModelView):
     form = TestForm
 
     column_filters = (
+        "test1",
         filters.FilterEqual("test1", "test1"),
         filters.FilterEqual("test2", "test2"),
     )
@@ -52,8 +53,23 @@ def test_model(app, db, admin):
     assert view._edit_form_class is not None
     assert not view._search_supported
     assert view._filters
-    assert all(isinstance(f, filters.FilterEqual) for f in view._filters)
-    assert [f.__dict__ for f in view._filters] == [
+    for f, f_type in zip(
+        view._filters,
+        (
+            filters.FilterLike,
+            filters.FilterNotLike,
+            filters.FilterEqual,
+            filters.FilterNotEqual,
+            filters.FilterEmpty,
+            filters.FilterInList,
+            filters.FilterNotInList,
+            filters.FilterEqual,
+            filters.FilterEqual,
+        ),
+        strict=True,
+    ):
+        assert isinstance(f, f_type)
+    assert [f.__dict__ for f in view._filters[-2:]] == [
         {
             "name": "test1",
             "options": None,


### PR DESCRIPTION
fixes https://github.com/pallets-eco/flask-admin/issues/2700, adds test and fixes type hints. Example updated to include str in the `column_filters`. I would wait for https://github.com/pallets-eco/flask-admin/pull/2685 and https://github.com/pallets-eco/flask-admin/pull/2695 to be merged so that I can rebase and have a linear history.