### PR TITLE
chore [examples]: move non-app.run() locs out of if __name__ == "__main__" guard

### DIFF
--- a/examples/auth/main.py
+++ b/examples/auth/main.py
@@ -185,9 +185,10 @@ admin.add_view(MyModelView(User, db))
 
 app_dir = os.path.realpath(os.path.dirname(__file__))
 database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
-if not os.path.exists(database_path):
-    with app.app_context():
-        build_sample_db()
 
 if __name__ == "__main__":
+    if not os.path.exists(database_path):
+        with app.app_context():
+            build_sample_db()
+
     app.run(debug=True)

--- a/examples/auth/main.py
+++ b/examples/auth/main.py
@@ -180,14 +180,14 @@ def build_sample_db():
     return
 
 
+admin.add_view(MyModelView(Role, db))
+admin.add_view(MyModelView(User, db))
+
+app_dir = os.path.realpath(os.path.dirname(__file__))
+database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
+
 if __name__ == "__main__":
-    admin.add_view(MyModelView(Role, db))
-    admin.add_view(MyModelView(User, db))
-
-    app_dir = os.path.realpath(os.path.dirname(__file__))
-    database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
-
     app.run(debug=True)

--- a/examples/auth/main.py
+++ b/examples/auth/main.py
@@ -186,9 +186,10 @@ admin.add_view(MyModelView(User, db))
 app_dir = os.path.realpath(os.path.dirname(__file__))
 database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
 
-if __name__ == "__main__":
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
 
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/auth_flask_login/main.py
+++ b/examples/auth_flask_login/main.py
@@ -272,20 +272,21 @@ def build_sample_db():
     db.session.commit()
 
 
+admin = Admin(
+    app,
+    name="Example: Auth",
+    index_view=MyAdminIndexView(),
+    theme=Bootstrap4Theme(base_template="my_master.html", fluid=True),
+)
+
+admin.add_view(MyModelView(User, db))
+
+app_dir = os.path.realpath(os.path.dirname(__file__))
+database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
+
+
 if __name__ == "__main__":
-    admin = Admin(
-        app,
-        name="Example: Auth",
-        index_view=MyAdminIndexView(),
-        theme=Bootstrap4Theme(base_template="my_master.html", fluid=True),
-    )
-
-    admin.add_view(MyModelView(User, db))
-
-    app_dir = os.path.realpath(os.path.dirname(__file__))
-    database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
-
     app.run(debug=True)

--- a/examples/auth_flask_login/main.py
+++ b/examples/auth_flask_login/main.py
@@ -284,10 +284,10 @@ admin.add_view(MyModelView(User, db))
 app_dir = os.path.realpath(os.path.dirname(__file__))
 database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
 
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
+
 
 if __name__ == "__main__":
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
-
     app.run(debug=True)

--- a/examples/auth_flask_login/main.py
+++ b/examples/auth_flask_login/main.py
@@ -283,10 +283,11 @@ admin.add_view(MyModelView(User, db))
 
 app_dir = os.path.realpath(os.path.dirname(__file__))
 database_path = os.path.join(app_dir, app.config["DATABASE_FILE"])
-if not os.path.exists(database_path):
-    with app.app_context():
-        build_sample_db()
 
 
 if __name__ == "__main__":
+    if not os.path.exists(database_path):
+        with app.app_context():
+            build_sample_db()
+
     app.run(debug=True)

--- a/examples/azure_blob_storage/main.py
+++ b/examples/azure_blob_storage/main.py
@@ -17,21 +17,21 @@ admin = Admin(app, name="Example: Azure Blob Storage File Admin")
 babel = Babel(app)
 
 
-if __name__ == "__main__":
-    with AzuriteContainer() as azurite_container:
-        print("\n\n=============================")
-        print("Run docker, waith for Azurite to start and then go to:")
-        print("http://127.0.0.1:5000/admin/")
-        print("\n\n=============================")
-        connection_string = azurite_container.get_connection_string()
-        client = BlobServiceClient.from_connection_string(
-            connection_string, api_version="2019-12-12"
+with AzuriteContainer() as azurite_container:
+    print("\n\n=============================")
+    print("Run docker, waith for Azurite to start and then go to:")
+    print("http://127.0.0.1:5000/admin/")
+    print("\n\n=============================")
+    connection_string = azurite_container.get_connection_string()
+    client = BlobServiceClient.from_connection_string(
+        connection_string, api_version="2019-12-12"
+    )
+    admin.add_view(
+        AzureFileAdmin(
+            blob_service_client=client,
+            container_name="fileadmin-tests",
         )
-        admin.add_view(
-            AzureFileAdmin(
-                blob_service_client=client,
-                container_name="fileadmin-tests",
-            )
-        )
+    )
 
-        app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/azure_blob_storage/main.py
+++ b/examples/azure_blob_storage/main.py
@@ -17,21 +17,20 @@ admin = Admin(app, name="Example: Azure Blob Storage File Admin")
 babel = Babel(app)
 
 
-with AzuriteContainer() as azurite_container:
-    print("\n\n=============================")
-    print("Run docker, waith for Azurite to start and then go to:")
-    print("http://127.0.0.1:5000/admin/")
-    print("\n\n=============================")
-    connection_string = azurite_container.get_connection_string()
-    client = BlobServiceClient.from_connection_string(
-        connection_string, api_version="2019-12-12"
-    )
-    admin.add_view(
-        AzureFileAdmin(
-            blob_service_client=client,
-            container_name="fileadmin-tests",
-        )
-    )
-
 if __name__ == "__main__":
+    with AzuriteContainer() as azurite_container:
+        print("\n\n=============================")
+        print("Run docker, waith for Azurite to start and then go to:")
+        print("http://127.0.0.1:5000/admin/")
+        print("\n\n=============================")
+        connection_string = azurite_container.get_connection_string()
+        client = BlobServiceClient.from_connection_string(
+            connection_string, api_version="2019-12-12"
+        )
+        admin.add_view(
+            AzureFileAdmin(
+                blob_service_client=client,
+                container_name="fileadmin-tests",
+            )
+        )
     app.run(debug=True)

--- a/examples/azure_blob_storage/main.py
+++ b/examples/azure_blob_storage/main.py
@@ -16,21 +16,22 @@ app.config["SECRET_KEY"] = "secret"
 admin = Admin(app, name="Example: Azure Blob Storage File Admin")
 babel = Babel(app)
 
+with AzuriteContainer() as azurite_container:
+    print("\n\n=============================")
+    print("Run docker, waith for Azurite to start and then go to:")
+    print("http://127.0.0.1:5000/admin/")
+    print("\n\n=============================")
+    connection_string = azurite_container.get_connection_string()
+    client = BlobServiceClient.from_connection_string(
+        connection_string, api_version="2019-12-12"
+    )
+    admin.add_view(
+        AzureFileAdmin(
+            blob_service_client=client,
+            container_name="fileadmin-tests",
+        )
+    )
+
 
 if __name__ == "__main__":
-    with AzuriteContainer() as azurite_container:
-        print("\n\n=============================")
-        print("Run docker, waith for Azurite to start and then go to:")
-        print("http://127.0.0.1:5000/admin/")
-        print("\n\n=============================")
-        connection_string = azurite_container.get_connection_string()
-        client = BlobServiceClient.from_connection_string(
-            connection_string, api_version="2019-12-12"
-        )
-        admin.add_view(
-            AzureFileAdmin(
-                blob_service_client=client,
-                container_name="fileadmin-tests",
-            )
-        )
     app.run(debug=True)

--- a/examples/azure_blob_storage/main.py
+++ b/examples/azure_blob_storage/main.py
@@ -16,22 +16,32 @@ app.config["SECRET_KEY"] = "secret"
 admin = Admin(app, name="Example: Azure Blob Storage File Admin")
 babel = Babel(app)
 
-with AzuriteContainer() as azurite_container:
-    print("\n\n=============================")
-    print("Run docker, waith for Azurite to start and then go to:")
-    print("http://127.0.0.1:5000/admin/")
-    print("\n\n=============================")
-    connection_string = azurite_container.get_connection_string()
-    client = BlobServiceClient.from_connection_string(
-        connection_string, api_version="2019-12-12"
-    )
-    admin.add_view(
-        AzureFileAdmin(
-            blob_service_client=client,
-            container_name="fileadmin-tests",
-        )
-    )
+
+@app.route("/")
+def index():
+    tmp = """<p><a href="/admin/">Click me to get to Admin! </a></p>"""
+    return tmp
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    with AzuriteContainer() as azurite_container:
+        print("\n\n=============================")
+        print("Run docker, waith for Azurite to start and then go to:")
+        print("http://127.0.0.1:5000/admin/")
+
+        connection_string = azurite_container.get_connection_string()
+
+        print(f"Using Azure Blob Storage connection string: {connection_string}")
+        print("\n\n=============================")
+
+        client = BlobServiceClient.from_connection_string(
+            connection_string, api_version="2019-12-12"
+        )
+        admin.add_view(
+            AzureFileAdmin(
+                blob_service_client=client,
+                container_name="fileadmin-tests",
+            )
+        )
+
+        app.run(debug=True)

--- a/examples/babel/main.py
+++ b/examples/babel/main.py
@@ -78,12 +78,13 @@ def index():
     return tmp
 
 
+# admin.locale_selector(get_locale)
+admin.add_view(ModelView(User, db))
+admin.add_view(ModelView(Post, db))
+
+with app.app_context():
+    db.create_all()
+
+
 if __name__ == "__main__":
-    # admin.locale_selector(get_locale)
-    admin.add_view(ModelView(User, db))
-    admin.add_view(ModelView(Post, db))
-
-    with app.app_context():
-        db.create_all()
-
     app.run(debug=True)

--- a/examples/babel/main.py
+++ b/examples/babel/main.py
@@ -82,9 +82,9 @@ def index():
 admin.add_view(ModelView(User, db))
 admin.add_view(ModelView(Post, db))
 
-with app.app_context():
-    db.create_all()
-
 
 if __name__ == "__main__":
+    with app.app_context():
+        db.create_all()
+
     app.run(debug=True)

--- a/examples/babel/main.py
+++ b/examples/babel/main.py
@@ -82,9 +82,8 @@ def index():
 admin.add_view(ModelView(User, db))
 admin.add_view(ModelView(Post, db))
 
+with app.app_context():
+    db.create_all()
 
 if __name__ == "__main__":
-    with app.app_context():
-        db.create_all()
-
     app.run(debug=True)

--- a/examples/babel/main.py
+++ b/examples/babel/main.py
@@ -70,7 +70,9 @@ def index():
 <p><a href="/admin/?lang=ru">Click me to get to Admin! (Russian)</a></p>
 <p><a href="/admin/?lang=tr">Click me to get to Admin! (Turkish)</a></p>
 <p><a href="/admin/?lang=pa">Click me to get to Admin! (Punjabi)</a></p>
-<p><a href="/admin/?lang=zh_CN">Click me to get to Admin! (Chinese - Simplified)</a></p>
+<p>
+  <a href="/admin/?lang=zh_CN">Click me to get to Admin! (Chinese - Simplified)</a>
+</p>
 <p>
 <a href="/admin/?lang=zh_TW">Click me to get to Admin! (Chinese - Traditional)</a>
 </p>

--- a/examples/bootstrap4/main.py
+++ b/examples/bootstrap4/main.py
@@ -123,7 +123,6 @@ class PageWithModalView(ModelView):
 with app.app_context():
     build_sample_db(db, User, Page)
 
-if __name__ == "__main__":
     # Icons reference (FontAwesome v4):
     # https://fontawesome.com/v4/icons/
 
@@ -216,4 +215,6 @@ if __name__ == "__main__":
         with app.app_context():
             build_sample_db(db, User, Page)
 
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/custom_layout/main.py
+++ b/examples/custom_layout/main.py
@@ -115,15 +115,16 @@ def build_sample_db(names, surnames, pages):
     db.session.commit()
 
 
+admin.add_view(UserAdmin(User, db))
+admin.add_view(CustomView(Page, db))
+admin.add_view(CustomView(Sale, db))
+
+app_dir = op.realpath(os.path.dirname(__file__))
+database_path = op.join(app_dir, app.config["DATABASE_FILE"])
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db(first_names, last_names, sample_text)
+
+
 if __name__ == "__main__":
-    admin.add_view(UserAdmin(User, db))
-    admin.add_view(CustomView(Page, db))
-    admin.add_view(CustomView(Sale, db))
-
-    app_dir = op.realpath(os.path.dirname(__file__))
-    database_path = op.join(app_dir, app.config["DATABASE_FILE"])
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db(first_names, last_names, sample_text)
-
     app.run(debug=True)

--- a/examples/datetime_timezone/main.py
+++ b/examples/datetime_timezone/main.py
@@ -111,21 +111,23 @@ class BlogModelView(ModelView):
     }
 
 
+with app.app_context():
+    Base.metadata.drop_all(db.engine)
+    Base.metadata.create_all(db.engine)
+    db.session.add(
+        Article(text="Written at 9:00 UTC", last_edit=datetime(2024, 8, 8, 9, 0, 0))
+    )
+    db.session.commit()
+    admin.add_view(BlogModelView(Article, db, name="Article", endpoint="article"))
+    admin.add_view(
+        TimezoneAwareBlogModelView(
+            Article,
+            db,
+            name="Timezone Aware Article",
+            endpoint="timezone_aware_article",
+        )
+    )
+
+
 if __name__ == "__main__":
-    with app.app_context():
-        Base.metadata.drop_all(db.engine)
-        Base.metadata.create_all(db.engine)
-        db.session.add(
-            Article(text="Written at 9:00 UTC", last_edit=datetime(2024, 8, 8, 9, 0, 0))
-        )
-        db.session.commit()
-        admin.add_view(BlogModelView(Article, db, name="Article", endpoint="article"))
-        admin.add_view(
-            TimezoneAwareBlogModelView(
-                Article,
-                db,
-                name="Timezone Aware Article",
-                endpoint="timezone_aware_article",
-            )
-        )
     app.run(debug=True)

--- a/examples/forms_files_images/main.py
+++ b/examples/forms_files_images/main.py
@@ -242,16 +242,17 @@ def build_sample_db():
     db.session.commit()
 
 
+admin.add_view(FileView(File, db))
+admin.add_view(ImageView(Image, db))
+admin.add_view(UserView(User, db))
+admin.add_view(PageView(Page, db))
+
+app_dir = op.realpath(os.path.dirname(__file__))
+database_path = op.join(app_dir, app.config["DATABASE_FILE"])
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
+
+
 if __name__ == "__main__":
-    admin.add_view(FileView(File, db))
-    admin.add_view(ImageView(Image, db))
-    admin.add_view(UserView(User, db))
-    admin.add_view(PageView(Page, db))
-
-    app_dir = op.realpath(os.path.dirname(__file__))
-    database_path = op.join(app_dir, app.config["DATABASE_FILE"])
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
-
     app.run(debug=True)

--- a/examples/geo_alchemy/main.py
+++ b/examples/geo_alchemy/main.py
@@ -84,26 +84,29 @@ app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
 app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
 app.add_url_rule(rule="/", view_func=index)
 
-with PostgresContainer(
-    image="postgis/postgis:12-3.0",
-    port=5432,
-    username="username",
-    password="password",
-    dbname="main",
-) as postgres:
-    app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
-    db.init_app(app)
-    admin.init_app(app)
-    admin.add_view(LeafletModelView(Point, db, category="Points"))
-    admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
-    admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
-    admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
-    admin.add_view(LeafletModelView(LineString, db, category="Lines"))
-    admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
 
-    with app.app_context():
-        db.create_all()
-
+admin.init_app(app)
+admin.add_view(LeafletModelView(Point, db, category="Points"))
+admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
+admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
+admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
+admin.add_view(LeafletModelView(LineString, db, category="Lines"))
+admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    with PostgresContainer(
+        image="postgis/postgis:12-3.0",
+        port=5432,
+        username="username",
+        password="password",
+        dbname="main",
+    ) as postgres:
+        print(f"Using database URL: {app.config['SQLALCHEMY_DATABASE_URI']}")
+
+        app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
+        db.init_app(app)
+
+        with app.app_context():
+            db.create_all()
+
+        app.run(debug=True)

--- a/examples/geo_alchemy/main.py
+++ b/examples/geo_alchemy/main.py
@@ -66,39 +66,40 @@ class OSMModelView(ModelView):
     )
 
 
+app = Flask(__name__)
+
+with PostgresContainer(
+    image="postgis/postgis:12-3.0",
+    port=5432,
+    username="username",
+    password="password",
+    dbname="main",
+) as postgres:
+    app.config["SECRET_KEY"] = "secret"
+    app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
+    app.config["SQLALCHEMY_ECHO"] = False
+    # Credentials for loading map tiles from Mapbox
+    app.config["FLASK_ADMIN_MAPS"] = True
+    app.config["FLASK_ADMIN_MAPS_SEARCH"] = False
+    app.config["FLASK_ADMIN_MAPBOX_MAP_ID"] = "light-v10"
+    app.config["FLASK_ADMIN_MAPBOX_ACCESS_TOKEN"] = "..."
+    # When creating new shapes, use this default map center
+    app.config["FLASK_ADMIN_DEFAULT_CENTER_LAT"] = -33.918861
+    app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
+    # If you want to use Google Maps, set the API key here
+    app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
+    app.add_url_rule(rule="/", view_func=index)
+    db.init_app(app)
+    admin.init_app(app)
+    admin.add_view(LeafletModelView(Point, db, category="Points"))
+    admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
+    admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
+    admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
+    admin.add_view(LeafletModelView(LineString, db, category="Lines"))
+    admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
+
+    with app.app_context():
+        db.create_all()
+
 if __name__ == "__main__":
-    with PostgresContainer(
-        image="postgis/postgis:12-3.0",
-        port=5432,
-        username="username",
-        password="password",
-        dbname="main",
-    ) as postgres:
-        app = Flask(__name__)
-        app.config["SECRET_KEY"] = "secret"
-        app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
-        app.config["SQLALCHEMY_ECHO"] = False
-        # Credentials for loading map tiles from Mapbox
-        app.config["FLASK_ADMIN_MAPS"] = True
-        app.config["FLASK_ADMIN_MAPS_SEARCH"] = False
-        app.config["FLASK_ADMIN_MAPBOX_MAP_ID"] = "light-v10"
-        app.config["FLASK_ADMIN_MAPBOX_ACCESS_TOKEN"] = "..."
-        # When creating new shapes, use this default map center
-        app.config["FLASK_ADMIN_DEFAULT_CENTER_LAT"] = -33.918861
-        app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
-        # If you want to use Google Maps, set the API key here
-        app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
-        app.add_url_rule(rule="/", view_func=index)
-        db.init_app(app)
-        admin.init_app(app)
-        admin.add_view(LeafletModelView(Point, db, category="Points"))
-        admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
-        admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
-        admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
-        admin.add_view(LeafletModelView(LineString, db, category="Lines"))
-        admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
-
-        with app.app_context():
-            db.create_all()
-
-        app.run(debug=True)
+    app.run(debug=True)

--- a/examples/geo_alchemy/main.py
+++ b/examples/geo_alchemy/main.py
@@ -68,38 +68,42 @@ class OSMModelView(ModelView):
 
 app = Flask(__name__)
 
-with PostgresContainer(
-    image="postgis/postgis:12-3.0",
-    port=5432,
-    username="username",
-    password="password",
-    dbname="main",
-) as postgres:
-    app.config["SECRET_KEY"] = "secret"
-    app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
-    app.config["SQLALCHEMY_ECHO"] = False
-    # Credentials for loading map tiles from Mapbox
-    app.config["FLASK_ADMIN_MAPS"] = True
-    app.config["FLASK_ADMIN_MAPS_SEARCH"] = False
-    app.config["FLASK_ADMIN_MAPBOX_MAP_ID"] = "light-v10"
-    app.config["FLASK_ADMIN_MAPBOX_ACCESS_TOKEN"] = "..."
-    # When creating new shapes, use this default map center
-    app.config["FLASK_ADMIN_DEFAULT_CENTER_LAT"] = -33.918861
-    app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
-    # If you want to use Google Maps, set the API key here
-    app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
-    app.add_url_rule(rule="/", view_func=index)
-    db.init_app(app)
-    admin.init_app(app)
-    admin.add_view(LeafletModelView(Point, db, category="Points"))
-    admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
-    admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
-    admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
-    admin.add_view(LeafletModelView(LineString, db, category="Lines"))
-    admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
+app.config["SQLALCHEMY_ECHO"] = False
 
-    with app.app_context():
-        db.create_all()
+# Credentials for loading map tiles from Mapbox
+app.config["FLASK_ADMIN_MAPS"] = True
+app.config["FLASK_ADMIN_MAPS_SEARCH"] = False
+app.config["FLASK_ADMIN_MAPBOX_MAP_ID"] = "light-v10"
+app.config["FLASK_ADMIN_MAPBOX_ACCESS_TOKEN"] = "..."
+
+# When creating new shapes, use this default map center
+app.config["FLASK_ADMIN_DEFAULT_CENTER_LAT"] = -33.918861
+app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
+
+# If you want to use Google Maps, set the API key here
+app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
+app.add_url_rule(rule="/", view_func=index)
+
 
 if __name__ == "__main__":
+    with PostgresContainer(
+        image="postgis/postgis:12-3.0",
+        port=5432,
+        username="username",
+        password="password",
+        dbname="main",
+    ) as postgres:
+        app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
+        db.init_app(app)
+        admin.init_app(app)
+        admin.add_view(LeafletModelView(Point, db, category="Points"))
+        admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
+        admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
+        admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
+        admin.add_view(LeafletModelView(LineString, db, category="Lines"))
+        admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
+
+        with app.app_context():
+            db.create_all()
+
     app.run(debug=True)

--- a/examples/geo_alchemy/main.py
+++ b/examples/geo_alchemy/main.py
@@ -84,26 +84,26 @@ app.config["FLASK_ADMIN_DEFAULT_CENTER_LONG"] = 18.423300
 app.config["FLASK_ADMIN_GOOGLE_MAPS_API_KEY"] = "..."
 app.add_url_rule(rule="/", view_func=index)
 
+with PostgresContainer(
+    image="postgis/postgis:12-3.0",
+    port=5432,
+    username="username",
+    password="password",
+    dbname="main",
+) as postgres:
+    app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
+    db.init_app(app)
+    admin.init_app(app)
+    admin.add_view(LeafletModelView(Point, db, category="Points"))
+    admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
+    admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
+    admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
+    admin.add_view(LeafletModelView(LineString, db, category="Lines"))
+    admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
+
+    with app.app_context():
+        db.create_all()
+
 
 if __name__ == "__main__":
-    with PostgresContainer(
-        image="postgis/postgis:12-3.0",
-        port=5432,
-        username="username",
-        password="password",
-        dbname="main",
-    ) as postgres:
-        app.config["SQLALCHEMY_DATABASE_URI"] = postgres.get_connection_url()
-        db.init_app(app)
-        admin.init_app(app)
-        admin.add_view(LeafletModelView(Point, db, category="Points"))
-        admin.add_view(OSMModelView(MultiPoint, db, category="Points"))
-        admin.add_view(LeafletModelView(Polygon, db, category="Polygons"))
-        admin.add_view(OSMModelView(MultiPolygon, db, category="Polygons"))
-        admin.add_view(LeafletModelView(LineString, db, category="Lines"))
-        admin.add_view(OSMModelView(MultiLineString, db, category="Lines"))
-
-        with app.app_context():
-            db.create_all()
-
     app.run(debug=True)

--- a/examples/host_matching/main.py
+++ b/examples/host_matching/main.py
@@ -44,17 +44,18 @@ def index(anyhost):
     )
 
 
+# Create first administrative interface at `first.localhost:5000/admin1`
+admin1 = Admin(app, url="/admin1", host="first.localhost:5000")
+admin1.add_view(FirstView())
+
+# Create second administrative interface at `second.localhost:5000/admin2`
+admin2 = Admin(app, url="/admin2", endpoint="admin2", host="second.localhost:5000")
+admin2.add_view(SecondView())
+
+# Create third administrative interface, available on any domain at `/admin3`
+admin3 = Admin(app, url="/admin3", endpoint="admin3", host="*")
+admin3.add_view(ThirdViewAllHosts())
+
+
 if __name__ == "__main__":
-    # Create first administrative interface at `first.localhost:5000/admin1`
-    admin1 = Admin(app, url="/admin1", host="first.localhost:5000")
-    admin1.add_view(FirstView())
-
-    # Create second administrative interface at `second.localhost:5000/admin2`
-    admin2 = Admin(app, url="/admin2", endpoint="admin2", host="second.localhost:5000")
-    admin2.add_view(SecondView())
-
-    # Create third administrative interface, available on any domain at `/admin3`
-    admin3 = Admin(app, url="/admin3", endpoint="admin3", host="*")
-    admin3.add_view(ThirdViewAllHosts())
-
     app.run(debug=True)

--- a/examples/methodview/main.py
+++ b/examples/methodview/main.py
@@ -38,7 +38,8 @@ class ViewWithMethodViews(BaseView):
             return cls.render("test.html", request=request, name="API_v2")
 
 
-if __name__ == "__main__":
-    admin.add_view(ViewWithMethodViews())
+admin.add_view(ViewWithMethodViews())
 
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/mongoengine/main.py
+++ b/examples/mongoengine/main.py
@@ -178,12 +178,16 @@ def create_example_data():
     ).save()
 
 
-with MongoDbContainer("mongo:7.0.7") as mongo:
-    mongo_uri = mongo.get_connection_url()
-    connect(host=mongo_uri)
-    create_example_data()
-    admin.add_view(UserView(User, "User"))
-    admin.add_view(TweetView(Tweet, "Tweets"))
+admin.add_view(UserView(User, "User"))
+admin.add_view(TweetView(Tweet, "Tweets"))
+
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    with MongoDbContainer("mongo:7.0.7") as mongo:
+        mongo_uri = mongo.get_connection_url()
+        print("using mongo uri:", mongo_uri)
+
+        connect(host=mongo_uri)
+        create_example_data()
+
+        app.run(debug=True)

--- a/examples/mongoengine/main.py
+++ b/examples/mongoengine/main.py
@@ -178,12 +178,12 @@ def create_example_data():
     ).save()
 
 
-with MongoDbContainer("mongo:7.0.7") as mongo:
-    mongo_uri = mongo.get_connection_url()
-    connect(host=mongo_uri)
-    create_example_data()
-    admin.add_view(UserView(User, "User"))
-    admin.add_view(TweetView(Tweet, "Tweets"))
-
 if __name__ == "__main__":
+    with MongoDbContainer("mongo:7.0.7") as mongo:
+        mongo_uri = mongo.get_connection_url()
+        connect(host=mongo_uri)
+        create_example_data()
+        admin.add_view(UserView(User, "User"))
+        admin.add_view(TweetView(Tweet, "Tweets"))
+
     app.run(debug=True)

--- a/examples/mongoengine/main.py
+++ b/examples/mongoengine/main.py
@@ -178,12 +178,12 @@ def create_example_data():
     ).save()
 
 
-if __name__ == "__main__":
-    with MongoDbContainer("mongo:7.0.7") as mongo:
-        mongo_uri = mongo.get_connection_url()
-        connect(host=mongo_uri)
-        create_example_data()
-        admin.add_view(UserView(User, "User"))
-        admin.add_view(TweetView(Tweet, "Tweets"))
+with MongoDbContainer("mongo:7.0.7") as mongo:
+    mongo_uri = mongo.get_connection_url()
+    connect(host=mongo_uri)
+    create_example_data()
+    admin.add_view(UserView(User, "User"))
+    admin.add_view(TweetView(Tweet, "Tweets"))
 
-        app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/mongoengine/main.py
+++ b/examples/mongoengine/main.py
@@ -178,12 +178,12 @@ def create_example_data():
     ).save()
 
 
-if __name__ == "__main__":
-    with MongoDbContainer("mongo:7.0.7") as mongo:
-        mongo_uri = mongo.get_connection_url()
-        connect(host=mongo_uri)
-        create_example_data()
-        admin.add_view(UserView(User, "User"))
-        admin.add_view(TweetView(Tweet, "Tweets"))
+with MongoDbContainer("mongo:7.0.7") as mongo:
+    mongo_uri = mongo.get_connection_url()
+    connect(host=mongo_uri)
+    create_example_data()
+    admin.add_view(UserView(User, "User"))
+    admin.add_view(TweetView(Tweet, "Tweets"))
 
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/multiple_admin_instances/main.py
+++ b/examples/multiple_admin_instances/main.py
@@ -23,10 +23,10 @@ admin2 = Admin(app, url="/admin2", endpoint="admin2")
 
 @app.route("/")
 def index():
-    return (
-        '<a href="/admin1">Click me to get to Admin 1</a><br/><a href="/admin2">'
-        "Click me to get to Admin 2</a>"
-    )
+    return """
+    <a href="/admin1">Click me to get to Admin 1</a> <br/>
+    <a href="/admin2">Click me to get to Admin 2</a>
+    """
 
 
 admin1.add_view(FirstView())

--- a/examples/multiple_admin_instances/main.py
+++ b/examples/multiple_admin_instances/main.py
@@ -29,7 +29,9 @@ def index():
     )
 
 
+admin1.add_view(FirstView())
+admin2.add_view(SecondView())
+
+
 if __name__ == "__main__":
-    admin1.add_view(FirstView())
-    admin2.add_view(SecondView())
     app.run(debug=True)

--- a/examples/peewee_simple/main.py
+++ b/examples/peewee_simple/main.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 import peewee
@@ -114,42 +115,36 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
+logging.basicConfig()
+logging.getLogger().setLevel(logging.DEBUG)
+
+admin = Admin(app, name="Example: Peewee")
+
+admin.add_view(UserAdmin(User))
+admin.add_view(PostAdmin(Post))
+
+admin.add_view(ViewWithPk(Book))
+admin.add_view(ModelView(Category))
+admin.add_view(ViewWithPk(BookCategory))
+
+# Create tables first
+with db:
+    db.drop_tables([BookCategory, Post, UserInfo, Book, Category, User], safe=True)
+    db.create_tables([User, UserInfo, Post, Book, Category, BookCategory], safe=True)
+
+with db.atomic():
+    # Create sample books
+    book1, created = Book.get_or_create(isbn="111", defaults={"name": "Sample Book 1"})
+    book2, created = Book.get_or_create(isbn="222", defaults={"name": "Sample Book 2"})
+
+    # Create sample categories
+    cat1, created = Category.get_or_create(name="Fiction")
+    cat2, created = Category.get_or_create(name="Science")
+
+    # Create relationships
+    BookCategory.get_or_create(isbn=book1, category=cat1)
+    BookCategory.get_or_create(isbn=book2, category=cat2)
+
+
 if __name__ == "__main__":
-    import logging
-
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
-
-    admin = Admin(app, name="Example: Peewee")
-
-    admin.add_view(UserAdmin(User))
-    admin.add_view(PostAdmin(Post))
-
-    admin.add_view(ViewWithPk(Book))
-    admin.add_view(ModelView(Category))
-    admin.add_view(ViewWithPk(BookCategory))
-
-    # Create tables first
-    with db:
-        db.drop_tables([BookCategory, Post, UserInfo, Book, Category, User], safe=True)
-        db.create_tables(
-            [User, UserInfo, Post, Book, Category, BookCategory], safe=True
-        )
-    with db.atomic():
-        # Create sample books
-        book1, created = Book.get_or_create(
-            isbn="111", defaults={"name": "Sample Book 1"}
-        )
-        book2, created = Book.get_or_create(
-            isbn="222", defaults={"name": "Sample Book 2"}
-        )
-
-        # Create sample categories
-        cat1, created = Category.get_or_create(name="Fiction")
-        cat2, created = Category.get_or_create(name="Science")
-
-        # Create relationships
-        BookCategory.get_or_create(isbn=book1, category=cat1)
-        BookCategory.get_or_create(isbn=book2, category=cat2)
-
     app.run(debug=True)

--- a/examples/pymongo_simple/main.py
+++ b/examples/pymongo_simple/main.py
@@ -107,12 +107,13 @@ def index():
     return f'<a href="{url_for("admin.index")}">Go to admin!</a>'
 
 
-with MongoDbContainer("mongo:7.0.7") as mongo:
-    conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
-    db = conn.test
-
-    admin.add_view(UserView(db.user, "User"))
-    admin.add_view(TweetView(db.tweet, "Tweets"))
-
 if __name__ == "__main__":
-    app.run(debug=True)
+    with MongoDbContainer("mongo:7.0.7") as mongo:
+        conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
+        print("MongoDB is running at:", conn.address)
+
+        db = conn.test
+        admin.add_view(UserView(db.user, "User"))
+        admin.add_view(TweetView(db.tweet, "Tweets"))
+
+        app.run(debug=True)

--- a/examples/pymongo_simple/main.py
+++ b/examples/pymongo_simple/main.py
@@ -107,12 +107,12 @@ def index():
     return f'<a href="{url_for("admin.index")}">Go to admin!</a>'
 
 
+with MongoDbContainer("mongo:7.0.7") as mongo:
+    conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
+    db = conn.test
+
+    admin.add_view(UserView(db.user, "User"))
+    admin.add_view(TweetView(db.tweet, "Tweets"))
+
 if __name__ == "__main__":
-    with MongoDbContainer("mongo:7.0.7") as mongo:
-        conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
-        db = conn.test
-
-        admin.add_view(UserView(db.user, "User"))
-        admin.add_view(TweetView(db.tweet, "Tweets"))
-
-        app.run(debug=True)
+    app.run(debug=True)

--- a/examples/pymongo_simple/main.py
+++ b/examples/pymongo_simple/main.py
@@ -107,12 +107,12 @@ def index():
     return f'<a href="{url_for("admin.index")}">Go to admin!</a>'
 
 
+with MongoDbContainer("mongo:7.0.7") as mongo:
+    conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
+    db = conn.test
+
+    admin.add_view(UserView(db.user, "User"))
+    admin.add_view(TweetView(db.tweet, "Tweets"))
+
 if __name__ == "__main__":
-    with MongoDbContainer("mongo:7.0.7") as mongo:
-        conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
-        db = conn.test
-
-        admin.add_view(UserView(db.user, "User"))
-        admin.add_view(TweetView(db.tweet, "Tweets"))
-
     app.run(debug=True)

--- a/examples/pymongo_simple/main.py
+++ b/examples/pymongo_simple/main.py
@@ -107,12 +107,12 @@ def index():
     return f'<a href="{url_for("admin.index")}">Go to admin!</a>'
 
 
-with MongoDbContainer("mongo:7.0.7") as mongo:
-    conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
-    db = conn.test
-
-    admin.add_view(UserView(db.user, "User"))
-    admin.add_view(TweetView(db.tweet, "Tweets"))
-
 if __name__ == "__main__":
+    with MongoDbContainer("mongo:7.0.7") as mongo:
+        conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
+        db = conn.test
+
+        admin.add_view(UserView(db.user, "User"))
+        admin.add_view(TweetView(db.tweet, "Tweets"))
+
     app.run(debug=True)

--- a/examples/rediscli/main.py
+++ b/examples/rediscli/main.py
@@ -14,18 +14,20 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-with RedisContainer() as redis_container:
-    redis_client = redis_container.get_client()
-    admin.add_view(
-        RedisCli(
-            Redis(
-                host=redis_container.get_container_host_ip(),
-                port=redis_container.get_exposed_port(redis_container.port),
-                password=redis_container.password,
+if __name__ == "__main__":
+    with RedisContainer() as redis_container:
+        redis_client = redis_container.get_client()
+        print("\n\n=============================")
+        print(f"using Redis in Docker container {redis_container}")
+
+        admin.add_view(
+            RedisCli(
+                Redis(
+                    host=redis_container.get_container_host_ip(),
+                    port=redis_container.get_exposed_port(redis_container.port),
+                    password=redis_container.password,
+                )
             )
         )
-    )
 
-
-if __name__ == "__main__":
-    app.run(debug=True)
+        app.run(debug=True)

--- a/examples/rediscli/main.py
+++ b/examples/rediscli/main.py
@@ -14,17 +14,17 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-if __name__ == "__main__":
-    with RedisContainer() as redis_container:
-        redis_client = redis_container.get_client()
-        admin.add_view(
-            RedisCli(
-                Redis(
-                    host=redis_container.get_container_host_ip(),
-                    port=redis_container.get_exposed_port(redis_container.port),
-                    password=redis_container.password,
-                )
+with RedisContainer() as redis_container:
+    redis_client = redis_container.get_client()
+    admin.add_view(
+        RedisCli(
+            Redis(
+                host=redis_container.get_container_host_ip(),
+                port=redis_container.get_exposed_port(redis_container.port),
+                password=redis_container.password,
             )
         )
+    )
 
-        app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/rediscli/main.py
+++ b/examples/rediscli/main.py
@@ -14,17 +14,18 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-if __name__ == "__main__":
-    with RedisContainer() as redis_container:
-        redis_client = redis_container.get_client()
-        admin.add_view(
-            RedisCli(
-                Redis(
-                    host=redis_container.get_container_host_ip(),
-                    port=redis_container.get_exposed_port(redis_container.port),
-                    password=redis_container.password,
-                )
+with RedisContainer() as redis_container:
+    redis_client = redis_container.get_client()
+    admin.add_view(
+        RedisCli(
+            Redis(
+                host=redis_container.get_container_host_ip(),
+                port=redis_container.get_exposed_port(redis_container.port),
+                password=redis_container.password,
             )
         )
+    )
 
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/rediscli/main.py
+++ b/examples/rediscli/main.py
@@ -14,17 +14,17 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-with RedisContainer() as redis_container:
-    redis_client = redis_container.get_client()
-    admin.add_view(
-        RedisCli(
-            Redis(
-                host=redis_container.get_container_host_ip(),
-                port=redis_container.get_exposed_port(redis_container.port),
-                password=redis_container.password,
+if __name__ == "__main__":
+    with RedisContainer() as redis_container:
+        redis_client = redis_container.get_client()
+        admin.add_view(
+            RedisCli(
+                Redis(
+                    host=redis_container.get_container_host_ip(),
+                    port=redis_container.get_exposed_port(redis_container.port),
+                    password=redis_container.password,
+                )
             )
         )
-    )
 
-if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -20,53 +20,54 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
+with LocalStackContainer(image="localstack/localstack:latest") as localstack:
+    s3_endpoint = localstack.get_url()
+    os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
+
+    # Create S3 client
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        endpoint_url=s3_endpoint,
+    )
+
+    # Create S3 bucket
+    bucket_name = "bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-directory/some-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-directory/yy/another-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    # Add S3FileAdmin view
+    admin.add_view(
+        S3FileAdmin(
+            bucket_name=bucket_name,
+            s3_client=s3_client,
+        )
+    )
+
+    # Add Local Directory view
+    admin.add_view(FileAdmin("localdir", name="Local Dir"))
+
+
 if __name__ == "__main__":
-    with LocalStackContainer(image="localstack/localstack:latest") as localstack:
-        s3_endpoint = localstack.get_url()
-        os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
-
-        # Create S3 client
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id="test",
-            aws_secret_access_key="test",
-            endpoint_url=s3_endpoint,
-        )
-
-        # Create S3 bucket
-        bucket_name = "bucket"
-        s3_client.create_bucket(Bucket=bucket_name)
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-directory/some-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-directory/yy/another-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        # Add S3FileAdmin view
-        admin.add_view(
-            S3FileAdmin(
-                bucket_name=bucket_name,
-                s3_client=s3_client,
-            )
-        )
-
-        # Add Local Directory view
-        admin.add_view(FileAdmin("localdir", name="Local Dir"))
-
-        app.run(debug=True)
+    app.run(debug=True)

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -20,54 +20,53 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-with LocalStackContainer(image="localstack/localstack:latest") as localstack:
-    s3_endpoint = localstack.get_url()
-    os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
-
-    # Create S3 client
-    s3_client = boto3.client(
-        "s3",
-        aws_access_key_id="test",
-        aws_secret_access_key="test",
-        endpoint_url=s3_endpoint,
-    )
-
-    # Create S3 bucket
-    bucket_name = "bucket"
-    s3_client.create_bucket(Bucket=bucket_name)
-
-    s3_client.upload_fileobj(
-        BytesIO(b"abcdef"),
-        "bucket",
-        "some-file",
-        ExtraArgs={"ContentType": "text/plain"},
-    )
-
-    s3_client.upload_fileobj(
-        BytesIO(b"abcdef"),
-        "bucket",
-        "some-directory/some-file",
-        ExtraArgs={"ContentType": "text/plain"},
-    )
-
-    s3_client.upload_fileobj(
-        BytesIO(b"abcdef"),
-        "bucket",
-        "some-directory/yy/another-file",
-        ExtraArgs={"ContentType": "text/plain"},
-    )
-
-    # Add S3FileAdmin view
-    admin.add_view(
-        S3FileAdmin(
-            bucket_name=bucket_name,
-            s3_client=s3_client,
-        )
-    )
-
-    # Add Local Directory view
-    admin.add_view(FileAdmin("localdir", name="Local Dir"))
-
-
 if __name__ == "__main__":
+    with LocalStackContainer(image="localstack/localstack:latest") as localstack:
+        s3_endpoint = localstack.get_url()
+        os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
+
+        # Create S3 client
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            endpoint_url=s3_endpoint,
+        )
+
+        # Create S3 bucket
+        bucket_name = "bucket"
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        s3_client.upload_fileobj(
+            BytesIO(b"abcdef"),
+            "bucket",
+            "some-file",
+            ExtraArgs={"ContentType": "text/plain"},
+        )
+
+        s3_client.upload_fileobj(
+            BytesIO(b"abcdef"),
+            "bucket",
+            "some-directory/some-file",
+            ExtraArgs={"ContentType": "text/plain"},
+        )
+
+        s3_client.upload_fileobj(
+            BytesIO(b"abcdef"),
+            "bucket",
+            "some-directory/yy/another-file",
+            ExtraArgs={"ContentType": "text/plain"},
+        )
+
+        # Add S3FileAdmin view
+        admin.add_view(
+            S3FileAdmin(
+                bucket_name=bucket_name,
+                s3_client=s3_client,
+            )
+        )
+
+        # Add Local Directory view
+        admin.add_view(FileAdmin("localdir", name="Local Dir"))
+
     app.run(debug=True)

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -20,53 +20,54 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
-with LocalStackContainer(image="localstack/localstack:latest") as localstack:
-    s3_endpoint = localstack.get_url()
-    os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
-
-    # Create S3 client
-    s3_client = boto3.client(
-        "s3",
-        aws_access_key_id="test",
-        aws_secret_access_key="test",
-        endpoint_url=s3_endpoint,
-    )
-
+def create_bucket(s3_client, bucket_name):
     # Create S3 bucket
-    bucket_name = "bucket"
     s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.upload_fileobj(
         BytesIO(b"abcdef"),
-        "bucket",
+        bucket_name,
         "some-file",
         ExtraArgs={"ContentType": "text/plain"},
     )
 
     s3_client.upload_fileobj(
         BytesIO(b"abcdef"),
-        "bucket",
+        bucket_name,
         "some-directory/some-file",
         ExtraArgs={"ContentType": "text/plain"},
     )
 
     s3_client.upload_fileobj(
         BytesIO(b"abcdef"),
-        "bucket",
+        bucket_name,
         "some-directory/yy/another-file",
         ExtraArgs={"ContentType": "text/plain"},
     )
 
-    # Add S3FileAdmin view
-    admin.add_view(
-        S3FileAdmin(
-            bucket_name=bucket_name,
-            s3_client=s3_client,
-        )
-    )
 
-    # Add Local Directory view
-    admin.add_view(FileAdmin("localdir", name="Local Dir"))
+# Add Local Directory view
+admin.add_view(FileAdmin("localdir", name="Local Dir"))
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    with LocalStackContainer(image="localstack/localstack:latest") as localstack:
+        s3_endpoint = localstack.get_url()
+        os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
+
+        print(f"using LocalStack in Docker container {s3_endpoint}")
+
+        # Create S3 client
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            endpoint_url=s3_endpoint,
+        )
+
+        bucket_name = "bucket"
+        create_bucket(s3_client, bucket_name)
+
+        # Add S3FileAdmin view
+        admin.add_view(S3FileAdmin(bucket_name=bucket_name, s3_client=s3_client))
+
+        app.run(debug=True)

--- a/examples/s3/main.py
+++ b/examples/s3/main.py
@@ -20,53 +20,53 @@ def index():
     return '<a href="/admin/">Click me to get to Admin!</a>'
 
 
+with LocalStackContainer(image="localstack/localstack:latest") as localstack:
+    s3_endpoint = localstack.get_url()
+    os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
+
+    # Create S3 client
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        endpoint_url=s3_endpoint,
+    )
+
+    # Create S3 bucket
+    bucket_name = "bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-directory/some-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    s3_client.upload_fileobj(
+        BytesIO(b"abcdef"),
+        "bucket",
+        "some-directory/yy/another-file",
+        ExtraArgs={"ContentType": "text/plain"},
+    )
+
+    # Add S3FileAdmin view
+    admin.add_view(
+        S3FileAdmin(
+            bucket_name=bucket_name,
+            s3_client=s3_client,
+        )
+    )
+
+    # Add Local Directory view
+    admin.add_view(FileAdmin("localdir", name="Local Dir"))
+
 if __name__ == "__main__":
-    with LocalStackContainer(image="localstack/localstack:latest") as localstack:
-        s3_endpoint = localstack.get_url()
-        os.environ["AWS_ENDPOINT_OVERRIDE"] = s3_endpoint
-
-        # Create S3 client
-        s3_client = boto3.client(
-            "s3",
-            aws_access_key_id="test",
-            aws_secret_access_key="test",
-            endpoint_url=s3_endpoint,
-        )
-
-        # Create S3 bucket
-        bucket_name = "bucket"
-        s3_client.create_bucket(Bucket=bucket_name)
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-directory/some-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        s3_client.upload_fileobj(
-            BytesIO(b"abcdef"),
-            "bucket",
-            "some-directory/yy/another-file",
-            ExtraArgs={"ContentType": "text/plain"},
-        )
-
-        # Add S3FileAdmin view
-        admin.add_view(
-            S3FileAdmin(
-                bucket_name=bucket_name,
-                s3_client=s3_client,
-            )
-        )
-
-        # Add Local Directory view
-        admin.add_view(FileAdmin("localdir", name="Local Dir"))
-
     app.run(debug=True)

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -30,7 +30,8 @@ class AnotherAdminView(BaseView):
         return self.render("test.html")
 
 
+admin.add_view(MyAdminView(name="view1", category="Test"))
+admin.add_view(AnotherAdminView(name="view2", category="Test"))
+
 if __name__ == "__main__":
-    admin.add_view(MyAdminView(name="view1", category="Test"))
-    admin.add_view(AnotherAdminView(name="view2", category="Test"))
     app.run(debug=True)

--- a/examples/sqla/admin/main.py
+++ b/examples/sqla/admin/main.py
@@ -1,5 +1,3 @@
-from flask import redirect
-from flask import url_for
 from flask_admin import Admin
 from flask_admin.babel import gettext
 from flask_admin.base import MenuLink
@@ -19,31 +17,6 @@ from .models import Post
 from .models import Tag
 from .models import Tree
 from .models import User
-
-
-@app.route("/")
-def index():
-    tmp = """
-<p><a href="/admin/?lang=en">Click me to get to Admin! (English)</a></p>
-<p><a href="/admin/?lang=cs">Click me to get to Admin! (Czech)</a></p>
-<p><a href="/admin/?lang=de">Click me to get to Admin! (German)</a></p>
-<p><a href="/admin/?lang=es">Click me to get to Admin! (Spanish)</a></p>
-<p><a href="/admin/?lang=fa">Click me to get to Admin! (Farsi)</a></p>
-<p><a href="/admin/?lang=fr">Click me to get to Admin! (French)</a></p>
-<p><a href="/admin/?lang=pt">Click me to get to Admin! (Portuguese)</a></p>
-<p><a href="/admin/?lang=ru">Click me to get to Admin! (Russian)</a></p>
-<p><a href="/admin/?lang=pa">Click me to get to Admin! (Punjabi)</a></p>
-<p><a href="/admin/?lang=zh_CN">Click me to get to Admin! (Chinese - Simplified)</a></p>
-<p>
-  <a href="/admin/?lang=zh_TW">Click me to get to Admin! (Chinese - Traditional)</a>
-</p>
-"""
-    return tmp
-
-
-@app.route("/favicon.ico")
-def favicon():
-    return redirect(url_for("static", filename="/favicon.ico"))
 
 
 # Custom filter class

--- a/examples/sqla/main.py
+++ b/examples/sqla/main.py
@@ -5,12 +5,13 @@ from admin import app
 from admin.data import build_sample_db
 from jinja2 import StrictUndefined
 
-if __name__ == "__main__":
-    app_dir = op.join(op.realpath(os.path.dirname(__file__)), "admin")
-    database_path = op.join(app_dir, app.config["DATABASE_FILE"])
-    if not os.path.exists(database_path):
-        with app.app_context():
-            build_sample_db()
+app_dir = op.join(op.realpath(os.path.dirname(__file__)), "admin")
+database_path = op.join(app_dir, app.config["DATABASE_FILE"])
+if not os.path.exists(database_path):
+    with app.app_context():
+        build_sample_db()
 
-    app.jinja_env.undefined = StrictUndefined
+app.jinja_env.undefined = StrictUndefined
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/sqla/main.py
+++ b/examples/sqla/main.py
@@ -3,6 +3,8 @@ import os.path as op
 
 from admin import app
 from admin.data import build_sample_db
+from flask import redirect
+from flask import url_for
 from jinja2 import StrictUndefined
 
 app_dir = op.join(op.realpath(os.path.dirname(__file__)), "admin")
@@ -12,6 +14,34 @@ if not os.path.exists(database_path):
         build_sample_db()
 
 app.jinja_env.undefined = StrictUndefined
+
+
+@app.route("/")
+def index():
+    tmp = """
+    <p><a href="/admin/?lang=en">Click me to get to Admin! (English)</a></p>
+    <p><a href="/admin/?lang=cs">Click me to get to Admin! (Czech)</a></p>
+    <p><a href="/admin/?lang=de">Click me to get to Admin! (German)</a></p>
+    <p><a href="/admin/?lang=es">Click me to get to Admin! (Spanish)</a></p>
+    <p><a href="/admin/?lang=fa">Click me to get to Admin! (Farsi)</a></p>
+    <p><a href="/admin/?lang=fr">Click me to get to Admin! (French)</a></p>
+    <p><a href="/admin/?lang=pt">Click me to get to Admin! (Portuguese)</a></p>
+    <p><a href="/admin/?lang=ru">Click me to get to Admin! (Russian)</a></p>
+    <p><a href="/admin/?lang=pa">Click me to get to Admin! (Punjabi)</a></p>
+    <p>
+      <a href="/admin/?lang=zh_CN">Click me to get to Admin! (Chinese - Simplified)</a>
+    </p>
+    <p>
+      <a href="/admin/?lang=zh_TW">Click me to get to Admin! (Chinese - Traditional)</a>
+    </p>
+    """
+    return tmp
+
+
+@app.route("/favicon.ico")
+def favicon():
+    return redirect(url_for("static", filename="favicon.ico"))
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/sqla/main.py
+++ b/examples/sqla/main.py
@@ -5,15 +5,12 @@ from admin import app
 from admin.data import build_sample_db
 from flask import redirect
 from flask import url_for
-from jinja2 import StrictUndefined
 
 app_dir = op.join(op.realpath(os.path.dirname(__file__)), "admin")
 database_path = op.join(app_dir, app.config["DATABASE_FILE"])
 if not os.path.exists(database_path):
     with app.app_context():
         build_sample_db()
-
-app.jinja_env.undefined = StrictUndefined
 
 
 @app.route("/")

--- a/examples/sqla_association_proxy/main.py
+++ b/examples/sqla_association_proxy/main.py
@@ -103,18 +103,18 @@ class KeywordAdmin(ModelView):
     column_list = ("id", "keyword")
 
 
+admin.add_view(UserAdmin(User, db))
+admin.add_view(KeywordAdmin(Keyword, db))
+
+with app.app_context():
+    db.create_all()
+    user = User("log")
+
+    for kw in (Keyword("new_from_blammo"), Keyword("its_big")):
+        user.keywords.append(kw)
+
+    db.session.add(user)
+    db.session.commit()
+
 if __name__ == "__main__":
-    admin.add_view(UserAdmin(User, db))
-    admin.add_view(KeywordAdmin(Keyword, db))
-
-    with app.app_context():
-        db.create_all()
-        user = User("log")
-
-        for kw in (Keyword("new_from_blammo"), Keyword("its_big")):
-            user.keywords.append(kw)
-
-        db.session.add(user)
-        db.session.commit()
-
     app.run(debug=True)

--- a/examples/sqla_custom_inline_forms/main.py
+++ b/examples/sqla_custom_inline_forms/main.py
@@ -171,14 +171,14 @@ def first_time_setup():
         db.session.commit()
 
 
+try:
+    os.mkdir(base_path)
+except OSError:
+    pass
+
+first_time_setup()
+
+admin.add_view(LocationAdmin())
+
 if __name__ == "__main__":
-    try:
-        os.mkdir(base_path)
-    except OSError:
-        pass
-
-    first_time_setup()
-
-    admin.add_view(LocationAdmin())
-
     app.run(debug=True)


### PR DESCRIPTION
This PR just to relocate the running gurard `if __name__ == "__main__":` into the right place.

**Reason of this PR:** the running guard has to be only for  `app.run()` so that the server won't be executed twice while the other code should be out of the `if` statement. It is useful to run the example with the python debugger using VScode or other tool, however in such cases, the server will be run implicitly (using `flask run` command) without the line of `app.run()`