### PR TITLE
fix get_one `sqla.ModelView`

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -1336,7 +1336,12 @@ class ModelView(BaseModelView):
             Model id
         """
         session = _get_deprecated_session(self.session)
-        return session.get(self.model, tools.iterdecode(id))
+        if isinstance(self._primary_key, tuple):
+            _id = tools.iterdecode(id)
+        else:
+            _id = tools.escape(id)
+
+        return session.get(self.model, _id)
 
     # Error handler
     def handle_view_exception(self, exc: Exception) -> bool:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -1336,13 +1336,11 @@ class ModelView(BaseModelView):
             Model id
         """
         session = _get_deprecated_session(self.session)
-        _id = tools.iterdecode(id)
-        if isinstance(self._primary_key, tuple):
-            _id = tools.iterdecode(id)
-        else:
-            _id = (tools.escape(id),)
 
-        return session.get(self.model, _id)
+        if isinstance(self._primary_key, tuple):
+            return session.get(self.model, tools.iterdecode(id))
+
+        return session.get(self.model, (id,))
 
     # Error handler
     def handle_view_exception(self, exc: Exception) -> bool:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -1336,10 +1336,11 @@ class ModelView(BaseModelView):
             Model id
         """
         session = _get_deprecated_session(self.session)
+        _id = tools.iterdecode(id)
         if isinstance(self._primary_key, tuple):
             _id = tools.iterdecode(id)
         else:
-            _id = tools.escape(id)
+            _id = (tools.escape(id),)
 
         return session.get(self.model, _id)
 

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -851,6 +851,16 @@ def test_details_view(
         assert "test2_val_1" in data
         assert "test1_val_1" in data
 
+        # test single-PK with multiple IDs in query string
+        rv = client.get(
+            "/admin/model2/details/?url=%2Fadmin%2Fmodel2%2F&id=1,2",
+            follow_redirects=True,
+        )
+        data = rv.data.decode("utf-8")
+        assert "String Field" in data
+        assert "test2_val_1" in data
+        assert "test1_val_1" in data
+
         # test column_details_list
         rv = client.get("/admin/sf_view/details/?url=%2Fadmin%2Fsf_view%2F&id=1")
         data = rv.data.decode("utf-8")

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -851,22 +851,61 @@ def test_details_view(
         assert "test2_val_1" in data
         assert "test1_val_1" in data
 
-        # test single-PK with multiple IDs in query string
-        rv = client.get(
-            "/admin/model2/details/?url=%2Fadmin%2Fmodel2%2F&id=1,2",
-            follow_redirects=True,
-        )
-        data = rv.data.decode("utf-8")
-        assert "String Field" in data
-        assert "test2_val_1" in data
-        assert "test1_val_1" in data
-
         # test column_details_list
         rv = client.get("/admin/sf_view/details/?url=%2Fadmin%2Fsf_view%2F&id=1")
         data = rv.data.decode("utf-8")
         assert "String Field" in data
         assert "test2_val_1" in data
         assert "test1_val_1" not in data
+
+
+def test_single_pk_multiple_ids_in_query(
+    app: Flask,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
+    with app.app_context():
+        Model1, Model2 = create_models(sqla_db_ext)
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view_no_details = CustomModelView(Model1, param)
+        admin.add_view(view_no_details)
+
+        # fields are scaffolded
+        view_w_details = CustomModelView(Model2, param, can_view_details=True)
+        admin.add_view(view_w_details)
+
+        # show only specific fields in details w/ column_details_list
+        string_field_view = CustomModelView(
+            Model2,
+            param,
+            can_view_details=True,
+            column_details_list=["string_field"],
+            endpoint="sf_view",
+        )
+        admin.add_view(string_field_view)
+
+        fill_db(sqla_db_ext, Model1, Model2)
+
+        client = app.test_client()
+
+        # test single-PK query string
+        rv = client.get("/admin/model2/details/?id=1")
+        data = rv.data.decode("utf-8")
+        assert "String Field" in data
+        assert "test2_val_1" in data
+        assert "test1_val_1" in data
+
+        # test single-PK with multiple IDs in query string
+        rv = client.get("/admin/model2/details/?id=1,2", follow_redirects=True)
+        data = rv.data.decode("utf-8")
+        assert "Record does not exist" in data
+
+        # test single-PK with multiple IDs in query string
+        rv = client.get("/admin/model2/edit/?id=1,2", follow_redirects=True)
+        data = rv.data.decode("utf-8")
+        assert "Record does not exist" in data
 
 
 def test_editable_list_special_pks(


### PR DESCRIPTION
A run-time error is raised when `get_one()` is called in `flask_admin.contrib.sqla.view.ModelView`

To replicate the error try to browse this: `/admin/details/?id=1,2`

**Risk:**
A security vulnerability is raised by [Tnable](https://www.tenable.com/) where it could lead to **_Blind SQL Inejection_** which is classified as a High risk vulnerability. This can be exploited in `/edit` and `/details` 


<img width="700" alt="image" src="https://github.com/user-attachments/assets/31e5f8e0-0849-4d82-b855-36d0f8f6d8ed" />


A test case is added to make sure that  `/admin/details/?id=1,2` is working as expected