### PR TITLE
docs: add Docker requirement to testcontainers examples

### DIFF
--- a/examples/azure_blob_storage/README.md
+++ b/examples/azure_blob_storage/README.md
@@ -13,6 +13,8 @@ git clone https://github.com/pallets-eco/flask-admin.git
 cd flask-admin/examples/azure-blob-storage
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:

--- a/examples/geo_alchemy/README.md
+++ b/examples/geo_alchemy/README.md
@@ -17,6 +17,8 @@ Install PostgreSQL on your macOS:
 brew install postgresql
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:

--- a/examples/mongoengine/README.md
+++ b/examples/mongoengine/README.md
@@ -11,6 +11,8 @@ git clone https://github.com/pallets-eco/flask-admin.git
 cd flask-admin/examples/mongoengine
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 Run the example using `uv`, which will manage the environment and dependencies automatically:
 

--- a/examples/pymongo_simple/README.md
+++ b/examples/pymongo_simple/README.md
@@ -11,6 +11,8 @@ git clone https://github.com/pallets-eco/flask-admin.git
 cd flask-admin/examples/pymongo
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:

--- a/examples/rediscli/README.md
+++ b/examples/rediscli/README.md
@@ -9,6 +9,8 @@ git clone https://github.com/pallets-eco/flask-admin.git
 cd flask-admin/examples/rediscli
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -11,6 +11,8 @@ git clone https://github.com/pallets-eco/flask-admin.git
 cd flask-admin/examples/s3
 ```
 
+> This example uses [testcontainers](https://testcontainers.com/) to manage its service dependencies automatically. Make sure [Docker](https://docs.docker.com/get-docker/) is installed and running before starting the example.
+
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:


### PR DESCRIPTION
## Summary

- Added a note to all 6 example READMEs that use testcontainers, making the Docker prerequisite explicit
- Affected examples: `s3`, `rediscli`, `pymongo_simple`, `mongoengine`, `geo_alchemy`, `azure_blob_storage`

Fixes #2656

## Test plan

- [ ] Verify each updated README renders correctly on GitHub
- [ ] Confirm the Docker and testcontainers links resolve properly