### PR TITLE
remove deprecated ruff setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,8 +259,6 @@ ignore = [
     "UP007",  # Use X | Y for type annotations; doesn't work with some of our (stringy) type definitions - should aim to resolve this
 ]
 
-ignore-init-module-imports = true
-
 [tool.ruff.lint.isort]
 force-single-line = true
 order-by-type = false


### PR DESCRIPTION
`ignore-init-module-imports` raises a warning during the test suite since the setting is deprecated.
The value, `true`, is the same of the default, so the setting is not needed.
https://docs.astral.sh/ruff/settings/#lint_ignore-init-module-imports 