### PR TITLE
fix: change condition for sqlalchemy-lite deprecated session check

### DIFF
--- a/flask_admin/contrib/sqla/_compat.py
+++ b/flask_admin/contrib/sqla/_compat.py
@@ -24,7 +24,7 @@ def _warn_session_deprecation(session, warn: bool = True):
     Raise error if session is from Flask-SQLAlchemy-Lite.
     """
     if not hasattr(session, "session"):
-        if T_SQLALCHEMY_LITE is not None and isinstance(session, T_SQLALCHEMY_LITE):
+        if T_SQLALCHEMY_LITE is not None and isinstance(session, T_SESSION):
             # see::
             # https://github.com/pallets-eco/flask-admin/issues/2585
             # https://github.com/pallets-eco/flask-admin/pull/2680

--- a/flask_admin/tests/conftest.py
+++ b/flask_admin/tests/conftest.py
@@ -163,7 +163,7 @@ def close_db(app: Flask, p: SQLAProvider):
 
 
 @pytest.fixture(params=sqla_db_exts)
-def sqla_db_ext(request, app):
+def sqla_db_ext_base(request, app):
     uri = "sqlite:///:memory:"
     configure_sqla(app, uri, request)
     p = request.param()
@@ -172,6 +172,16 @@ def sqla_db_ext(request, app):
     with app.app_context():
         yield p
         close_db(app, p)
+
+@pytest.fixture
+def sqla_db_ext(sqla_db_ext_base, session_or_db):
+    if (
+        sqla_db_ext_base.__class__.__name__ == "SQLALiteProvider"
+        and session_or_db == "session"
+    ):
+        pytest.skip("SQLALiteProvider does not support passing session")
+
+    return sqla_db_ext_base
 
 
 @pytest.fixture(

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -249,6 +249,23 @@ def fill_db(sqla_db_ext, Model1, Model2):
     )
     sqla_db_ext.db.session.commit()
 
+def test_sqlalchemy_lite_model_with_session_raise_error(
+    app, sqla_db_ext_base, admin, session_or_db
+):
+    Model1, Model2 = create_models(sqla_db_ext_base)
+
+    if sqla_db_ext_base.__class__.__name__ == "SQLALiteProvider" and session_or_db == "session":
+        with pytest.raises(
+            TypeError,
+            match="Passing a session object directly is not supported with Flask-SQLAlchemy-Lite",
+        ):
+            CustomModelView(Model1, sqla_db_ext_base.db.session)
+        return
+
+    # normal behavior for other combinations
+    param = sqla_db_ext_base.db.session if session_or_db == "session" else sqla_db_ext_base.db
+    view = CustomModelView(Model1, param)
+    admin.add_view(view)
 
 @pytest.mark.filterwarnings(
     "ignore:'iter_groups' is expected to return 4 items tuple since wtforms 3.1, this "


### PR DESCRIPTION
In https://github.com/pallets-eco/flask-admin/issues/2831 I have noticed that `def _warn_session_deprecation(session, warn: bool = True):` condition to check that you are passing sqlalchemy-lite db object instead of db.session actually does not work.

This small fix addresses the issue by modifying that condition. I have decided to be specific and check for T_SESSION.
Maybe codition can be switched to `if T_SQLALCHEMY_LITE is not None and not isinstance(session, T_SQLALCHEMY_LITE ):` which should be fine probably.


