### PR TITLE
FileAdmin: show empty date when directory has no date

### DIFF
--- a/flask_admin/contrib/fileadmin/__init__.py
+++ b/flask_admin/contrib/fileadmin/__init__.py
@@ -854,6 +854,8 @@ class BaseFileAdmin(BaseView, ActionsMixin):
         :param timestamp: The timestamp to format.
         :return: A formatted date.
         """
+        if timestamp == 0:
+            return ""
         return datetime.fromtimestamp(timestamp).strftime(self.date_format)
 
     def _save_form_files(self, directory: str, path: str, form: t.Any) -> None:


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
This PR updates FileAdmin to display an empty value instead of the default 1970-01-01 when a directory is given a timestamp of 0.
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->
Fixes: #2598 
<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in changelog.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
