### PR TITLE
fast test-in-docker

### DIFF
--- a/.devcontainer/tests/Dockerfile
+++ b/.devcontainer/tests/Dockerfile
@@ -1,7 +1,9 @@
-ARG IMAGE=bullseye
-FROM mcr.microsoft.com/devcontainers/${IMAGE}
+ARG IMAGE=python:3.10-slim
+FROM ${IMAGE}
 
 ENV UV_PROJECT_ENVIRONMENT=/venv
+ENV UV_PYTHON=python3.10
+ENV UV_CACHE_DIR=/root/.cache/uv
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends postgresql-client \
@@ -10,5 +12,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /workspace
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra all --no-install-project
+
 COPY . .
-RUN uv sync --extra all

--- a/.devcontainer/tests/docker-compose.yaml
+++ b/.devcontainer/tests/docker-compose.yaml
@@ -4,11 +4,11 @@ services:
       context: ../..
       dockerfile: .devcontainer/tests/Dockerfile
       args:
-        IMAGE: python:3.12
+        IMAGE: python:3.10-slim
 
     volumes:
       - ../..:/workspace
-      - /workspace/.venv
+      - uv-cache:/root/.cache/uv
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -44,3 +44,4 @@ services:
 volumes:
   postgres-data:
   azurite-data:
+  uv-cache:

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,11 @@
 .pytest_cache
 .vscode
 .idea
+
+.git
+__pycache__
+**/*.pyc
+**/*.pyo
+*.egg-info
+.coverage
+.venv

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,8 @@ doctest:
 
 .PHONY: test-in-docker
 test-in-docker:
-	docker compose -f .devcontainer/tests/docker-compose.yaml run --remove-orphans app uv run pytest
+	docker compose -f .devcontainer/tests/docker-compose.yaml build app
+	docker compose -f .devcontainer/tests/docker-compose.yaml run --remove-orphans app uv run --no-sync pytest
 
 .PHONY: tox-in-docker
 tox-in-docker:


### PR DESCRIPTION
fixes #2833.
~~replace `run --remove-orphans` with `up -d` to start the container detached, then `exec to run pytest` inside the already-running container.
This avoids the overhead of spinning up a fresh container each time you run tests and helps local development.
`make tox-in-docker` stays the same to ensure fresh environment.~~

https://github.com/pallets-eco/flask-admin/pull/2838#issuecomment-4363716311

Before:
1st Run: 213s (build) + 48s (test)
2nd Run: 60s + 48s (test)

Now:
1st Run: 17s + 53s (test)
2nd Run: 2s + 53s (test)

(degradation in test performance due to additional tests added after rebasing on top of master)
Performance improvement achieved by:

1. persisting the uv download cache between builds
2. using the smaller python:3.10-slim in place of mcr.microsoft.com/devcontainers/python:3.12 (~700MB+). Python 3.10 chosen to align with the test runner (min version supported)
3. separating the build (docker compose ... build app) from the run (uv run --no-sync pytest) adding --no-sync, so the container doesn't re-resolve dependencies at test time
