### PR TITLE
fix the CSRF token on delete files and directories

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/file/list.html
+++ b/flask_admin/templates/bootstrap4/admin/file/list.html
@@ -86,8 +86,11 @@
                         {% if name != '..' and admin_view.can_delete_dirs %}
                         <form class="icon" method="POST" action="{{ get_url('.delete') }}">
                             {{ delete_form.path(value=path) }}
+
                             {% if delete_form.csrf_token is defined and delete_form.csrf_token %}
-                            {{ delete_form.csrf_token }}
+                              {{ delete_form.csrf_token }}
+                            {% elif csrf_token is defined and csrf_token %}
+                              <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
                             {% endif %}
                             <button onclick="return confirm('{{ _gettext('Are you sure you want to delete \\\'%(name)s\\\' recursively?', name=name) }}')">
                                 <i class="fa fa-times glyphicon glyphicon-remove"></i>
@@ -97,8 +100,11 @@
                     {% else %}
                     <form class="icon" method="POST" action="{{ get_url('.delete') }}">
                         {{ delete_form.path(value=path) }}
+
                         {% if delete_form.csrf_token is defined and delete_form.csrf_token %}
-                        {{ delete_form.csrf_token }}
+                          {{ delete_form.csrf_token }}
+                        {% elif csrf_token is defined and csrf_token %}
+                          <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
                         {% endif %}
                         <button onclick="return confirm('{{ _gettext('Are you sure you want to delete \\\'%(name)s\\\'?', name=name) }}')">
                             <i class="fa fa-trash glyphicon glyphicon-trash"></i>

--- a/flask_admin/tests/fileadmin/test_fileadmin.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin.py
@@ -11,6 +11,10 @@ from flask_admin.contrib import fileadmin
 from flask_admin.contrib.fileadmin import FileAdmin
 from flask_admin.contrib.fileadmin.azure import AzureFileAdmin
 from flask_admin.contrib.fileadmin.s3 import S3FileAdmin
+
+from flask_admin import Admin
+from flask_admin.contrib import fileadmin
+from flask_admin.form import SecureForm
 from flask_admin.theme import Bootstrap4Theme
 
 
@@ -237,6 +241,175 @@ class Base:
             assert rv.status_code == 200
             data = rv.data.decode("utf-8")
             assert "fa_modal_window" not in data
+
+        def get_csrf_token(self, data):
+            data = data.split('name="csrf_token" type="hidden" value="')[1]
+            token = data.split('"')[0]
+            return token
+
+        @pytest.mark.parametrize(
+            "page",
+            [
+                "/admin/fileadmin/",
+                "/admin/fileadmin/upload",
+                "/admin/fileadmin/rename/?path=dummy.txt",
+                "/admin/fileadmin/rename/?path=d1",
+                "/admin/fileadmin/mkdir",
+            ],
+        )
+        def test_csrf_token(self, app, admin, page):
+            # Cross-Site-Request-Forgery (CSRF) Protection
+            app.config["WTF_CSRF_ENABLED"] = True
+
+            os.makedirs(op.join(self._test_files_root, "d1"), exist_ok=True)
+
+            fileadmin_class = self.fileadmin_class()
+            fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
+
+            class SecureFileAdmin(fileadmin_class):  # type: ignore[valid-type, misc]
+                form_base_class = SecureForm
+
+            fileadmin_kwargs["endpoint"] = "fileadmin"
+            view = SecureFileAdmin(*fileadmin_args, **fileadmin_kwargs)
+            admin.add_view(view)
+
+            client = app.test_client()
+
+            rv = client.get(page, follow_redirects=True)
+            data = rv.data.decode("utf-8")
+            assert rv.status_code == 200
+            assert 'name="csrf_token"' in data
+            assert len(self.get_csrf_token(data)) == 56
+
+        def test_csrf_submit(self, app, admin, request):
+            # Cross-Site-Request-Forgery (CSRF) Protection
+            app.config["WTF_CSRF_ENABLED"] = True
+
+            def finalizer():
+                try:
+                    os.remove(op.join(self._test_files_root, "d1/dum.txt"))
+                    os.remove(op.join(self._test_files_root, "dummy_renamed.txt"))
+                    os.remove(op.join(self._test_files_root, "dummy2.txt"))
+                except OSError:
+                    pass
+
+            request.addfinalizer(finalizer)
+
+            fileadmin_class = self.fileadmin_class()
+            fileadmin_args, fileadmin_kwargs = self.fileadmin_args()
+
+            class SecureFileAdmin(fileadmin_class):  # type: ignore[valid-type, misc]
+                form_base_class = SecureForm
+
+                def is_accessible(self):
+                    return True
+
+            fileadmin_kwargs["endpoint"] = "myfileadmin"
+            view = SecureFileAdmin(*fileadmin_args, **fileadmin_kwargs)
+            admin.add_view(view)
+
+            client = app.test_client()
+
+            rv = client.get("/admin/myfileadmin/", follow_redirects=True)
+            data = rv.data.decode("utf-8")
+            # make sure that dummy.txt exists
+            assert "dummy.txt" in data
+
+            # read the token
+            rv = client.get("/admin/myfileadmin", follow_redirects=True)
+            data = rv.data.decode("utf-8")
+            assert rv.status_code == 200
+            assert 'name="csrf_token"' in data
+            assert len(self.get_csrf_token(data)) == 56
+            csrf_token = self.get_csrf_token(data)
+
+            # rename
+            rv = client.post(
+                "/admin/myfileadmin/rename/?path=dummy.txt",
+                data=dict(
+                    name="dummy_renamed.txt",
+                    path="dummy.txt",
+                ),
+            )
+            data = rv.data.decode("utf-8")
+            data = data.split("</nav>")[1]
+            assert rv.status_code == 200
+            assert "CSRF token missing" in data
+
+            rv = client.post(
+                "/admin/myfileadmin/rename/?path=dummy.txt",
+                data=dict(
+                    name="dummy_renamed.txt", path="dummy.txt", csrf_token=csrf_token
+                ),
+                follow_redirects=True,
+            )
+            assert rv.status_code == 200
+            assert "dummy_renamed.txt" in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
+
+            rv = client.post(
+                "/admin/myfileadmin/upload/",
+                data=dict(
+                    upload=(BytesIO(b""), "dummy_renamed.txt"), csrf_token=csrf_token
+                ),
+                follow_redirects=True,
+            )
+            data = rv.data.decode("utf-8")
+            assert rv.status_code == 200
+            assert "dummy_renamed.txt" in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
+            assert "already exists." in data
+
+            with open(op.join(self._test_files_root, "dummy.txt"), "w") as fp:
+                fp.write("new_string\n")
+
+            # delete
+            rv = client.post(
+                "/admin/myfileadmin/delete/",
+                data=dict(path="dummy_renamed.txt", csrf_token=csrf_token),
+                follow_redirects=True,
+            )
+            assert rv.status_code == 200
+            assert "dummy_renamed.txt" not in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
+
+            # mkdir
+            rv = client.post(
+                "/admin/myfileadmin/mkdir/",
+                data=dict(name="dummy_dir", csrf_token=csrf_token),
+                follow_redirects=True,
+            )
+            assert rv.status_code == 200
+            assert "dummy_dir" in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
+
+            # rename - dir
+            rv = client.post(
+                "/admin/myfileadmin/rename/?path=dummy_dir",
+                data=dict(
+                    name="dummy_renamed_dir", path="dummy_dir", csrf_token=csrf_token
+                ),
+                follow_redirects=True,
+            )
+            assert rv.status_code == 200
+            assert "dummy_renamed_dir" in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
+
+            # delete - directory
+            rv = client.post(
+                "/admin/myfileadmin/delete/",
+                data=dict(path="dummy_renamed_dir", csrf_token=csrf_token),
+                follow_redirects=True,
+            )
+            assert rv.status_code == 200
+            assert "dummy_renamed_dir" not in client.get(
+                "/admin/myfileadmin/", follow_redirects=True
+            ).data.decode("utf-8")
 
 
 class TestLocalFileAdmin(Base.FileAdminTests):

--- a/flask_admin/tests/fileadmin/test_fileadmin.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin.py
@@ -11,9 +11,6 @@ from flask_admin.contrib import fileadmin
 from flask_admin.contrib.fileadmin import FileAdmin
 from flask_admin.contrib.fileadmin.azure import AzureFileAdmin
 from flask_admin.contrib.fileadmin.s3 import S3FileAdmin
-
-from flask_admin import Admin
-from flask_admin.contrib import fileadmin
 from flask_admin.form import SecureForm
 from flask_admin.theme import Bootstrap4Theme
 
@@ -242,7 +239,7 @@ class Base:
             data = rv.data.decode("utf-8")
             assert "fa_modal_window" not in data
 
-        def get_csrf_token(self, data):
+        def get_csrf_token(self, data: str) -> str:
             data = data.split('name="csrf_token" type="hidden" value="')[1]
             token = data.split('"')[0]
             return token
@@ -257,7 +254,7 @@ class Base:
                 "/admin/fileadmin/mkdir",
             ],
         )
-        def test_csrf_token(self, app, admin, page):
+        def test_csrf_token(self, app: Flask, admin: Admin, page: str) -> None:
             # Cross-Site-Request-Forgery (CSRF) Protection
             app.config["WTF_CSRF_ENABLED"] = True
 
@@ -281,11 +278,11 @@ class Base:
             assert 'name="csrf_token"' in data
             assert len(self.get_csrf_token(data)) == 56
 
-        def test_csrf_submit(self, app, admin, request):
+        def test_csrf_submit(self, app: Flask, admin: Admin, request: t.Any) -> None:
             # Cross-Site-Request-Forgery (CSRF) Protection
             app.config["WTF_CSRF_ENABLED"] = True
 
-            def finalizer():
+            def finalizer() -> None:
                 try:
                     os.remove(op.join(self._test_files_root, "d1/dum.txt"))
                     os.remove(op.join(self._test_files_root, "dummy_renamed.txt"))
@@ -301,7 +298,7 @@ class Base:
             class SecureFileAdmin(fileadmin_class):  # type: ignore[valid-type, misc]
                 form_base_class = SecureForm
 
-                def is_accessible(self):
+                def is_accessible(self) -> bool:
                     return True
 
             fileadmin_kwargs["endpoint"] = "myfileadmin"

--- a/flask_admin/tests/fileadmin/test_fileadmin_azure.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin_azure.py
@@ -27,11 +27,16 @@ class TestAzureFileAdmin(Base.FileAdminTests):
             azure_connection_string
         )
         self._client.create_container(self._container_name)
-        file_name = "dummy.txt"
-        file_path = os.path.join(self._test_files_root, file_name)
-        blob_client = self._client.get_blob_client(self._container_name, file_name)
-        with open(file_path, "rb") as file:
-            blob_client.upload_blob(file)
+        for file_name in [["dummy.txt"], ["d1", "dum.txt"]]:
+            file_path = os.path.join(self._test_files_root, *file_name)
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, "w") as f:
+                f.write("")
+
+            blob_path = "/".join(file_name)
+            blob_client = self._client.get_blob_client(self._container_name, blob_path)
+            with open(file_path, "rb") as file:
+                blob_client.upload_blob(file)
 
         yield
 

--- a/flask_admin/tests/fileadmin/test_fileadmin_s3.py
+++ b/flask_admin/tests/fileadmin/test_fileadmin_s3.py
@@ -21,6 +21,7 @@ def mock_s3_client() -> t.Generator[t.Any, None, None]:
         client = boto3.client("s3")
         client.create_bucket(Bucket=_bucket_name)
         client.upload_fileobj(BytesIO(b""), _bucket_name, "dummy.txt")
+        client.upload_fileobj(BytesIO(b""), _bucket_name, "d1/dum.txt")
         yield client
 
 


### PR DESCRIPTION
CSRF token is not generated in the `file/list.html` page for both file and directory delete `<form>`. This PR uses `csrf_token()` to generate the token and put them in a hidden field to be submitted within the delete action.

**Why this PR:** it supports CSRF in `file/list.html` if the user useed `flask_wtf.csrf.CSRFProtect`

**Test:** This PR adds many test cases that covers all pages of FileAdmin() including list, rename, upload, ...etc. also there are some tests that include the csrf_token in the post request and assert the response to be 200 not 400.  