### PR TITLE
fix(typing): enable disallow_incomplete_defs mypy flag

### DIFF
--- a/examples/auth_flask_login/main.py
+++ b/examples/auth_flask_login/main.py
@@ -96,7 +96,7 @@ class User(db.Model, flask_login.UserMixin):
         return self.username
 
     @staticmethod
-    def get(data, field) -> t.Optional["User"]:
+    def get(data: t.Any, field: str) -> t.Optional["User"]:
         return db.session.execute(
             db.select(User).where(getattr(User, field) == data)
         ).scalar()

--- a/examples/forms_files_images/main.py
+++ b/examples/forms_files_images/main.py
@@ -1,5 +1,6 @@
 import os
 import os.path as op
+import typing as t
 
 import jinja2.runtime
 from flask import Flask
@@ -145,7 +146,7 @@ class FileView(ModelView):
 
 class ImageView(ModelView):
     def _list_thumbnail(
-        view, context: jinja2.runtime.Context | None, model, name: str
+        view: t.Any, context: jinja2.runtime.Context | None, model: t.Any, name: str
     ) -> str | Markup:
         if not model.path:
             return ""

--- a/flask_admin/contrib/fileadmin/azure.py
+++ b/flask_admin/contrib/fileadmin/azure.py
@@ -50,7 +50,7 @@ class AzureStorage(BaseFileStorage):
         self,
         blob_service_client: BlobServiceClient,
         container_name: str,
-        on_windows=False,
+        on_windows: bool = False,
     ):
         """
         Constructor
@@ -301,7 +301,7 @@ class AzureFileAdmin(BaseFileAdmin):
         self,
         blob_service_client: BlobServiceClient,
         container_name: str,
-        on_windows: bool | None = False,
+        on_windows: bool = False,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> None:

--- a/flask_admin/contrib/geoa/fields.py
+++ b/flask_admin/contrib/geoa/fields.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import geoalchemy2
 from shapely.geometry import shape
 from sqlalchemy import func
@@ -12,15 +14,15 @@ from .widgets import LeafletWidget
 class GeoJSONField(JSONField):
     def __init__(
         self,
-        label=None,
-        validators=None,
-        geometry_type="GEOMETRY",
-        srid="-1",
+        label: str | None = None,
+        validators: list[t.Any] | None = None,
+        geometry_type: str = "GEOMETRY",
+        srid: int = -1,
         session: T_SESSION_OR_DB | None = None,
-        tile_layer_url=None,
-        tile_layer_attribution=None,
-        **kwargs,
-    ):
+        tile_layer_url: str | None = None,
+        tile_layer_attribution: str | None = None,
+        **kwargs: t.Any,
+    ) -> None:
         self.widget = LeafletWidget(
             tile_layer_url=tile_layer_url, tile_layer_attribution=tile_layer_attribution
         )

--- a/flask_admin/contrib/geoa/fields.py
+++ b/flask_admin/contrib/geoa/fields.py
@@ -6,6 +6,7 @@ from sqlalchemy import func
 
 from flask_admin.form import JSONField
 
+from ..._types import T_VALIDATOR
 from ..sqla._compat import _get_deprecated_session
 from ..sqla._types import T_SESSION_OR_DB
 from .widgets import LeafletWidget
@@ -15,7 +16,7 @@ class GeoJSONField(JSONField):
     def __init__(
         self,
         label: str | None = None,
-        validators: list[t.Any] | None = None,
+        validators: list[T_VALIDATOR] | None = None,
         geometry_type: str = "GEOMETRY",
         srid: int = -1,
         session: T_SESSION_OR_DB | None = None,

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.shape import to_shape
 from markupsafe import Markup
@@ -5,12 +7,14 @@ from sqlalchemy import func
 from wtforms.widgets import html_params
 
 from flask_admin._types import T_COLUMN_TYPE_FORMATTERS
-from flask_admin.contrib.geoa import ModelView
 from flask_admin.contrib.sqla._compat import _get_deprecated_session
 from flask_admin.contrib.sqla.typefmt import DEFAULT_FORMATTERS as BASE_FORMATTERS
 
+if TYPE_CHECKING:
+    from flask_admin.contrib.geoa import ModelView
 
-def geom_formatter(view: ModelView, value: WKBElement, name: str) -> str:
+
+def geom_formatter(view: "ModelView", value: WKBElement, name: str) -> str:
     kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -1,3 +1,5 @@
+import typing as t
+
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.shape import to_shape
 from markupsafe import Markup
@@ -8,7 +10,7 @@ from flask_admin.contrib.sqla._compat import _get_deprecated_session
 from flask_admin.contrib.sqla.typefmt import DEFAULT_FORMATTERS as BASE_FORMATTERS
 
 
-def geom_formatter(view, value, name) -> str:
+def geom_formatter(view: t.Any, value: WKBElement, name: str) -> str:
     kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -1,16 +1,16 @@
-import typing as t
-
 from geoalchemy2.elements import WKBElement
 from geoalchemy2.shape import to_shape
 from markupsafe import Markup
 from sqlalchemy import func
 from wtforms.widgets import html_params
 
+from flask_admin._types import T_COLUMN_TYPE_FORMATTERS
+from flask_admin.contrib.geoa import ModelView
 from flask_admin.contrib.sqla._compat import _get_deprecated_session
 from flask_admin.contrib.sqla.typefmt import DEFAULT_FORMATTERS as BASE_FORMATTERS
 
 
-def geom_formatter(view: t.Any, value: WKBElement, name: str) -> str:
+def geom_formatter(view: ModelView, value: WKBElement, name: str) -> str:
     kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",
@@ -36,5 +36,5 @@ def geom_formatter(view: t.Any, value: WKBElement, name: str) -> str:
     return Markup(f"<textarea {params}>{geojson}</textarea>")
 
 
-DEFAULT_FORMATTERS = BASE_FORMATTERS.copy()
-DEFAULT_FORMATTERS[WKBElement] = geom_formatter
+DEFAULT_FORMATTERS: T_COLUMN_TYPE_FORMATTERS = BASE_FORMATTERS.copy()
+DEFAULT_FORMATTERS[WKBElement] = geom_formatter  # type: ignore[assignment]

--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -15,7 +15,13 @@ class BaseMongoEngineFilter(filters.BaseFilter):
     Base MongoEngine filter.
     """
 
-    def __init__(self, column: str, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None) -> None:
+    def __init__(
+        self,
+        column: str,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+    ) -> None:
         """
         Constructor.
 

--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -2,6 +2,8 @@ from bson.errors import InvalidId
 from bson.objectid import ObjectId
 from mongoengine.queryset import Q
 
+from flask_admin._types import T_OPTIONS
+from flask_admin._types import T_WIDGET_TYPE
 from flask_admin.babel import lazy_gettext
 from flask_admin.model import filters
 
@@ -13,7 +15,7 @@ class BaseMongoEngineFilter(filters.BaseFilter):
     Base MongoEngine filter.
     """
 
-    def __init__(self, column: str, name, options=None, data_type=None):
+    def __init__(self, column: str, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None) -> None:
         """
         Constructor.
 

--- a/flask_admin/contrib/mongoengine/helpers.py
+++ b/flask_admin/contrib/mongoengine/helpers.py
@@ -26,7 +26,7 @@ def make_thumb_args(value):
         return make_gridfs_args(value)
 
 
-def format_error(error: ValidationError | wtfValidationError | str):
+def format_error(error: ValidationError | wtfValidationError | str) -> str:
     if isinstance(error, ValidationError):
         return as_unicode(error)
 

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -247,15 +247,15 @@ class ModelView(BaseModelView):
     def __init__(
         self,
         model: type[T_MONGO_ENGINE_DOCUMENT],
-        name=None,
-        category=None,
-        endpoint=None,
-        url=None,
-        static_folder=None,
-        menu_class_name=None,
-        menu_icon_type=None,
-        menu_icon_value=None,
-    ):
+        name: str | None = None,
+        category: str | None = None,
+        endpoint: str | None = None,
+        url: str | None = None,
+        static_folder: str | None = None,
+        menu_class_name: str | None = None,
+        menu_icon_type: str | None = None,
+        menu_icon_value: str | None = None,
+    ) -> None:
         """
         Constructor
 
@@ -440,7 +440,7 @@ class ModelView(BaseModelView):
 
         return flt
 
-    def is_valid_filter(self, filter: BaseMongoEngineFilter):  # type: ignore[override]
+    def is_valid_filter(self, filter: BaseMongoEngineFilter) -> bool:  # type: ignore[override]
         """
         Validate if the provided filter is a valid MongoEngine filter
 

--- a/flask_admin/contrib/pymongo/view.py
+++ b/flask_admin/contrib/pymongo/view.py
@@ -192,7 +192,7 @@ class ModelView(BaseModelView):
         """
         return model.get(name)
 
-    def _search(self, query, search_term: str):
+    def _search(self, query: dict[str, t.Any], search_term: str) -> dict[str, t.Any]:
         values = search_term.split(" ")
 
         queries: list[dict[str, t.Any]] = []
@@ -234,13 +234,13 @@ class ModelView(BaseModelView):
     def get_list(  # type: ignore[override]
         self,
         page: int | None,
-        sort_column,
+        sort_column: str | None,
         sort_desc: bool,
         search: str | None,
         filters: t.Sequence[T_FILTER] | None,
-        execute=True,
+        execute: bool = True,
         page_size: int | None = None,
-    ):
+    ) -> tuple[int | None, t.Any]:
         """
         Get list of objects from MongoEngine
 

--- a/flask_admin/contrib/sqla/_compat.py
+++ b/flask_admin/contrib/sqla/_compat.py
@@ -20,7 +20,7 @@ def _warn_session_deprecation(
 ) -> T_SESSION_OR_DB: ...
 
 
-def _warn_session_deprecation(session, warn: bool = True):
+def _warn_session_deprecation(session: T_SESSION_OR_DB | None, warn: bool = True) -> T_SESSION_OR_DB | None:
     """
     Warn about deprecation of passing session objects directly.
     Raise error if session is from Flask-SQLAlchemy-Lite.

--- a/flask_admin/contrib/sqla/_compat.py
+++ b/flask_admin/contrib/sqla/_compat.py
@@ -20,7 +20,9 @@ def _warn_session_deprecation(
 ) -> T_SESSION_OR_DB: ...
 
 
-def _warn_session_deprecation(session: T_SESSION_OR_DB | None, warn: bool = True) -> T_SESSION_OR_DB | None:
+def _warn_session_deprecation(
+    session: T_SESSION_OR_DB | None, warn: bool = True
+) -> T_SESSION_OR_DB | None:
     """
     Warn about deprecation of passing session objects directly.
     Raise error if session is from Flask-SQLAlchemy-Lite.

--- a/flask_admin/tests/conftest.py
+++ b/flask_admin/tests/conftest.py
@@ -104,7 +104,7 @@ def admin(app, babel):
     yield admin
 
 
-def configure_sqla(app: Flask, uri: str, request):
+def configure_sqla(app: Flask, uri: str, request: pytest.FixtureRequest) -> None:
     """
     Sets common app config.
     Function calling must have @pytest.fixture(params=sqla_db_exts)
@@ -141,7 +141,7 @@ def session_or_db(request):
 
 def skip_or_return_session_or_db(
     extension: "SQLAProvider | SQLALiteProvider", string: t.Literal["session", "db"]
-):
+) -> t.Any:
     """
     Helper function to skip tests (when using SQLALiteProvider and deprecated session)
     or to return the appropriate parameter (extension.db.session or extension.db) for

--- a/flask_admin/tests/test_host_matching.py
+++ b/flask_admin/tests/test_host_matching.py
@@ -16,7 +16,9 @@ def app():
     yield app
 
 
-def init_admin(app: Flask, using_init_app: bool, admin_kwargs: dict[str, t.Any]) -> base.Admin:
+def init_admin(
+    app: Flask, using_init_app: bool, admin_kwargs: dict[str, t.Any]
+) -> base.Admin:
     if using_init_app:
         admin = base.Admin(**admin_kwargs)
         admin.init_app(app)

--- a/flask_admin/tests/test_host_matching.py
+++ b/flask_admin/tests/test_host_matching.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from flask import Flask
 from flask import url_for
@@ -14,7 +16,7 @@ def app():
     yield app
 
 
-def init_admin(app, using_init_app: bool, admin_kwargs):
+def init_admin(app: Flask, using_init_app: bool, admin_kwargs: dict[str, t.Any]) -> base.Admin:
     if using_init_app:
         admin = base.Admin(**admin_kwargs)
         admin.init_app(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ disallow_any_generics = true
 
 # These next few are various gradations of forcing use of type annotations
 disallow_untyped_calls = false
-disallow_incomplete_defs = false
+disallow_incomplete_defs = true
 disallow_untyped_defs = false
 
 # This one isn't too hard to get passing, but return on investment is lower


### PR DESCRIPTION
## Summary

- Add missing type annotations to all partially-typed functions flagged by mypy's `disallow_incomplete_defs`
- Enable `disallow_incomplete_defs = true` in `pyproject.toml`
- Fix `GeoJSONField.srid` default from `str` (`"-1"`) to `int` (`-1`) to match actual usage (compared against `int`, assigned to `int` field)
- Fix `AzureFileAdmin.on_windows` type from `bool | None` to `bool` to match `AzureStorage` constructor

Fixes #2440 (partial — checks off the `disallow_incomplete_defs` item)

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | `disallow_incomplete_defs = true` |
| `contrib/sqla/_compat.py` | Typed overload implementation params/return |
| `contrib/mongoengine/helpers.py` | Added `-> str` to `format_error` |
| `contrib/mongoengine/filters.py` | Typed `BaseMongoEngineFilter.__init__` params |
| `contrib/mongoengine/view.py` | Typed `ModelView.__init__` params, `is_valid_filter` return |
| `contrib/geoa/typefmt.py` | Typed `geom_formatter` params |
| `contrib/geoa/fields.py` | Typed `GeoJSONField.__init__` params, fixed `srid` type |
| `contrib/pymongo/view.py` | Typed `_search` and `get_list` params/return |
| `contrib/fileadmin/azure.py` | Fixed `on_windows` param type |
| `tests/test_host_matching.py` | Typed `init_admin` params/return |
| `tests/conftest.py` | Typed `configure_sqla` and `skip_or_return_session_or_db` |

## Test plan

- [x] `mypy` passes with `disallow_incomplete_defs = true` (only pre-existing `unused-ignore` error remains)
- [x] Existing test suite passes without regressions