### PR TITLE
Generate URL Filter-squashed

### DIFF
--- a/doc/adding_a_new_model_backend.rst
+++ b/doc/adding_a_new_model_backend.rst
@@ -208,10 +208,18 @@ Implementing filters
             def validate(self, value):
                 return True
 
-            # You can "clean" values before they will be
-            # passed to the your data access layer
+            # You can "clean" the value before it is passed to the data
+            # access layer. Usually it is used to parse string values into
+            # a valid clean data type. For example, you can convert string
+            # to integer, etc.
             def clean(self, value):
                 return value
+
+            # You can also convert value back to string representation
+            # for displaying in the URL.
+            def stringify(self, value):
+                return str(value)
+
 
 
 Feel free ask questions if you have problems adding a new model backend.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -8,6 +8,7 @@ API
    mod_theme
    mod_helpers
    mod_model
+   mod_model_filters
    mod_form
    mod_form_rules
    mod_form_fields

--- a/doc/api/mod_model_filters.rst
+++ b/doc/api/mod_model_filters.rst
@@ -1,0 +1,8 @@
+``flask_admin.model.filters``
+==============================
+
+.. automodule:: flask_admin.model.filters
+
+    .. autoclass:: BaseFilter
+        :members:
+        :exclude-members: get_url_argument

--- a/doc/api/mod_model_filters.rst
+++ b/doc/api/mod_model_filters.rst
@@ -5,4 +5,3 @@
 
     .. autoclass:: BaseFilter
         :members:
-        :exclude-members: get_url_argument

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -283,10 +283,28 @@ will be also presented in create/edit form field::
         'country': 'The country where the user lives'
     }
 
-To **make columns searchable**, or to use them for filtering, specify a list of column names::
+To **make columns searchable**, specify a list of column names::
 
     column_searchable_list = ['name', 'email']
+
+To **use columns for filtering**, specify a list of filterable objects, where it could
+be a string column's name, column, or :meth:`~flask_admin.model.filters.BaseFilter`::
+
     column_filters = ['country']
+    column_filters = [User.country]
+    column_filters = [FilterLike("email", "Email")]
+
+However, executing filters can be done on the server side, where it reads the filter values
+from the URL-request arguments. To make it work, you can specify a list of filterable objects
+with their corresponding filter values::
+
+    url = view.get_url(
+    search="foo",
+    filters=[
+        (FilterEqual(Account.email, "Email"), "jane@doe.com"),
+        (FilterGreaterThan(Account.age, "Age"), 30),
+      ]
+    )
 
 
 To make **columns sortable**, specify a list of column names like the example below. The

--- a/examples/bootstrap4/files/d1/dummy3.js
+++ b/examples/bootstrap4/files/d1/dummy3.js
@@ -1,0 +1,1 @@
+console.log('Hello from dummy3.js');

--- a/examples/bootstrap4/files/d1/dummy3.js
+++ b/examples/bootstrap4/files/d1/dummy3.js
@@ -1,1 +1,0 @@
-console.log('Hello from dummy3.js');

--- a/examples/pymongo_simple/main.py
+++ b/examples/pymongo_simple/main.py
@@ -112,6 +112,51 @@ if __name__ == "__main__":
         conn: MongoClient[Any] = MongoClient(mongo.get_connection_url())
         db = conn.test
 
+        # Insert 5 users
+        users = [
+            {"name": "Alice", "email": "alice@example.com", "password": "pass123"},
+            {"name": "Bob", "email": "bob@example.com", "password": "pass456"},
+            {"name": "Charlie", "email": "charlie@example.com", "password": "pass789"},
+            {"name": "Diana", "email": "diana@example.com", "password": "pass321"},
+            {"name": "Eve", "email": "eve@example.com", "password": "pass654"},
+        ]
+        user_ids = db.user.insert_many(users).inserted_ids
+
+        # Insert some tweets
+        tweets = [
+            {
+                "name": "tweet1",
+                "user_id": user_ids[0],
+                "text": "Hello World!",
+                "testie": True,
+            },
+            {
+                "name": "tweet2",
+                "user_id": user_ids[1],
+                "text": "Flask is awesome",
+                "testie": False,
+            },
+            {
+                "name": "tweet3",
+                "user_id": user_ids[0],
+                "text": "Learning MongoDB",
+                "testie": True,
+            },
+            {
+                "name": "tweet4",
+                "user_id": user_ids[2],
+                "text": "Python rocks!",
+                "testie": False,
+            },
+            {
+                "name": "tweet5",
+                "user_id": user_ids[3],
+                "text": "Admin interface demo",
+                "testie": True,
+            },
+        ]
+        db.tweet.insert_many(tweets)
+
         admin.add_view(UserView(db.user, "User"))
         admin.add_view(TweetView(db.tweet, "Tweets"))
 

--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -100,7 +100,7 @@ class FilterSmaller(BaseMongoEngineFilter):
         return lazy_gettext("smaller than")
 
 
-class FilterEmpty(BaseMongoEngineFilter, filters.BaseBooleanFilter):
+class FilterEmpty(BaseMongoEngineFilter, filters.BaseEmptyFilter):
     def apply(self, query: QuerySet, value: t.Any) -> QuerySet:
         if value == "1":
             flt = {str(self.column): None}

--- a/flask_admin/contrib/mongoengine/filters.py
+++ b/flask_admin/contrib/mongoengine/filters.py
@@ -38,7 +38,7 @@ class BaseMongoEngineFilter(filters.BaseFilter):
         :param data_type:
             Client data type
         """
-        super().__init__(name, options, data_type)
+        super().__init__(name, options, data_type, column=column)
 
         self.column = column
 
@@ -131,6 +131,9 @@ class FilterInList(BaseMongoEngineFilter):
 
     def operation(self) -> T_TRANSLATABLE:
         return lazy_gettext("in list")
+
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
 
 
 class FilterNotInList(FilterInList):

--- a/flask_admin/contrib/peewee/filters.py
+++ b/flask_admin/contrib/peewee/filters.py
@@ -33,9 +33,9 @@ class BasePeeweeFilter(filters.BaseFilter):
         :param data_type:
             Client data type
         """
-        super().__init__(name, options, data_type)
+        super().__init__(name, options, data_type, column=column)
 
-        self.column = column
+        self.column: t.Any = column
 
 
 # Common filters
@@ -89,7 +89,7 @@ class FilterSmaller(BasePeeweeFilter):
         return lazy_gettext("smaller than")
 
 
-class FilterEmpty(BasePeeweeFilter, filters.BaseBooleanFilter):
+class FilterEmpty(BasePeeweeFilter, filters.BaseEmptyFilter):
     def apply(self, query: t.Any, value: t.Any) -> t.Any:
         if value == "1":
             return query.filter(self.column >> None)
@@ -118,6 +118,9 @@ class FilterInList(BasePeeweeFilter):
 
     def operation(self) -> T_TRANSLATABLE:
         return lazy_gettext("in list")
+
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
 
 
 class FilterNotInList(FilterInList):

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -492,7 +492,7 @@ class ModelView(BaseModelView):
             for flt, _flt_name, value in filters:  # type: ignore[union-attr]
                 f = self._filters[flt]
 
-                query = self._handle_join(query, f.column, joins)  # type: ignore[attr-defined]
+                query = self._handle_join(query, f.column, joins)
                 query = f.apply(query, f.clean(value))
 
         # Get count

--- a/flask_admin/contrib/pymongo/filters.py
+++ b/flask_admin/contrib/pymongo/filters.py
@@ -34,7 +34,7 @@ class BasePyMongoFilter(filters.BaseFilter):
         :param data_type:
             Client data type
         """
-        super().__init__(name, options, data_type)
+        super().__init__(name, options, data_type, column=column)
 
         self.column = column
 

--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -68,9 +68,14 @@ class BaseSQLAFilter(filters.BaseFilter):
         :param data_type:
             Client data type
         """
-        super().__init__(name, options, data_type)
+        super().__init__(
+            name,
+            options,
+            data_type,
+            column=column,
+        )
 
-        self.column = column
+        self.column: T_COLUMN = column
         self._joins: list[t.Any] | None = None
         self._bound = False
         self._bound_model: type | None = None
@@ -218,7 +223,7 @@ class FilterSmaller(BaseSQLAFilter):
         return lazy_gettext("smaller than")
 
 
-class FilterEmpty(BaseSQLAFilter, filters.BaseBooleanFilter):
+class FilterEmpty(BaseSQLAFilter, filters.BaseEmptyFilter):
     def apply(
         self, query: T_SQLALCHEMY_QUERY, value: t.Any, alias: t.Any = None
     ) -> t.Any:
@@ -251,6 +256,9 @@ class FilterInList(BaseSQLAFilter):
 
     def operation(self) -> T_TRANSLATABLE:
         return lazy_gettext("in list")
+
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
 
 
 class FilterNotInList(FilterInList):
@@ -725,6 +733,17 @@ class ChoiceTypeNotLikeFilter(FilterNotLike):
             return query
 
 
+class ChoiceTypeEmptyFilter(FilterEmpty):
+    def __init__(
+        self,
+        column: T_COLUMN,
+        name: str,
+        options: T_OPTIONS = None,
+        **kwargs: t.Any,
+    ) -> None:
+        super().__init__(column, name, options, **kwargs)
+
+
 class UuidFilterEqual(FilterEqual, filters.BaseUuidFilter):
     pass
 
@@ -817,7 +836,7 @@ class FilterConverter(filters.BaseFilterConverter):
         ChoiceTypeNotEqualFilter,
         ChoiceTypeLikeFilter,
         ChoiceTypeNotLikeFilter,
-        FilterEmpty,
+        ChoiceTypeEmptyFilter,
     )
     uuid_filters = (
         UuidFilterEqual,
@@ -938,7 +957,7 @@ class FilterConverter(filters.BaseFilterConverter):
 
         return [f(column, name, options, **kwargs) for f in self.enum]
 
-    @filters.convert("uuid")
+    @filters.convert("uuid", "UUIDType")
     def conv_uuid(
         self, column: T_SQLALCHEMY_COLUMN, name: str, **kwargs: t.Any
     ) -> list[BaseSQLAFilter]:

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -387,7 +387,7 @@ class ModelView(BaseModelView):
         self._search_fields: list[tuple[T_SQLALCHEMY_COLUMN, t.Any]] | None = None
 
         self._filter_joins: dict[
-            tuple[bool, t.Any] | T_INSTRUMENTED_ATTRIBUTE | str, t.Any
+            T_COLUMN | tuple[bool, t.Any] | T_INSTRUMENTED_ATTRIBUTE | str, t.Any
         ] = dict()
 
         self._sortable_joins: dict[T_COLUMN, list[T_INSTRUMENTED_ATTRIBUTE]] = dict()
@@ -1186,8 +1186,8 @@ class ModelView(BaseModelView):
             # Figure out joins
             if isinstance(flt, sqla_filters.BaseSQLAFilter):
                 # If no key_name is specified, use filter column as filter key
-                filter_key = flt.key_name or flt.column
-                path = self._filter_joins.get(filter_key, [])  # type: ignore[arg-type]
+                filter_key = flt.key_name if flt.key_name is not None else flt.column
+                path = self._filter_joins.get(filter_key, [])
 
                 query, joins, alias = self._apply_path_joins(
                     query, joins, path, inner_join=False

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1408,7 +1408,8 @@ class BaseModelView(BaseView, ActionsMixin):
             c1 = flt.column_name().lower()
             c2 = filter_arg.column_name().lower()
 
-            if c2 == c1 and type(flt) == type(filter_arg):
+            c2_is_a_c1 = issubclass(type(filter_arg), type(flt))
+            if c2 == c1 and c2_is_a_c1:
                 filter_arg_key = k
                 break
 
@@ -1419,6 +1420,28 @@ class BaseModelView(BaseView, ActionsMixin):
         search: str | None = None,
         filters: list[tuple[BaseFilter, t.Any]] | None = None,
     ) -> str:
+        """Return URL for the view with applied filters and search query.
+
+        :param search:
+            Optional search query string.
+        :param filters:
+            List of tuples containing (BaseFilter instance, filter value).
+            If duplicate filters are provided (filter type/same column), they
+            both will be included in the URL with different parameter names.
+            Both filters will be applied with an AND condition. Note that
+            the order of filters in the list does not matter.
+            Example::
+
+                filters = [
+                    (FilterLike(column='first_name'), 'John'),
+                    (FilterLike(column='first_name'), 'Jane')
+                ]
+                myview.url_for(filters=filters)
+                # Output: /admin/myview?flt0_0=John&flt1_0=Jane
+
+        :return:
+            URL string with filter and search parameters applied.
+        """
         url_args = {}
         if search:
             url_args["search"] = search
@@ -1432,7 +1455,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 warnings.warn(
                     f"The filter {flt.__class__.__name__}('{flt.name}') is not found "
                     "in filter arguments, did you forget to add it in column_filters?",
-                    stacklevel=1,
+                    stacklevel=2,
                 )
                 continue
             else:
@@ -2027,7 +2050,6 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return None
 
-    # FIXME: rename to get_view_args()
     def _get_list_extra_args(self) -> ViewArgs:
         """
         Return arguments from query string.

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1392,6 +1392,64 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return None
 
+    def _find_filter_arg(self, flt: BaseFilter) -> tuple[int, BaseFilter] | None:
+        """
+        Given a filter `flt`, return the unique name for that filter in
+        this view.
+
+        :param flt:
+            Filter instance
+        """
+        if not self._filter_args:
+            return None
+
+        filter_arg_key = None
+        for k, (_index, filter_arg) in self._filter_args.items():
+            c1 = flt.column_name().lower()
+            c2 = filter_arg.column_name().lower()
+
+            if c2 == c1 and type(flt) == type(filter_arg):
+                filter_arg_key = k
+                break
+
+        return self._filter_args[filter_arg_key] if filter_arg_key else None
+
+    def url_for(
+        self,
+        search: str | None = None,
+        filters: list[tuple[BaseFilter, t.Any]] | None = None,
+    ) -> str:
+        url_args = {}
+        if search:
+            url_args["search"] = search
+
+        if filters is None:
+            filters = []
+
+        for i, (flt, value) in enumerate(filters):
+            found_arg = self._find_filter_arg(flt)
+            if not found_arg:
+                warnings.warn(
+                    f"The filter {flt.__class__.__name__}('{flt.name}') is not found "
+                    "in filter arguments, did you forget to add it in column_filters?",
+                    stacklevel=1,
+                )
+                continue
+            else:
+                idx, filter_arg = found_arg
+
+                farg = self.get_filter_arg(
+                    idx,
+                    self._filters[idx],  # type: ignore[index]
+                )
+
+                k, v = flt.get_url_argument(i, farg, value)
+                url_args[k] = v
+
+        url = self.get_url(f"{self.endpoint}.index_view", _external=False, **url_args)
+
+        return url
+
     # Form helpers
     def scaffold_form(self) -> type[Form]:
         """
@@ -1969,6 +2027,7 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return None
 
+    # FIXME: rename to get_view_args()
     def _get_list_extra_args(self) -> ViewArgs:
         """
         Return arguments from query string.
@@ -2007,8 +2066,8 @@ class BaseModelView(BaseView, ActionsMixin):
         kwargs: dict[str, str] = {}
 
         if filters:
-            for i, pair in enumerate(filters):
-                idx, flt_name, value = pair
+            for i, flt in enumerate(filters):
+                idx, flt_name, value = flt
 
                 key = "flt%d_%s" % (
                     i,

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -22,6 +22,7 @@ class BaseFilter:
         options: T_OPTIONS = None,
         data_type: T_WIDGET_TYPE = None,
         key_name: str | None = None,
+        column: t.Any | None = None,
     ) -> None:
         """
         Constructor.
@@ -34,11 +35,14 @@ class BaseFilter:
             Client-side widget type to use.
         :param key_name:
             Optional name who represent this filter.
+        :param column:
+            Optional, field of Model/Document
         """
         self.name = name
         self.options = options
         self.data_type = data_type
         self.key_name = key_name
+        self.column = column
 
     def get_options(self, view: T_MODEL_VIEW) -> T_OPTION_LIST | None:
         """
@@ -104,6 +108,49 @@ class BaseFilter:
         """
         raise NotImplementedError()
 
+    def stringify(self, value: t.Any) -> str:
+        """
+        It is the opposite of `clean` method where it converts a Python object back
+        to a string.
+
+        Return string representation of value.
+
+        :param value:
+            Value
+        """
+        return str(value)
+
+    def get_url_argument(
+        self, flt_idx: int, flt_key: str, value: t.Any
+    ) -> tuple[str, str]:
+        """
+        Return URL argument for this filter. e.g. flt0_7=value
+
+        :param flt_idx:
+            Filter index
+        :param flt_key:
+            Filter key
+        """
+
+        stringified = self.stringify(value)
+        valid = self.validate(stringified)
+        if not valid:
+            raise ValueError(
+                f"Cannot generate URL argument for invalid filter value. "
+                f"Value: {value}"
+            )
+
+        return f"flt{flt_idx}_{flt_key}", f"{stringified}"
+
+    def column_name(self) -> str:
+        """
+        Return column name for this filter.
+        """
+        if hasattr(self.column, "name"):
+            return self.column.name  # type: ignore[union-attr]
+
+        return str(self.column)
+
     def __unicode__(self) -> str:
         return self.name
 
@@ -115,14 +162,32 @@ class BaseBooleanFilter(BaseFilter):
     """
 
     def __init__(
-        self, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None
+        self,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+        column: t.Any | None = None,
     ) -> None:
         super().__init__(
-            name, (("1", lazy_gettext("Yes")), ("0", lazy_gettext("No"))), data_type
+            name,
+            (("1", lazy_gettext("Yes")), ("0", lazy_gettext("No"))),
+            data_type,
+            column,
         )
 
     def validate(self, value: str) -> bool:
         return value in ("0", "1")
+
+    def stringify(self, value: t.Any) -> str:
+        return "1" if value else "0"
+
+
+class BaseEmptyFilter(BaseBooleanFilter):
+    """
+    Filter empty values, uses fixed list of options.
+    """
+
+    pass
 
 
 class BaseIntFilter(BaseFilter):
@@ -134,7 +199,7 @@ class BaseIntFilter(BaseFilter):
     """
 
     def clean(self, value: str) -> int:
-        return int(value)
+        return int(value) if value else 0
 
 
 class BaseFloatFilter(BaseFilter):
@@ -143,7 +208,7 @@ class BaseFloatFilter(BaseFilter):
     """
 
     def clean(self, value: str) -> float:
-        return float(value)
+        return float(value) if value else 0.0
 
 
 class BaseIntListFilter(BaseFilter):
@@ -157,6 +222,9 @@ class BaseIntListFilter(BaseFilter):
     def clean(self, value: str) -> list[int]:
         return [int(v.strip()) for v in value.split(",") if v.strip()]
 
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
+
 
 class BaseFloatListFilter(BaseFilter):
     """
@@ -165,6 +233,9 @@ class BaseFloatListFilter(BaseFilter):
 
     def clean(self, value: str) -> list[float]:
         return [float(v.strip()) for v in value.split(",") if v.strip()]
+
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
 
 
 class BaseDateFilter(BaseFilter):
@@ -179,6 +250,9 @@ class BaseDateFilter(BaseFilter):
 
     def clean(self, value: str) -> datetime.date:
         return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+
+    def stringify(self, value: t.Any) -> str:
+        return value.strftime("%Y-%m-%d")
 
 
 class BaseDateBetweenFilter(BaseFilter):
@@ -211,6 +285,9 @@ class BaseDateBetweenFilter(BaseFilter):
         except ValueError:
             return False
 
+    def stringify(self, value: t.Any) -> str:
+        return " to ".join(v.strftime("%Y-%m-%d") for v in value)
+
 
 class BaseDateTimeFilter(BaseFilter):
     """
@@ -218,14 +295,26 @@ class BaseDateTimeFilter(BaseFilter):
     """
 
     def __init__(
-        self, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None
+        self,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+        column: t.Any | None = None,
     ) -> None:
-        super().__init__(name, options, data_type="datetimepicker")
+        super().__init__(
+            name,
+            options,
+            data_type="datetimepicker",
+            column=column,
+        )
 
     def clean(self, value: str) -> datetime.datetime:
         # datetime filters will not work in SQLite + SQLAlchemy if value not converted
         # to datetime
         return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+
+    def stringify(self, value: t.Any) -> str:
+        return value.strftime("%Y-%m-%d %H:%M:%S")
 
 
 class BaseDateTimeBetweenFilter(BaseFilter):
@@ -256,6 +345,9 @@ class BaseDateTimeBetweenFilter(BaseFilter):
         except ValueError:
             return False
 
+    def stringify(self, value: t.Any) -> str:
+        return " to ".join(v.strftime("%Y-%m-%d %H:%M:%S") for v in value)
+
 
 class BaseTimeFilter(BaseFilter):
     """
@@ -263,15 +355,22 @@ class BaseTimeFilter(BaseFilter):
     """
 
     def __init__(
-        self, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None
+        self,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+        column: t.Any | None = None,
     ) -> None:
-        super().__init__(name, options, data_type="timepicker")
+        super().__init__(name, options, data_type="timepicker", column=column)
 
     def clean(self, value: str) -> datetime.time:
         # time filters will not work in SQLite + SQLAlchemy if value not converted
         # to time
         timetuple = time.strptime(value, "%H:%M:%S")
         return datetime.time(timetuple.tm_hour, timetuple.tm_min, timetuple.tm_sec)
+
+    def stringify(self, value: t.Any) -> str:
+        return value.strftime("%H:%M:%S")
 
 
 class BaseTimeBetweenFilter(BaseFilter):
@@ -303,6 +402,9 @@ class BaseTimeBetweenFilter(BaseFilter):
             raise
             return False
 
+    def stringify(self, value: t.Any) -> str:
+        return " to ".join(v.strftime("%H:%M:%S") for v in value)
+
 
 class BaseUuidFilter(BaseFilter):
     """
@@ -310,9 +412,13 @@ class BaseUuidFilter(BaseFilter):
     """
 
     def __init__(
-        self, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None
+        self,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+        column: t.Any | None = None,
     ) -> None:
-        super().__init__(name, options, data_type="uuid")
+        super().__init__(name, options, data_type="uuid", column=column)
 
     def clean(self, value: str) -> t.Any:
         value = uuid.UUID(value)  # type: ignore[assignment]
@@ -326,6 +432,9 @@ class BaseUuidListFilter(BaseFilter):
 
     def clean(self, value: str) -> list[str]:
         return [str(uuid.UUID(v.strip())) for v in value.split(",") if v.strip()]
+
+    def stringify(self, value: t.Any) -> str:
+        return ",".join(str(v) for v in value)
 
 
 def convert(*args: t.Any) -> t.Callable[..., t.Any]:

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -244,9 +244,13 @@ class BaseDateFilter(BaseFilter):
     """
 
     def __init__(
-        self, name: str, options: T_OPTIONS = None, data_type: T_WIDGET_TYPE = None
+        self,
+        name: str,
+        options: T_OPTIONS = None,
+        data_type: T_WIDGET_TYPE = None,
+        column: t.Any | None = None,
     ) -> None:
-        super().__init__(name, options, data_type="datepicker")
+        super().__init__(name, options, data_type="datepicker", column=column)
 
     def clean(self, value: str) -> datetime.date:
         return datetime.datetime.strptime(value, "%Y-%m-%d").date()

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -127,9 +127,20 @@ class BaseFilter:
         Return URL argument for this filter. e.g. flt0_7=value
 
         :param flt_idx:
-            Filter index
+            Filter index, used to distinguish multiple filters of the same type.
+            For example, if you have two filters, they will have flt_idx 0 and 1,
+            and the URL arguments will be flt0_7 and flt1_7
+            respectively.
         :param flt_key:
-            Filter key
+            Filter key, used to distinguish different filters.
+            For example, if you have two filters of the same type, one for "equals"
+            and one for "not equals", they will have flt_key 7 and 8 respectively,
+            and the URL arguments will be flt0_7 and flt1_8 respectively.
+        :param value:
+            Filter value to be converted to value of the returned URL argument.
+
+        :return:
+            Tuple of URL argument key and value. For example: ("flt0_7", "15")
         """
 
         stringified = self.stringify(value)

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -13,6 +13,7 @@ from flask_admin import Admin
 from flask_admin.contrib.mongoengine import filters
 from flask_admin.contrib.mongoengine import ModelView
 from flask_admin.contrib.mongoengine.ajax import QueryAjaxModelLoader
+from flask_admin.contrib.pymongo._types import T_PYMONGO_DB
 
 
 class Test(Document):  # type: ignore[misc]
@@ -153,7 +154,7 @@ def test_model(app: Flask, db: t.Any, admin: Admin) -> None:
     assert "test2" in data
 
 
-def create_filter_params():
+def create_filter_params() -> list[tuple[t.Any, ...]]:
     params = [
         (filters.FilterEqual, "test1", "x", "flt0_0", "flt0_test1_equals", "x"),
         (filters.FilterNotEqual, "test1", "x", "flt0_0", "flt0_test1_not_equal", "x"),
@@ -347,17 +348,16 @@ def create_filter_params():
     create_filter_params(),
 )
 def test_url_for(
-    app,
-    app_context,
-    db,
-    admin,
-    FilterClass,
-    col,
-    filter_value,
-    arg_key,
-    arg_named_key,
-    expected_value,
-):
+    app: Flask,
+    admin: Admin,
+    db: T_PYMONGO_DB,
+    FilterClass: type[filters.BaseMongoEngineFilter],
+    col: str,
+    filter_value: t.Any,
+    arg_key: str,
+    arg_named_key: str,
+    expected_value: str,
+) -> None:
     class MyView(ModelView):
         __test__ = False
 
@@ -368,8 +368,9 @@ def test_url_for(
         ]
         form = TestForm
 
-    view = MyView(Test, "Test", endpoint="user")
-    admin.add_view(view)
+    with app.app_context():
+        view = MyView(Test, "Test", endpoint="user")
+        admin.add_view(view)
 
     with app.test_request_context("http://localhost/admin/user/"):
         # Without named filters

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -1,5 +1,7 @@
 import typing as t
+from datetime import datetime
 
+import pytest
 from flask import Flask
 from mongoengine import Document
 from mongoengine import StringField
@@ -23,6 +25,11 @@ class TestForm(form.Form):
     __test__ = False
     test1 = fields.StringField("Test1")
     test2 = fields.StringField("Test2")
+
+    intfield = fields.IntegerField("intfield")
+    floatfield = fields.FloatField("floatfield")
+    boolfield = fields.BooleanField("boolfield")
+    datefield = fields.DateField("datefield")
 
 
 class TestView(ModelView):
@@ -144,6 +151,237 @@ def test_model(app: Flask, db: t.Any, admin: Admin) -> None:
     data = rv.data.decode("utf-8")
     assert "test2large" not in data
     assert "test2" in data
+
+
+def create_filter_params():
+    params = [
+        (filters.FilterEqual, "test1", "x", "flt0_0", "flt0_test1_equals", "x"),
+        (filters.FilterNotEqual, "test1", "x", "flt0_0", "flt0_test1_not_equal", "x"),
+        (filters.FilterLike, "test1", "x", "flt0_0", "flt0_test1_contains", "x"),
+        (filters.FilterNotLike, "test1", "x", "flt0_0", "flt0_test1_not_contains", "x"),
+        (filters.FilterGreater, "test1", "x", "flt0_0", "flt0_test1_greater_than", "x"),
+        (filters.FilterSmaller, "test1", "x", "flt0_0", "flt0_test1_smaller_than", "x"),
+        (filters.FilterEmpty, "test1", "1", "flt0_0", "flt0_test1_empty", "1"),
+        (
+            filters.FilterInList,
+            "test1",
+            ["x", "y"],
+            "flt0_0",
+            "flt0_test1_in_list",
+            "x,y",
+        ),
+        (
+            filters.FilterNotInList,
+            "test1",
+            ["x", "y"],
+            "flt0_0",
+            "flt0_test1_not_in_list",
+            "x,y",
+        ),
+        (
+            filters.BooleanEqualFilter,
+            "boolfield",
+            "1",
+            "flt0_0",
+            "flt0_boolfield_equals",
+            "1",
+        ),
+        (
+            filters.BooleanNotEqualFilter,
+            "boolfield",
+            "1",
+            "flt0_0",
+            "flt0_boolfield_not_equal",
+            "1",
+        ),
+        (
+            filters.IntEqualFilter,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_equals",
+            "10",
+        ),
+        (
+            filters.IntNotEqualFilter,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_not_equal",
+            "10",
+        ),
+        (
+            filters.IntGreaterFilter,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_greater_than",
+            "10",
+        ),
+        (
+            filters.IntSmallerFilter,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_smaller_than",
+            "10",
+        ),
+        (
+            filters.IntInListFilter,
+            "intfield",
+            [10, 20],
+            "flt0_0",
+            "flt0_intfield_in_list",
+            "10,20",
+        ),
+        (
+            filters.IntNotInListFilter,
+            "intfield",
+            [10, 20],
+            "flt0_0",
+            "flt0_intfield_not_in_list",
+            "10,20",
+        ),
+        (
+            filters.FloatEqualFilter,
+            "floatfield",
+            1.2,
+            "flt0_0",
+            "flt0_floatfield_equals",
+            "1.2",
+        ),
+        (
+            filters.FloatNotEqualFilter,
+            "floatfield",
+            1.2,
+            "flt0_0",
+            "flt0_floatfield_not_equal",
+            "1.2",
+        ),
+        (
+            filters.FloatGreaterFilter,
+            "floatfield",
+            1.2,
+            "flt0_0",
+            "flt0_floatfield_greater_than",
+            "1.2",
+        ),
+        (
+            filters.FloatSmallerFilter,
+            "floatfield",
+            1.2,
+            "flt0_0",
+            "flt0_floatfield_smaller_than",
+            "1.2",
+        ),
+        (
+            filters.FloatInListFilter,
+            "floatfield",
+            [1.2, 2.4],
+            "flt0_0",
+            "flt0_floatfield_in_list",
+            "1.2,2.4",
+        ),
+        (
+            filters.FloatNotInListFilter,
+            "floatfield",
+            [1.2, 2.4],
+            "flt0_0",
+            "flt0_floatfield_not_in_list",
+            "1.2,2.4",
+        ),
+        (
+            filters.DateTimeEqualFilter,
+            "datefield",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datefield_equals",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeNotEqualFilter,
+            "datefield",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datefield_not_equal",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeGreaterFilter,
+            "datefield",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datefield_greater_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeSmallerFilter,
+            "datefield",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datefield_smaller_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeBetweenFilter,
+            "datefield",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_0",
+            "flt0_datefield_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+        (
+            filters.DateTimeNotBetweenFilter,
+            "datefield",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_0",
+            "flt0_datefield_not_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+    ]
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, col, filter_value, arg_key, arg_named_key, expected_value",
+    create_filter_params(),
+)
+def test_url_for(
+    app,
+    app_context,
+    db,
+    admin,
+    FilterClass,
+    col,
+    filter_value,
+    arg_key,
+    arg_named_key,
+    expected_value,
+):
+    class MyView(ModelView):
+        __test__ = False
+
+        column_list = ("test1", "test2", "test3", "test4")
+        column_sortable_list = ("test1", "test2")
+        column_filters = [
+            FilterClass(col, col),
+        ]
+        form = TestForm
+
+    view = MyView(Test, "Test", endpoint="user")
+    admin.add_view(view)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        # Without named filters
+        view.named_filter_urls = False
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_key}={expected_value}"
+
+        view.named_filter_urls = True
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"
 
 
 def test_query_ajax_model_loader_initialization(db: t.Any) -> None:

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from datetime import time
 
 import peewee
+import pytest
 from flask import Flask
 from peewee import SqliteDatabase
 from wtforms import fields
@@ -14,6 +15,7 @@ from flask_admin import form
 from flask_admin._compat import as_unicode
 from flask_admin._compat import iteritems
 from flask_admin._types import T_PEEWEE_MODEL
+from flask_admin.contrib.peewee import filters
 from flask_admin.contrib.peewee import ModelView
 
 
@@ -50,6 +52,7 @@ def create_models(
             date_field: t.Any = None,
             timeonly_field: t.Any = None,
             datetime_field: t.Any = None,
+            bool_field: t.Any = None,
             **kwargs: t.Any,
         ) -> None:
             super().__init__(**kwargs)
@@ -61,6 +64,7 @@ def create_models(
             self.date_field = date_field
             self.timeonly_field = timeonly_field
             self.datetime_field = datetime_field
+            self.bool_field = bool_field
 
         test1 = peewee.CharField(max_length=20, null=True)
         test2 = peewee.CharField(max_length=20, null=True)
@@ -69,6 +73,9 @@ def create_models(
         date_field = peewee.DateField(null=True)
         timeonly_field = peewee.TimeField(null=True)
         datetime_field = peewee.DateTimeField(null=True)
+        bool_field = peewee.BooleanField(null=True)
+        int_field = peewee.IntegerField(null=True)
+        float_field = peewee.FloatField(null=True)
 
         def __str__(self) -> str:
             # "or ''" fixes error when loading choices for relation field:
@@ -1180,3 +1187,357 @@ def test_export_csv(app: Flask, db: peewee.SqliteDatabase, admin: Admin) -> None
     data = rv.data.decode("utf-8")
     assert rv.status_code == 200
     assert len(data.splitlines()) > 21
+
+
+def create_filter_params():
+    params = [
+        (filters.FilterLike, "test1", "x", "flt0_0", "flt0_test1_contains", "x"),
+        (filters.FilterNotLike, "test1", "x", "flt0_1", "flt0_test1_not_contains", "x"),
+        (filters.FilterEqual, "test1", "x", "flt0_2", "flt0_test1_equals", "x"),
+        (filters.FilterNotEqual, "test1", "x", "flt0_3", "flt0_test1_not_equal", "x"),
+        (filters.FilterEmpty, "test1", "1", "flt0_4", "flt0_test1_empty", "1"),
+        (
+            filters.FilterInList,
+            "test1",
+            ["x", "y"],
+            "flt0_5",
+            "flt0_test1_in_list",
+            "x,y",
+        ),
+        (
+            filters.FilterNotInList,
+            "test1",
+            ["x", "y"],
+            "flt0_6",
+            "flt0_test1_not_in_list",
+            "x,y",
+        ),
+        (
+            filters.BooleanEqualFilter,
+            "bool_field",
+            "1",
+            "flt0_0",
+            "flt0_bool_field_equals",
+            "1",
+        ),
+        (
+            filters.BooleanNotEqualFilter,
+            "bool_field",
+            "1",
+            "flt0_1",
+            "flt0_bool_field_not_equal",
+            "1",
+        ),
+        (
+            filters.IntEqualFilter,
+            "int_field",
+            10,
+            "flt0_0",
+            "flt0_int_field_equals",
+            "10",
+        ),
+        (
+            filters.IntNotEqualFilter,
+            "int_field",
+            10,
+            "flt0_1",
+            "flt0_int_field_not_equal",
+            "10",
+        ),
+        (
+            filters.IntGreaterFilter,
+            "int_field",
+            10,
+            "flt0_2",
+            "flt0_int_field_greater_than",
+            "10",
+        ),
+        (
+            filters.IntSmallerFilter,
+            "int_field",
+            10,
+            "flt0_3",
+            "flt0_int_field_smaller_than",
+            "10",
+        ),
+        (filters.FilterEmpty, "int_field", 10, "flt0_4", "flt0_int_field_empty", "1"),
+        (
+            filters.IntInListFilter,
+            "int_field",
+            [10, 20],
+            "flt0_5",
+            "flt0_int_field_in_list",
+            "10,20",
+        ),
+        (
+            filters.IntNotInListFilter,
+            "int_field",
+            [10, 20],
+            "flt0_6",
+            "flt0_int_field_not_in_list",
+            "10,20",
+        ),
+        (
+            filters.FloatEqualFilter,
+            "float_field",
+            1.2,
+            "flt0_0",
+            "flt0_float_field_equals",
+            "1.2",
+        ),
+        (
+            filters.FloatNotEqualFilter,
+            "float_field",
+            1.2,
+            "flt0_1",
+            "flt0_float_field_not_equal",
+            "1.2",
+        ),
+        (
+            filters.FloatGreaterFilter,
+            "float_field",
+            1.2,
+            "flt0_2",
+            "flt0_float_field_greater_than",
+            "1.2",
+        ),
+        (
+            filters.FloatSmallerFilter,
+            "float_field",
+            1.2,
+            "flt0_3",
+            "flt0_float_field_smaller_than",
+            "1.2",
+        ),
+        (
+            filters.FilterEmpty,
+            "float_field",
+            10,
+            "flt0_4",
+            "flt0_float_field_empty",
+            "1",
+        ),
+        (
+            filters.FloatInListFilter,
+            "float_field",
+            [1.2, 2.4],
+            "flt0_5",
+            "flt0_float_field_in_list",
+            "1.2,2.4",
+        ),
+        (
+            filters.FloatNotInListFilter,
+            "float_field",
+            [1.2, 2.4],
+            "flt0_6",
+            "flt0_float_field_not_in_list",
+            "1.2,2.4",
+        ),
+        (
+            filters.DateEqualFilter,
+            "date_field",
+            date(2025, 11, 1),
+            "flt0_0",
+            "flt0_date_field_equals",
+            "2025-11-01",
+        ),
+        (
+            filters.DateNotEqualFilter,
+            "date_field",
+            date(2025, 11, 1),
+            "flt0_1",
+            "flt0_date_field_not_equal",
+            "2025-11-01",
+        ),
+        (
+            filters.DateGreaterFilter,
+            "date_field",
+            date(2025, 11, 1),
+            "flt0_2",
+            "flt0_date_field_greater_than",
+            "2025-11-01",
+        ),
+        (
+            filters.DateSmallerFilter,
+            "date_field",
+            date(2025, 11, 1),
+            "flt0_3",
+            "flt0_date_field_smaller_than",
+            "2025-11-01",
+        ),
+        (
+            filters.DateBetweenFilter,
+            "date_field",
+            (date(2025, 11, 1), date(2025, 11, 15)),
+            "flt0_4",
+            "flt0_date_field_between",
+            "2025-11-01+to+2025-11-15",
+        ),
+        (
+            filters.DateNotBetweenFilter,
+            "date_field",
+            (date(2025, 11, 1), date(2025, 11, 15)),
+            "flt0_5",
+            "flt0_date_field_not_between",
+            "2025-11-01+to+2025-11-15",
+        ),
+        (
+            filters.FilterEmpty,
+            "date_field",
+            (date(2025, 11, 1), date(2025, 11, 15)),
+            "flt0_6",
+            "flt0_date_field_empty",
+            "1",
+        ),
+        (
+            filters.TimeEqualFilter,
+            "timeonly_field",
+            time(15, 30, 0),
+            "flt0_0",
+            "flt0_timeonly_field_equals",
+            "15:30:00",
+        ),
+        (
+            filters.TimeNotEqualFilter,
+            "timeonly_field",
+            time(15, 30, 0),
+            "flt0_1",
+            "flt0_timeonly_field_not_equal",
+            "15:30:00",
+        ),
+        (
+            filters.TimeGreaterFilter,
+            "timeonly_field",
+            time(15, 30, 0),
+            "flt0_2",
+            "flt0_timeonly_field_greater_than",
+            "15:30:00",
+        ),
+        (
+            filters.TimeSmallerFilter,
+            "timeonly_field",
+            time(15, 30, 0),
+            "flt0_3",
+            "flt0_timeonly_field_smaller_than",
+            "15:30:00",
+        ),
+        (
+            filters.TimeBetweenFilter,
+            "timeonly_field",
+            (time(15, 30, 0), time(15, 30, 0)),
+            "flt0_4",
+            "flt0_timeonly_field_between",
+            "15:30:00+to+15:30:00",
+        ),
+        (
+            filters.TimeNotBetweenFilter,
+            "timeonly_field",
+            (time(15, 30, 0), time(15, 30, 0)),
+            "flt0_5",
+            "flt0_timeonly_field_not_between",
+            "15:30:00+to+15:30:00",
+        ),
+        (
+            filters.FilterEmpty,
+            "timeonly_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_6",
+            "flt0_timeonly_field_empty",
+            "1",
+        ),
+        (
+            filters.DateTimeEqualFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datetime_field_equals",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeNotEqualFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_1",
+            "flt0_datetime_field_not_equal",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeGreaterFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_2",
+            "flt0_datetime_field_greater_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeSmallerFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_3",
+            "flt0_datetime_field_smaller_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeBetweenFilter,
+            "datetime_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_4",
+            "flt0_datetime_field_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+        (
+            filters.DateTimeNotBetweenFilter,
+            "datetime_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_5",
+            "flt0_datetime_field_not_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+        (
+            filters.FilterEmpty,
+            "datetime_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_6",
+            "flt0_datetime_field_empty",
+            "1",
+        ),
+    ]
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, col, filter_value, arg_key, arg_named_key, expected_value",
+    create_filter_params(),
+)
+def test_url_for(
+    app,
+    app_context,
+    db,
+    admin,
+    FilterClass,
+    col,
+    filter_value,
+    arg_key,
+    arg_named_key,
+    expected_value,
+):
+    Model1, Model2 = create_models(db)
+
+    class MyView(ModelView):
+        __test__ = False
+
+        # FilterClass(col, col),
+        column_filters = [col]
+
+    view = MyView(Model1, endpoint="user")
+    admin.add_view(view)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_key}={expected_value}"
+
+        view.named_filter_urls = True
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -1189,7 +1189,7 @@ def test_export_csv(app: Flask, db: peewee.SqliteDatabase, admin: Admin) -> None
     assert len(data.splitlines()) > 21
 
 
-def create_filter_params():
+def create_filter_params() -> list[tuple[t.Any, ...]]:
     params = [
         (filters.FilterLike, "test1", "x", "flt0_0", "flt0_test1_contains", "x"),
         (filters.FilterNotLike, "test1", "x", "flt0_1", "flt0_test1_not_contains", "x"),
@@ -1510,17 +1510,16 @@ def create_filter_params():
     create_filter_params(),
 )
 def test_url_for(
-    app,
-    app_context,
-    db,
-    admin,
-    FilterClass,
-    col,
-    filter_value,
-    arg_key,
-    arg_named_key,
-    expected_value,
-):
+    app: Flask,
+    db: peewee.SqliteDatabase,
+    admin: Admin,
+    FilterClass: type[filters.BasePeeweeFilter],
+    col: str,
+    filter_value: t.Any,
+    arg_key: str,
+    arg_named_key: str,
+    expected_value: str,
+) -> None:
     Model1, Model2 = create_models(db)
 
     class MyView(ModelView):
@@ -1529,8 +1528,9 @@ def test_url_for(
         # FilterClass(col, col),
         column_filters = [col]
 
-    view = MyView(Model1, endpoint="user")
-    admin.add_view(view)
+    with app.app_context():
+        view = MyView(Model1, endpoint="user")
+        admin.add_view(view)
 
     with app.test_request_context("http://localhost/admin/user/"):
         d1 = filter_value

--- a/flask_admin/tests/pymongo/test_basic.py
+++ b/flask_admin/tests/pymongo/test_basic.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from flask import Flask
 from wtforms import fields
@@ -86,7 +88,7 @@ def test_model(app: Flask, db: T_PYMONGO_DB, admin: Admin) -> None:
     assert db.test.estimated_document_count() == 0
 
 
-def create_filter_params():
+def create_filter_params() -> list[tuple[t.Any, ...]]:
     params = [
         (filters.FilterEqual, "test1", "x", "flt0_0", "flt0_test1_equals", "x"),
         (filters.FilterNotEqual, "test1", "x", "flt0_0", "flt0_test1_not_equal", "x"),
@@ -133,17 +135,16 @@ def create_filter_params():
     create_filter_params(),
 )
 def test_url_for(
-    app,
-    app_context,
-    db,
-    admin,
-    FilterClass,
-    col,
-    filter_value,
-    arg_key,
-    arg_named_key,
-    expected_value,
-):
+    app: Flask,
+    admin: Admin,
+    db: T_PYMONGO_DB,
+    FilterClass: type[filters.BasePyMongoFilter],
+    col: str,
+    filter_value: t.Any,
+    arg_key: str,
+    arg_named_key: str,
+    expected_value: t.Any,
+) -> None:
     class MyView(ModelView):
         __test__ = False
 
@@ -154,8 +155,9 @@ def test_url_for(
         ]
         form = TestForm
 
-    view = MyView(db.test, endpoint="user")
-    admin.add_view(view)
+    with app.app_context():
+        view = MyView(db.test, endpoint="user")
+        admin.add_view(view)
 
     # print(view.column_filters)
 

--- a/flask_admin/tests/pymongo/test_basic.py
+++ b/flask_admin/tests/pymongo/test_basic.py
@@ -1,8 +1,10 @@
+import pytest
 from flask import Flask
 from wtforms import fields
 from wtforms import form
 
 from flask_admin import Admin
+from flask_admin.contrib.pymongo import filters
 from flask_admin.contrib.pymongo import ModelView
 from flask_admin.contrib.pymongo._types import T_PYMONGO_DB
 
@@ -12,11 +14,14 @@ class TestForm(form.Form):
     test1 = fields.StringField("Test1")
     test2 = fields.StringField("Test2")
 
+    int_field = fields.IntegerField("int_field")
+    bool_field = fields.BooleanField("bool_field")
+
 
 class TestView(ModelView):
     __test__ = False
-    column_list = ("test1", "test2", "test3", "test4")
-    column_sortable_list = ("test1", "test2")
+    column_list = ("test1", "int_field", "bool_field", "test4")
+    column_sortable_list = ("test1", "test2", "int_field")
 
     form = TestForm
 
@@ -79,3 +84,87 @@ def test_model(app: Flask, db: T_PYMONGO_DB, admin: Admin) -> None:
     rv = client.post(url)
     assert rv.status_code == 302
     assert db.test.estimated_document_count() == 0
+
+
+def create_filter_params():
+    params = [
+        (filters.FilterEqual, "test1", "x", "flt0_0", "flt0_test1_equals", "x"),
+        (filters.FilterNotEqual, "test1", "x", "flt0_0", "flt0_test1_not_equal", "x"),
+        (filters.FilterLike, "test1", "x", "flt0_0", "flt0_test1_contains", "x"),
+        (filters.FilterNotLike, "test1", "x", "flt0_0", "flt0_test1_not_contains", "x"),
+        (
+            filters.FilterGreater,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_greater_than",
+            "10",
+        ),
+        (
+            filters.FilterSmaller,
+            "intfield",
+            10,
+            "flt0_0",
+            "flt0_intfield_smaller_than",
+            "10",
+        ),
+        (
+            filters.BooleanEqualFilter,
+            "boolfield",
+            True,
+            "flt0_0",
+            "flt0_boolfield_equals",
+            "1",
+        ),  # equals
+        (
+            filters.BooleanNotEqualFilter,
+            "boolfield",
+            True,
+            "flt0_0",
+            "flt0_boolfield_not_equal",
+            "1",
+        ),  # not equal
+    ]
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, col, filter_value, arg_key, arg_named_key, expected_value",
+    create_filter_params(),
+)
+def test_url_for(
+    app,
+    app_context,
+    db,
+    admin,
+    FilterClass,
+    col,
+    filter_value,
+    arg_key,
+    arg_named_key,
+    expected_value,
+):
+    class MyView(ModelView):
+        __test__ = False
+
+        column_list = ("test1", "test2", "test3", "test4")
+        column_sortable_list = ("test1", "test2")
+        column_filters = [
+            FilterClass(col, col),
+        ]
+        form = TestForm
+
+    view = MyView(db.test, endpoint="user")
+    admin.add_view(view)
+
+    # print(view.column_filters)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_key}={expected_value}"
+
+        view.named_filter_urls = True
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -90,7 +90,7 @@ class CustomModelView(ModelView):
     form_choices = {"choice_field": [("choice-1", "One"), ("choice-2", "Two")]}
 
 
-def create_models(sqla_db_ext: T_ANY_SQLA_PROVIDER) -> tuple[type, type]:
+def create_models(sqla_db_ext: T_ANY_SQLA_PROVIDER) -> tuple[t.Any, t.Any]:
     class Model1(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
         __tablename__ = "model1"
 
@@ -123,8 +123,8 @@ def create_models(sqla_db_ext: T_ANY_SQLA_PROVIDER) -> tuple[type, type]:
         sqla_utils_color = Column(ColorType)
         test5 = Column(Float(2))
 
-        def __unicode__(self):
-            return self.test1
+        def __unicode__(self) -> str:
+            return self.test1  # type: ignore[return-value]
 
         def __str__(self) -> str:
             return self.test1  # type: ignore[return-value]
@@ -436,7 +436,7 @@ def test_list_columns(
             Model1,
             param,
             endpoint="model1_2",
-            column_list=[Model1.test1, Model1.test3],  # type: ignore[attr-defined]
+            column_list=[Model1.test1, Model1.test3],
             column_labels=dict(test1="Column1"),
         )
         admin.add_view(view2)
@@ -660,7 +660,7 @@ def test_complex_searchable_list(
         view2 = CustomModelView(
             Model1,
             param,
-            column_searchable_list=[Model2.string_field],  # type: ignore[attr-defined]
+            column_searchable_list=[Model2.string_field],
         )
         admin.add_view(view2)
 
@@ -988,7 +988,7 @@ def test_column_filters(
         view13 = CustomModelView(
             Model2,
             param,
-            column_filters=[filters.FilterEqual(Model1.test1, "Test1")],  # type: ignore[attr-defined]
+            column_filters=[filters.FilterEqual(Model1.test1, "Test1")],
             endpoint="_relation_test",
         )
         admin.add_view(view13)
@@ -1877,7 +1877,7 @@ def test_column_filters_sqla_obj(
         Model1, Model2 = create_models(sqla_db_ext)
 
         param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
-        view = CustomModelView(Model1, param, column_filters=[Model1.test1])  # type: ignore[attr-defined]
+        view = CustomModelView(Model1, param, column_filters=[Model1.test1])
         admin.add_view(view)
         assert view._filters
         assert len(view._filters) == 7
@@ -1904,7 +1904,7 @@ def test_column_filters_dotted_path(
 
         # Binding resolves the string into the real attribute and records joins.
         assert flt._bound is True
-        assert flt.column is Model1.test1  # type: ignore[attr-defined]
+        assert flt.column is Model1.test1
         assert flt._joins  # at least one relationship to traverse
         assert flt.key_name == "model1.test1"
         assert "model1.test1" in view._filter_joins
@@ -2034,8 +2034,8 @@ def test_enum_filter_dotted_path(
 
         # Binding ran the hook, which populated enum_class from the resolved column.
         assert flt._bound is True
-        assert flt.enum_class is Model1.EnumChoices  # type: ignore[attr-defined]
-        assert flt.column is Model1.enum_type_field  # type: ignore[attr-defined]
+        assert flt.enum_class is Model1.EnumChoices
+        assert flt.column is Model1.enum_type_field
 
 
 def test_hybrid_property(
@@ -2707,7 +2707,7 @@ def test_complex_sort_exception(
             M2,
             param,
             endpoint="model2_3",
-            column_sortable_list=[M1.test1],  # type: ignore[attr-defined]
+            column_sortable_list=[M1.test1],
         )
         admin.add_view(view)
 
@@ -2755,7 +2755,7 @@ def test_default_complex_sort(
             M2,
             param,
             endpoint="model2_2",
-            column_default_sort=(M1.test1, False),  # type: ignore[attr-defined]
+            column_default_sort=(M1.test1, False),
         )
         admin.add_view(view2)
 

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -121,6 +121,10 @@ def create_models(sqla_db_ext: T_ANY_SQLA_PROVIDER) -> tuple[type, type]:
         sqla_utils_ip_address = Column(IPAddressType)
         sqla_utils_currency = Column(CurrencyType)
         sqla_utils_color = Column(ColorType)
+        test5 = Column(Float(2))
+
+        def __unicode__(self):
+            return self.test1
 
         def __str__(self) -> str:
             return self.test1  # type: ignore[return-value]
@@ -523,6 +527,7 @@ def test_exclude_columns(
             ("bool_field", "Bool Field"),
             ("email_field", "Email Field"),
             ("choice_field", "Choice Field"),
+            ("test5", "Test5"),
         ]
 
         client = app.test_client()

--- a/flask_admin/tests/sqla/test_filter.py
+++ b/flask_admin/tests/sqla/test_filter.py
@@ -1,16 +1,26 @@
+import typing as t
 from datetime import datetime
 from datetime import time
 
 import pytest
+from flask import Flask
 
+from flask_admin.base import Admin
 from flask_admin.contrib.sqla import filters
 from flask_admin.tests.conftest import skip_or_return_session_or_db
+from flask_admin.tests.conftest import T_ANY_SQLA_PROVIDER
+from flask_admin.tests.conftest import T_LITERAL_SESSION_OR_DB
 from flask_admin.tests.sqla.test_basic import create_models
 from flask_admin.tests.sqla.test_basic import CustomModelView
 from flask_admin.tests.sqla.test_basic import fill_db
 
 
-def test_column_filters(app, sqla_db_ext, admin, session_or_db):
+def test_column_filters(
+    app: Flask,
+    admin: Admin,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
     with app.app_context():
         Model1, Model2 = create_models(sqla_db_ext)
 
@@ -962,7 +972,12 @@ def test_column_filters(app, sqla_db_ext, admin, session_or_db):
         assert "test1_val_2" not in data
 
 
-def test_url_for_simple(app, sqla_db_ext, admin, session_or_db):
+def test_url_for_simple(
+    app: Flask,
+    admin: Admin,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
     # with app.app_context():
     Model1, Model2 = create_models(sqla_db_ext)
 
@@ -1020,7 +1035,7 @@ def test_url_for_simple(app, sqla_db_ext, admin, session_or_db):
         )
 
 
-def create_filter_params():
+def create_filter_params() -> list[tuple[t.Any, ...]]:
     uuid1 = "a81bc81b-dead-4e5d-abff-90865d1e13b1"
     uuid2 = "344a5ad9-6b2a-410c-aa06-401d1ae8ea39"
 
@@ -1362,17 +1377,17 @@ def create_filter_params():
     create_filter_params(),
 )
 def test_url_for(
-    app,
-    sqla_db_ext,
-    admin,
-    session_or_db,
-    FilterClass,
-    col,
-    filter_value,
-    arg_key,
-    arg_named_key,
-    expected_value,
-):
+    app: Flask,
+    admin: Admin,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+    FilterClass: type[filters.BaseSQLAFilter],
+    col: str,
+    filter_value: t.Any,
+    arg_key: str,
+    arg_named_key: str,
+    expected_value: t.Any,
+) -> None:
     # with app.app_context():
     Model1, Model2 = create_models(sqla_db_ext)
 
@@ -1394,7 +1409,7 @@ def test_url_for(
         assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"
 
 
-def create_filter_params_enums_and_choices():
+def create_filter_params_enums_and_choices() -> list[tuple[t.Any, ...]]:
     params = [
         (
             filters.EnumEqualFilter,
@@ -1485,17 +1500,17 @@ def create_filter_params_enums_and_choices():
     create_filter_params_enums_and_choices(),
 )
 def test_url_for_enums_and_choices(
-    app,
-    sqla_db_ext,
-    admin,
-    session_or_db,
-    FilterClass,
-    col,
-    filter_value,
-    arg_key,
-    arg_named_key,
-    expected_value,
-):
+    app: Flask,
+    admin: Admin,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+    FilterClass: type[filters.BaseSQLAFilter],
+    col: str,
+    filter_value: t.Any,
+    arg_key: str,
+    arg_named_key: str,
+    expected_value: t.Any,
+) -> None:
     Model1, Model2 = create_models(sqla_db_ext)
 
     col = getattr(Model1, col)
@@ -1515,12 +1530,17 @@ def test_url_for_enums_and_choices(
         assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"
 
 
-def test_column_filters_sqla_obj(app, sqla_db_ext, admin, session_or_db):
+def test_column_filters_sqla_obj(
+    app: Flask,
+    admin: Admin,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
     with app.app_context():
         Model1, Model2 = create_models(sqla_db_ext)
 
-        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
-        view = CustomModelView(Model1, param, column_filters=[Model1.test1])
+        session = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view = CustomModelView(Model1, session, column_filters=[Model1.test1])
         admin.add_view(view)
         assert view._filters
         assert len(view._filters) == 7

--- a/flask_admin/tests/sqla/test_filter.py
+++ b/flask_admin/tests/sqla/test_filter.py
@@ -1,0 +1,1526 @@
+from datetime import datetime
+from datetime import time
+
+import pytest
+
+from flask_admin.contrib.sqla import filters
+from flask_admin.tests.conftest import skip_or_return_session_or_db
+from flask_admin.tests.sqla.test_basic import create_models
+from flask_admin.tests.sqla.test_basic import CustomModelView
+from flask_admin.tests.sqla.test_basic import fill_db
+
+
+def test_column_filters(app, sqla_db_ext, admin, session_or_db):
+    with app.app_context():
+        Model1, Model2 = create_models(sqla_db_ext)
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view1 = CustomModelView(Model1, param, column_filters=["test1"])
+        admin.add_view(view1)
+
+        client = app.test_client()
+        assert view1._filters
+        assert len(view1._filters) == 7
+
+        # Generate views
+        view2 = CustomModelView(Model2, param, column_filters=["model1"])
+
+        view5 = CustomModelView(
+            Model1, param, column_filters=["test1"], endpoint="_strings"
+        )
+        admin.add_view(view5)
+
+        view6 = CustomModelView(Model2, param, column_filters=["int_field"])
+        admin.add_view(view6)
+
+        view7 = CustomModelView(
+            Model1, param, column_filters=["bool_field"], endpoint="_bools"
+        )
+        admin.add_view(view7)
+
+        view8 = CustomModelView(
+            Model2, param, column_filters=["float_field"], endpoint="_float"
+        )
+        admin.add_view(view8)
+
+        view9 = CustomModelView(
+            Model2,
+            param,
+            endpoint="_model2",
+            column_filters=["model1.bool_field"],
+            column_list=[
+                "string_field",
+                "model1.id",
+                "model1.bool_field",
+            ],
+        )
+        admin.add_view(view9)
+
+        view10 = CustomModelView(
+            Model1,
+            param,
+            column_filters=["test1"],
+            endpoint="_model3",
+            named_filter_urls=True,
+        )
+        admin.add_view(view10)
+
+        view11 = CustomModelView(
+            Model1,
+            param,
+            column_filters=["date_field", "datetime_field", "time_field"],
+            endpoint="_datetime",
+        )
+        admin.add_view(view11)
+
+        view12 = CustomModelView(
+            Model1, param, column_filters=["enum_field"], endpoint="_enumfield"
+        )
+        admin.add_view(view12)
+
+        view13 = CustomModelView(
+            Model2,
+            param,
+            column_filters=[filters.FilterEqual(Model1.test1, "Test1")],
+            endpoint="_relation_test",
+        )
+        admin.add_view(view13)
+
+        view14 = CustomModelView(
+            Model1,
+            param,
+            column_filters=["enum_type_field"],
+            endpoint="_enumtypefield",
+        )
+        admin.add_view(view14)
+        # Test views
+        assert view1._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view1._filter_groups["Test1"]
+        ] == [
+            (0, "contains"),
+            (1, "not contains"),
+            (2, "equals"),
+            (3, "not equal"),
+            (4, "empty"),
+            (5, "in list"),
+            (6, "not in list"),
+        ]
+        assert view2._filter_groups
+        # Test filter that references property0
+        assert [
+            (f["index"], f["operation"]) for f in view2._filter_groups["Model1 / Test1"]
+        ] == [
+            (0, "contains"),
+            (1, "not contains"),
+            (2, "equals"),
+            (3, "not equal"),
+            (4, "empty"),
+            (5, "in list"),
+            (6, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"]) for f in view2._filter_groups["Model1 / Test2"]
+        ] == [
+            (7, "contains"),
+            (8, "not contains"),
+            (9, "equals"),
+            (10, "not equal"),
+            (11, "empty"),
+            (12, "in list"),
+            (13, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"]) for f in view2._filter_groups["Model1 / Test3"]
+        ] == [
+            (14, "contains"),
+            (15, "not contains"),
+            (16, "equals"),
+            (17, "not equal"),
+            (18, "empty"),
+            (19, "in list"),
+            (20, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"]) for f in view2._filter_groups["Model1 / Test4"]
+        ] == [
+            (21, "contains"),
+            (22, "not contains"),
+            (23, "equals"),
+            (24, "not equal"),
+            (25, "empty"),
+            (26, "in list"),
+            (27, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Bool Field"]
+        ] == [
+            (28, "equals"),
+            (29, "not equal"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Date Field"]
+        ] == [
+            (30, "equals"),
+            (31, "not equal"),
+            (32, "greater than"),
+            (33, "smaller than"),
+            (34, "between"),
+            (35, "not between"),
+            (36, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Time Field"]
+        ] == [
+            (37, "equals"),
+            (38, "not equal"),
+            (39, "greater than"),
+            (40, "smaller than"),
+            (41, "between"),
+            (42, "not between"),
+            (43, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Datetime Field"]
+        ] == [
+            (44, "equals"),
+            (45, "not equal"),
+            (46, "greater than"),
+            (47, "smaller than"),
+            (48, "between"),
+            (49, "not between"),
+            (50, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Email Field"]
+        ] == [
+            (51, "contains"),
+            (52, "not contains"),
+            (53, "equals"),
+            (54, "not equal"),
+            (55, "empty"),
+            (56, "in list"),
+            (57, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Enum Field"]
+        ] == [
+            (58, "equals"),
+            (59, "not equal"),
+            (60, "empty"),
+            (61, "in list"),
+            (62, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Enum Type Field"]
+        ] == [
+            (63, "equals"),
+            (64, "not equal"),
+            (65, "empty"),
+            (66, "in list"),
+            (67, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Choice Field"]
+        ] == [
+            (68, "contains"),
+            (69, "not contains"),
+            (70, "equals"),
+            (71, "not equal"),
+            (72, "empty"),
+            (73, "in list"),
+            (74, "not in list"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Sqla Utils Choice"]
+        ] == [
+            (75, "equals"),
+            (76, "not equal"),
+            (77, "contains"),
+            (78, "not contains"),
+            (79, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view2._filter_groups["Model1 / Sqla Utils Enum"]
+        ] == [
+            (80, "equals"),
+            (81, "not equal"),
+            (82, "contains"),
+            (83, "not contains"),
+            (84, "empty"),
+        ]
+
+        # Test filter with a dot
+        view3 = CustomModelView(Model2, param, column_filters=["model1.bool_field"])
+        assert view3._filter_groups
+        assert [
+            (f["index"], f["operation"])
+            for f in view3._filter_groups["model1 / Model1 / Bool Field"]
+        ] == [
+            (0, "equals"),
+            (1, "not equal"),
+        ]
+
+        # Test column_labels on filters
+        view4 = CustomModelView(
+            Model2,
+            param,
+            column_filters=["model1.bool_field", "string_field"],
+            column_labels={
+                "model1.bool_field": "Test Filter #1",
+                "string_field": "Test Filter #2",
+            },
+        )
+        assert view4._filter_groups
+        assert list(view4._filter_groups.keys()) == ["Test Filter #1", "Test Filter #2"]
+
+        fill_db(sqla_db_ext, Model1, Model2)
+
+        # Test equals
+        rv = client.get("/admin/model1/?flt0_0=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        # the filter value is always in "data"
+        # need to check a different column than test1 for the expected row
+
+        assert "test2_val_1" in data
+        assert "test1_val_2" not in data
+
+        # Test NOT IN filter
+        rv = client.get("/admin/model1/?flt0_6=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+
+        assert "test1_val_2" in data
+        assert "test2_val_1" not in data
+
+        # Test string filter
+        assert view5._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view5._filter_groups["Test1"]
+        ] == [
+            (0, "contains"),
+            (1, "not contains"),
+            (2, "equals"),
+            (3, "not equal"),
+            (4, "empty"),
+            (5, "in list"),
+            (6, "not in list"),
+        ]
+
+        # string - equals
+        rv = client.get("/admin/_strings/?flt0_0=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test1_val_2" not in data
+
+        # string - not equal
+        rv = client.get("/admin/_strings/?flt0_1=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test1_val_2" in data
+
+        # string - contains
+        rv = client.get("/admin/_strings/?flt0_2=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test1_val_2" not in data
+
+        # string - not contains
+        rv = client.get("/admin/_strings/?flt0_3=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test1_val_2" in data
+
+        # string - empty
+        rv = client.get("/admin/_strings/?flt0_4=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "empty_obj" in data
+        assert "test1_val_1" not in data
+        assert "test1_val_2" not in data
+
+        # string - not empty
+        rv = client.get("/admin/_strings/?flt0_4=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "empty_obj" not in data
+        assert "test1_val_1" in data
+        assert "test1_val_2" in data
+
+        # string - in list
+        rv = client.get("/admin/_strings/?flt0_5=test1_val_1%2Ctest1_val_2")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" in data
+        assert "test1_val_3" not in data
+        assert "test1_val_4" not in data
+
+        # string - not in list
+        rv = client.get("/admin/_strings/?flt0_6=test1_val_1%2Ctest1_val_2")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" not in data
+        assert "test1_val_3" in data
+        assert "test1_val_4" in data
+
+        # Test integer filter
+        assert view6._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view6._filter_groups["Int Field"]
+        ] == [
+            (0, "equals"),
+            (1, "not equal"),
+            (2, "greater than"),
+            (3, "smaller than"),
+            (4, "empty"),
+            (5, "in list"),
+            (6, "not in list"),
+        ]
+
+        # integer - equals
+        rv = client.get("/admin/model2/?flt0_0=5000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" in data
+        assert "test2_val_4" not in data
+
+        # integer - equals (huge number)
+        rv = client.get("/admin/model2/?flt0_0=6169453081680413441")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_5" in data
+        assert "test2_val_4" not in data
+
+        # integer - equals - test validation
+        rv = client.get("/admin/model2/?flt0_0=badval")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "Invalid Filter Value" in data
+
+        # integer - not equal
+        rv = client.get("/admin/model2/?flt0_1=5000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" not in data
+        assert "test2_val_4" in data
+
+        # integer - greater
+        rv = client.get("/admin/model2/?flt0_2=6000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" not in data
+        assert "test2_val_4" in data
+
+        # integer - smaller
+        rv = client.get("/admin/model2/?flt0_3=6000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" in data
+        assert "test2_val_4" not in data
+
+        # integer - empty
+        rv = client.get("/admin/model2/?flt0_4=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" not in data
+        assert "test2_val_4" not in data
+
+        # integer - not empty
+        rv = client.get("/admin/model2/?flt0_4=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" in data
+        assert "test2_val_4" in data
+
+        # integer - in list
+        rv = client.get("/admin/model2/?flt0_5=5000%2C9000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" in data
+        assert "test2_val_4" in data
+
+        # integer - in list (huge number)
+        rv = client.get("/admin/model2/?flt0_5=6169453081680413441")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_5" in data
+
+        # integer - in list - test validation
+        rv = client.get("/admin/model2/?flt0_5=5000%2Cbadval")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "Invalid Filter Value" in data
+
+        # integer - not in list
+        rv = client.get("/admin/model2/?flt0_6=5000%2C9000")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" not in data
+        assert "test2_val_4" not in data
+        # Test boolean filter
+        assert view7._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view7._filter_groups["Bool Field"]
+        ] == [
+            (0, "equals"),
+            (1, "not equal"),
+        ]
+
+        # boolean - equals - Yes
+        rv = client.get("/admin/_bools/?flt0_0=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" not in data
+
+        # boolean - equals - No
+        rv = client.get("/admin/_bools/?flt0_0=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" in data
+
+        # boolean - not equals - Yes
+        rv = client.get("/admin/_bools/?flt0_1=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" in data
+
+        # boolean - not equals - No
+        rv = client.get("/admin/_bools/?flt0_1=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" not in data
+        # Test float filter
+        assert view8._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view8._filter_groups["Float Field"]
+        ] == [
+            (0, "equals"),
+            (1, "not equal"),
+            (2, "greater than"),
+            (3, "smaller than"),
+            (4, "empty"),
+            (5, "in list"),
+            (6, "not in list"),
+        ]
+
+        # float - equals
+        rv = client.get("/admin/_float/?flt0_0=25.9")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" in data
+        assert "test2_val_4" not in data
+
+        # float - equals - test validation
+        rv = client.get("/admin/_float/?flt0_0=badval")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "Invalid Filter Value" in data
+
+        # float - not equal
+        rv = client.get("/admin/_float/?flt0_1=25.9")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" not in data
+        assert "test2_val_4" in data
+
+        # float - greater
+        rv = client.get("/admin/_float/?flt0_2=60.5")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" not in data
+        assert "test2_val_4" in data
+
+        # float - smaller
+        rv = client.get("/admin/_float/?flt0_3=60.5")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_3" in data
+        assert "test2_val_4" not in data
+
+        # float - empty
+        rv = client.get("/admin/_float/?flt0_4=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" not in data
+        assert "test2_val_4" not in data
+
+        # float - not empty
+        rv = client.get("/admin/_float/?flt0_4=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" in data
+        assert "test2_val_4" in data
+
+        # float - in list
+        rv = client.get("/admin/_float/?flt0_5=25.9%2C75.5")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" not in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" in data
+        assert "test2_val_4" in data
+
+        # float - in list - test validation
+        rv = client.get("/admin/_float/?flt0_5=25.9%2Cbadval")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "Invalid Filter Value" in data
+
+        # float - not in list
+        rv = client.get("/admin/_float/?flt0_6=25.9%2C75.5")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" in data
+        assert "test2_val_3" not in data
+        assert "test2_val_4" not in data
+
+        # Test filters to joined table field
+        rv = client.get("/admin/_model2/?flt1_0=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test2_val_1" in data
+        assert "test2_val_2" not in data
+        assert "test2_val_3" not in data
+        assert "test2_val_4" not in data
+
+        # Test human readable URLs
+        rv = client.get("/admin/_model3/?flt1_test1_equals=test1_val_1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "test1_val_2" not in data
+        # Test date, time, and datetime filters
+        assert view11._filter_groups
+        assert [
+            (f["index"], f["operation"]) for f in view11._filter_groups["Date Field"]
+        ] == [
+            (0, "equals"),
+            (1, "not equal"),
+            (2, "greater than"),
+            (3, "smaller than"),
+            (4, "between"),
+            (5, "not between"),
+            (6, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"])
+            for f in view11._filter_groups["Datetime Field"]
+        ] == [
+            (7, "equals"),
+            (8, "not equal"),
+            (9, "greater than"),
+            (10, "smaller than"),
+            (11, "between"),
+            (12, "not between"),
+            (13, "empty"),
+        ]
+
+        assert [
+            (f["index"], f["operation"]) for f in view11._filter_groups["Time Field"]
+        ] == [
+            (14, "equals"),
+            (15, "not equal"),
+            (16, "greater than"),
+            (17, "smaller than"),
+            (18, "between"),
+            (19, "not between"),
+            (20, "empty"),
+        ]
+
+        # date - equals
+        rv = client.get("/admin/_datetime/?flt0_0=2014-11-17")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" in data
+        assert "date_obj2" not in data
+
+        # date - not equal
+        rv = client.get("/admin/_datetime/?flt0_1=2014-11-17")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" not in data
+        assert "date_obj2" in data
+
+        # date - greater
+        rv = client.get("/admin/_datetime/?flt0_2=2014-11-16")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" in data
+        assert "date_obj2" not in data
+
+        # date - smaller
+        rv = client.get("/admin/_datetime/?flt0_3=2014-11-16")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" not in data
+        assert "date_obj2" in data
+
+        # date - between
+        rv = client.get("/admin/_datetime/?flt0_4=2014-11-13+to+2014-11-20")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" in data
+        assert "date_obj2" not in data
+
+        # date - not between
+        rv = client.get("/admin/_datetime/?flt0_5=2014-11-13+to+2014-11-20")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "date_obj1" not in data
+        assert "date_obj2" in data
+
+        # date - empty
+        rv = client.get("/admin/_datetime/?flt0_6=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "date_obj1" not in data
+        assert "date_obj2" not in data
+
+        # date - empty
+        rv = client.get("/admin/_datetime/?flt0_6=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "date_obj1" in data
+        assert "date_obj2" in data
+
+        # datetime - equals
+        rv = client.get("/admin/_datetime/?flt0_7=2014-04-03+01%3A09%3A00")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" in data
+        assert "datetime_obj2" not in data
+
+        # datetime - not equal
+        rv = client.get("/admin/_datetime/?flt0_8=2014-04-03+01%3A09%3A00")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" not in data
+        assert "datetime_obj2" in data
+
+        # datetime - greater
+        rv = client.get("/admin/_datetime/?flt0_9=2014-04-03+01%3A08%3A00")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" in data
+        assert "datetime_obj2" not in data
+
+        # datetime - smaller
+        rv = client.get("/admin/_datetime/?flt0_10=2014-04-03+01%3A08%3A00")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" not in data
+        assert "datetime_obj2" in data
+
+        # datetime - between
+        rv = client.get(
+            "/admin/_datetime"
+            "/?flt0_11=2014-04-02+00%3A00%3A00+to+2014-11-20+23%3A59%3A59"
+        )
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" in data
+        assert "datetime_obj2" not in data
+
+        # datetime - not between
+        rv = client.get(
+            "/admin/_datetime"
+            "/?flt0_12=2014-04-02+00%3A00%3A00+to+2014-11-20+23%3A59%3A59"
+        )
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "datetime_obj1" not in data
+        assert "datetime_obj2" in data
+
+        # datetime - empty
+        rv = client.get("/admin/_datetime/?flt0_13=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "datetime_obj1" not in data
+        assert "datetime_obj2" not in data
+
+        # datetime - not empty
+        rv = client.get("/admin/_datetime/?flt0_13=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "datetime_obj1" in data
+        assert "datetime_obj2" in data
+
+        # time - equals
+        rv = client.get("/admin/_datetime/?flt0_14=11%3A10%3A09")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" in data
+        assert "timeonly_obj2" not in data
+
+        # time - not equal
+        rv = client.get("/admin/_datetime/?flt0_15=11%3A10%3A09")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" not in data
+        assert "timeonly_obj2" in data
+
+        # time - greater
+        rv = client.get("/admin/_datetime/?flt0_16=11%3A09%3A09")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" in data
+        assert "timeonly_obj2" not in data
+
+        # time - smaller
+        rv = client.get("/admin/_datetime/?flt0_17=11%3A09%3A09")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" not in data
+        assert "timeonly_obj2" in data
+
+        # time - between
+        rv = client.get("/admin/_datetime/?flt0_18=10%3A40%3A00+to+11%3A50%3A59")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" in data
+        assert "timeonly_obj2" not in data
+
+        # time - not between
+        rv = client.get("/admin/_datetime/?flt0_19=10%3A40%3A00+to+11%3A50%3A59")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "timeonly_obj1" not in data
+        assert "timeonly_obj2" in data
+
+        # time - empty
+        rv = client.get("/admin/_datetime/?flt0_20=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "timeonly_obj1" not in data
+        assert "timeonly_obj2" not in data
+
+        # time - not empty
+        rv = client.get("/admin/_datetime/?flt0_20=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "timeonly_obj1" in data
+        assert "timeonly_obj2" in data
+
+        # Test enum filter
+        # enum - equals
+        rv = client.get("/admin/_enumfield/?flt0_0=model1_v1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "enum_obj1" in data
+        assert "enum_obj2" not in data
+
+        # enum - not equal
+        rv = client.get("/admin/_enumfield/?flt0_1=model1_v1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "enum_obj1" not in data
+        assert "enum_obj2" in data
+
+        # enum - empty
+        rv = client.get("/admin/_enumfield/?flt0_2=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "enum_obj1" not in data
+        assert "enum_obj2" not in data
+
+        # enum - not empty
+        rv = client.get("/admin/_enumfield/?flt0_2=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "enum_obj1" in data
+        assert "enum_obj2" in data
+
+        # enum - in list
+        rv = client.get("/admin/_enumfield/?flt0_3=model1_v1%2Cmodel1_v2")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "enum_obj1" in data
+        assert "enum_obj2" in data
+
+        # enum - not in list
+        rv = client.get("/admin/_enumfield/?flt0_4=model1_v1%2Cmodel1_v2")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "enum_obj1" not in data
+        assert "enum_obj2" not in data
+
+        # Test enum type filter
+        # enum type - equals
+        rv = client.get("/admin/_enumtypefield/?flt0_0=first")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "enum_type_obj1" in data
+        assert "enum_type_obj2" not in data
+
+        # enum - not equal
+        rv = client.get("/admin/_enumtypefield/?flt0_1=first")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "enum_type_obj1" not in data
+        assert "enum_type_obj2" in data
+
+        # enum - empty
+        rv = client.get("/admin/_enumtypefield/?flt0_2=1")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "enum_type_obj1" not in data
+        assert "enum_type_obj2" not in data
+
+        # enum - not empty
+        rv = client.get("/admin/_enumtypefield/?flt0_2=0")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "enum_type_obj1" in data
+        assert "enum_type_obj2" in data
+
+        # enum - in list
+        rv = client.get("/admin/_enumtypefield/?flt0_3=first%2Csecond")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" not in data
+        assert "enum_type_obj1" in data
+        assert "enum_type_obj2" in data
+
+        # enum - not in list
+        rv = client.get("/admin/_enumtypefield/?flt0_4=first%2Csecond")
+        assert rv.status_code == 200
+        data = rv.data.decode("utf-8")
+        assert "test1_val_1" in data
+        assert "enum_type_obj1" not in data
+        assert "enum_type_obj2" not in data
+
+        # Test single custom filter on relation
+        rv = client.get("/admin/_relation_test/?flt1_0=test1_val_1")
+        data = rv.data.decode("utf-8")
+
+        assert "test1_val_1" in data
+        assert "test1_val_2" not in data
+
+
+def test_url_for_simple(app, sqla_db_ext, admin, session_or_db):
+    # with app.app_context():
+    Model1, Model2 = create_models(sqla_db_ext)
+
+    param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+    view = CustomModelView(
+        Model1,
+        param,
+        endpoint="user",
+        column_filters=["test1", "id", "test5", "bool_field"],
+    )
+    admin.add_view(view)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        filtered_url = view.url_for()
+        assert filtered_url == "/admin/user/"
+
+        filtered_url = view.url_for(search="exam", filters=[])
+        assert filtered_url == "/admin/user/?search=exam"
+
+        filtered_url = view.url_for(
+            search="exam",
+            filters=[
+                (filters.FilterLike(Model1.test1, "Email"), "test1"),
+                (filters.FilterLike(Model1.test1, "Email222"), "test1"),
+                (filters.BooleanEqualFilter(Model1.bool_field, "active"), False),
+                (filters.IntInListFilter(Model1.id, "ID"), [33, 30, 35]),
+                (filters.FloatGreaterFilter(Model1.test5, "Salary"), 50000.0),
+                (filters.FloatSmallerFilter(Model1.test5, "Salary"), 150000.0),
+            ],
+        )
+        assert (
+            filtered_url == "/admin/user/?search=exam&flt0_0=test1&flt1_0=test1&"
+            "flt2_21=0&flt3_12=33,30,35&flt4_16=50000.0&flt5_17=150000.0"
+        )
+
+        view.named_filter_urls = True
+
+        filtered_url = view.url_for(
+            search="exam",
+            filters=[
+                (filters.FilterLike(Model1.test1, "Email"), "test1"),
+                (filters.FilterLike(Model1.test1, "Email222"), "test1"),
+                (filters.BooleanEqualFilter(Model1.bool_field, "active"), False),
+                (filters.IntInListFilter(Model1.id, "ID"), [33, 30, 35]),
+                (filters.FloatGreaterFilter(Model1.test5, "Salary"), 50000.0),
+            ],
+        )
+        assert (
+            filtered_url == "/admin/user/?search=exam&"
+            "flt0_test1_contains=test1&"
+            "flt1_test1_contains=test1&"
+            "flt2_bool_field_equals=0&"
+            "flt3_id_in_list=33,30,35&"
+            "flt4_test5_greater_than=50000.0"
+        )
+
+
+def create_filter_params():
+    uuid1 = "a81bc81b-dead-4e5d-abff-90865d1e13b1"
+    uuid2 = "344a5ad9-6b2a-410c-aa06-401d1ae8ea39"
+
+    params = [
+        (filters.FilterLike, "test1", "x", "flt0_0", "flt0_test1_contains", "x"),
+        (filters.FilterNotLike, "test1", "x", "flt0_1", "flt0_test1_not_contains", "x"),
+        (filters.FilterEqual, "test1", "x", "flt0_2", "flt0_test1_equals", "x"),
+        (filters.FilterNotEqual, "test1", "x", "flt0_3", "flt0_test1_not_equal", "x"),
+        (filters.FilterEmpty, "test1", "1", "flt0_4", "flt0_test1_empty", "1"),
+        (
+            filters.FilterInList,
+            "test1",
+            ["x", "y"],
+            "flt0_5",
+            "flt0_test1_in_list",
+            "x,y",
+        ),
+        (
+            filters.FilterNotInList,
+            "test1",
+            ["x", "y"],
+            "flt0_6",
+            "flt0_test1_not_in_list",
+            "x,y",
+        ),
+        (filters.IntEqualFilter, "id", 30, "flt0_0", "flt0_id_equals", "30"),  # equals
+        (
+            filters.IntNotEqualFilter,
+            "id",
+            30,
+            "flt0_1",
+            "flt0_id_not_equal",
+            "30",
+        ),  # not equal
+        (
+            filters.IntGreaterFilter,
+            "id",
+            30,
+            "flt0_2",
+            "flt0_id_greater_than",
+            "30",
+        ),  # greater
+        (
+            filters.IntSmallerFilter,
+            "id",
+            30,
+            "flt0_3",
+            "flt0_id_smaller_than",
+            "30",
+        ),  # smaller
+        (filters.FilterEmpty, "id", 1, "flt0_4", "flt0_id_empty", "1"),  # empty
+        (
+            filters.IntInListFilter,
+            "id",
+            [30, 35],
+            "flt0_5",
+            "flt0_id_in_list",
+            "30,35",
+        ),  # in list
+        (
+            filters.IntNotInListFilter,
+            "id",
+            [30, 35],
+            "flt0_6",
+            "flt0_id_not_in_list",
+            "30,35",
+        ),  # not in list
+        (
+            filters.FloatEqualFilter,
+            "test5",
+            1.5,
+            "flt0_0",
+            "flt0_test5_equals",
+            "1.5",
+        ),  # equals
+        (
+            filters.FloatNotEqualFilter,
+            "test5",
+            1.5,
+            "flt0_1",
+            "flt0_test5_not_equal",
+            "1.5",
+        ),  # not equal
+        (
+            filters.FloatGreaterFilter,
+            "test5",
+            1.5,
+            "flt0_2",
+            "flt0_test5_greater_than",
+            "1.5",
+        ),  # greater
+        (
+            filters.FloatSmallerFilter,
+            "test5",
+            1.5,
+            "flt0_3",
+            "flt0_test5_smaller_than",
+            "1.5",
+        ),  # smaller
+        (filters.FilterEmpty, "test5", 1, "flt0_4", "flt0_test5_empty", "1"),  # empty
+        (
+            filters.FloatInListFilter,
+            "test5",
+            [1.5, 2.5],
+            "flt0_5",
+            "flt0_test5_in_list",
+            "1.5,2.5",
+        ),  # in list
+        (
+            filters.FloatNotInListFilter,
+            "test5",
+            [1.5, 2.5],
+            "flt0_6",
+            "flt0_test5_not_in_list",
+            "1.5,2.5",
+        ),  # not in list
+        (
+            filters.BooleanEqualFilter,
+            "bool_field",
+            True,
+            "flt0_0",
+            "flt0_bool_field_equals",
+            "1",
+        ),  # equals
+        (
+            filters.BooleanEqualFilter,
+            "bool_field",
+            False,
+            "flt0_0",
+            "flt0_bool_field_equals",
+            "0",
+        ),  # equals
+        (
+            filters.BooleanNotEqualFilter,
+            "bool_field",
+            True,
+            "flt0_1",
+            "flt0_bool_field_not_equal",
+            "1",
+        ),  # not equal
+        (
+            filters.BooleanNotEqualFilter,
+            "bool_field",
+            False,
+            "flt0_1",
+            "flt0_bool_field_not_equal",
+            "0",
+        ),  # not equal
+        (
+            filters.DateEqualFilter,
+            "date_field",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_date_field_equals",
+            "2025-11-01",
+        ),
+        (
+            filters.DateNotEqualFilter,
+            "date_field",
+            datetime(2025, 11, 1),
+            "flt0_1",
+            "flt0_date_field_not_equal",
+            "2025-11-01",
+        ),
+        (
+            filters.DateGreaterFilter,
+            "date_field",
+            datetime(2025, 11, 1),
+            "flt0_2",
+            "flt0_date_field_greater_than",
+            "2025-11-01",
+        ),
+        (
+            filters.DateSmallerFilter,
+            "date_field",
+            datetime(2025, 11, 1),
+            "flt0_3",
+            "flt0_date_field_smaller_than",
+            "2025-11-01",
+        ),
+        (
+            filters.DateBetweenFilter,
+            "date_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_4",
+            "flt0_date_field_between",
+            "2025-11-01+to+2025-11-15",
+        ),
+        (
+            filters.DateNotBetweenFilter,
+            "date_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_5",
+            "flt0_date_field_not_between",
+            "2025-11-01+to+2025-11-15",
+        ),
+        (
+            filters.FilterEmpty,
+            "date_field",
+            "1",
+            "flt0_6",
+            "flt0_date_field_empty",
+            "1",
+        ),
+        (
+            filters.DateTimeEqualFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_datetime_field_equals",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeNotEqualFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_1",
+            "flt0_datetime_field_not_equal",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeGreaterFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_2",
+            "flt0_datetime_field_greater_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeSmallerFilter,
+            "datetime_field",
+            datetime(2025, 11, 1),
+            "flt0_3",
+            "flt0_datetime_field_smaller_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeBetweenFilter,
+            "datetime_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_4",
+            "flt0_datetime_field_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+        (
+            filters.DateTimeNotBetweenFilter,
+            "datetime_field",
+            (datetime(2025, 11, 1), datetime(2025, 11, 15)),
+            "flt0_5",
+            "flt0_datetime_field_not_between",
+            "2025-11-01+00:00:00+to+2025-11-15+00:00:00",
+        ),
+        (
+            filters.FilterEmpty,
+            "datetime_field",
+            "1",
+            "flt0_6",
+            "flt0_datetime_field_empty",
+            "1",
+        ),
+        (
+            filters.TimeEqualFilter,
+            "time_field",
+            time(6, 30, 0),
+            "flt0_0",
+            "flt0_time_field_equals",
+            "06:30:00",
+        ),
+        (
+            filters.UuidFilterEqual,
+            "sqla_utils_uuid",
+            uuid1,
+            "flt0_0",
+            "flt0_sqla_utils_uuid_equals",
+            uuid1,
+        ),
+        (
+            filters.UuidFilterNotEqual,
+            "sqla_utils_uuid",
+            uuid1,
+            "flt0_1",
+            "flt0_sqla_utils_uuid_not_equal",
+            uuid1,
+        ),
+        (
+            filters.FilterEmpty,
+            "sqla_utils_uuid",
+            "1",
+            "flt0_2",
+            "flt0_sqla_utils_uuid_empty",
+            "1",
+        ),
+        (
+            filters.UuidFilterInList,
+            "sqla_utils_uuid",
+            [uuid1, uuid2],
+            "flt0_3",
+            "flt0_sqla_utils_uuid_in_list",
+            f"{uuid1},{uuid2}",
+        ),
+        (
+            filters.UuidFilterNotInList,
+            "sqla_utils_uuid",
+            [uuid1, uuid2],
+            "flt0_4",
+            "flt0_sqla_utils_uuid_not_in_list",
+            f"{uuid1},{uuid2}",
+        ),
+        (
+            filters.DateTimeGreaterFilter,
+            "sqla_utils_arrow",
+            datetime(2025, 11, 1),
+            "flt0_0",
+            "flt0_sqla_utils_arrow_greater_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.DateTimeSmallerFilter,
+            "sqla_utils_arrow",
+            datetime(2025, 11, 1),
+            "flt0_1",
+            "flt0_sqla_utils_arrow_smaller_than",
+            "2025-11-01+00:00:00",
+        ),
+        (
+            filters.FilterEmpty,
+            "sqla_utils_arrow",
+            "1",
+            "flt0_2",
+            "flt0_sqla_utils_arrow_empty",
+            "1",
+        ),
+    ]
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, col, filter_value, arg_key, arg_named_key, expected_value",
+    create_filter_params(),
+)
+def test_url_for(
+    app,
+    sqla_db_ext,
+    admin,
+    session_or_db,
+    FilterClass,
+    col,
+    filter_value,
+    arg_key,
+    arg_named_key,
+    expected_value,
+):
+    # with app.app_context():
+    Model1, Model2 = create_models(sqla_db_ext)
+
+    col = getattr(Model1, col)
+
+    param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+    view = CustomModelView(Model1, param, endpoint="user", column_filters=[col])
+    admin.add_view(view)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_key}={expected_value}"
+
+        view.named_filter_urls = True
+
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"
+
+
+def create_filter_params_enums_and_choices():
+    params = [
+        (
+            filters.EnumEqualFilter,
+            "enum_field",
+            "model1_v1",
+            "flt0_0",
+            "flt0_enum_field_equals",
+            "model1_v1",
+        ),
+        (
+            filters.EnumFilterNotEqual,
+            "enum_field",
+            "model1_v1",
+            "flt0_1",
+            "flt0_enum_field_not_equal",
+            "model1_v1",
+        ),
+        (
+            filters.EnumFilterEmpty,
+            "enum_field",
+            "1",
+            "flt0_2",
+            "flt0_enum_field_empty",
+            "1",
+        ),
+        (
+            filters.EnumFilterInList,
+            "enum_field",
+            ["model1_v1"],
+            "flt0_3",
+            "flt0_enum_field_in_list",
+            "model1_v1",
+        ),
+        (
+            filters.EnumFilterNotInList,
+            "enum_field",
+            ["model1_v1"],
+            "flt0_4",
+            "flt0_enum_field_not_in_list",
+            "model1_v1",
+        ),
+        (
+            filters.ChoiceTypeEqualFilter,
+            "sqla_utils_choice",
+            "choice-1",
+            "flt0_0",
+            "flt0_sqla_utils_choice_equals",
+            "choice-1",
+        ),
+        (
+            filters.ChoiceTypeNotEqualFilter,
+            "sqla_utils_choice",
+            "choice-1",
+            "flt0_1",
+            "flt0_sqla_utils_choice_not_equal",
+            "choice-1",
+        ),
+        (
+            filters.ChoiceTypeLikeFilter,
+            "sqla_utils_choice",
+            "choice-1",
+            "flt0_2",
+            "flt0_sqla_utils_choice_contains",
+            "choice-1",
+        ),
+        (
+            filters.ChoiceTypeNotLikeFilter,
+            "sqla_utils_choice",
+            "choice-1",
+            "flt0_3",
+            "flt0_sqla_utils_choice_not_contains",
+            "choice-1",
+        ),
+        (
+            filters.ChoiceTypeEmptyFilter,
+            "sqla_utils_choice",
+            "1",
+            "flt0_4",
+            "flt0_sqla_utils_choice_empty",
+            "1",
+        ),
+    ]
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, col, filter_value, arg_key, arg_named_key, expected_value",
+    create_filter_params_enums_and_choices(),
+)
+def test_url_for_enums_and_choices(
+    app,
+    sqla_db_ext,
+    admin,
+    session_or_db,
+    FilterClass,
+    col,
+    filter_value,
+    arg_key,
+    arg_named_key,
+    expected_value,
+):
+    Model1, Model2 = create_models(sqla_db_ext)
+
+    col = getattr(Model1, col)
+
+    param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+    view = CustomModelView(Model1, param, endpoint="user", column_filters=[col])
+    admin.add_view(view)
+
+    with app.test_request_context("http://localhost/admin/user/"):
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_key}={expected_value}"
+
+        view.named_filter_urls = True
+        d1 = filter_value
+        filtered_url = view.url_for(filters=[(FilterClass(col, "f1"), d1)])
+        assert filtered_url == f"/admin/user/?{arg_named_key}={expected_value}"
+
+
+def test_column_filters_sqla_obj(app, sqla_db_ext, admin, session_or_db):
+    with app.app_context():
+        Model1, Model2 = create_models(sqla_db_ext)
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view = CustomModelView(Model1, param, column_filters=[Model1.test1])
+        admin.add_view(view)
+        assert view._filters
+        assert len(view._filters) == 7

--- a/flask_admin/tests/test_filters.py
+++ b/flask_admin/tests/test_filters.py
@@ -148,15 +148,22 @@ def create_filter_clean_params() -> list[tuple[t.Any, ...]]:
         ):
             params.append((FilterClass, "SATURDAY", Day.SATURDAY.name))
 
+    # Clean module path for better readability in test output.
+    for i, p in enumerate(params):
+        Cls = p[0]
+        Cls = Cls.__module__.replace("flask_admin.contrib.", "").replace(".filters", "")
+        params[i] = (Cls,) + params[i]
+
     return params
 
 
 @pytest.mark.parametrize(
-    "FilterClass, filter_value, expected_value", create_filter_clean_params()
+    "module, FilterClass, filter_value, expected_value", create_filter_clean_params()
 )
 def test_filter_clean(
     app: Flask,
     admin: Admin,
+    module: str,
     FilterClass: type[filters.BaseFilter],
     filter_value: t.Any,
     expected_value: t.Any,

--- a/flask_admin/tests/test_filters.py
+++ b/flask_admin/tests/test_filters.py
@@ -7,7 +7,9 @@ from datetime import time
 import pytest
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
+from flask import Flask
 
+from flask_admin.base import Admin
 from flask_admin.contrib.mongoengine import filters as mofilters
 from flask_admin.contrib.peewee import filters as peefilters
 from flask_admin.contrib.pymongo import filters as pymofilters
@@ -20,7 +22,7 @@ class Day(enum.Enum):
     SUNDAY = 7
 
 
-def create_filter_clean_params():
+def create_filter_clean_params() -> list[tuple[t.Any, ...]]:
     params: list[t.Any] = []
     all_filter_classes: list[type[filters.BaseFilter]] = []
     all = (
@@ -152,8 +154,14 @@ def create_filter_clean_params():
 @pytest.mark.parametrize(
     "FilterClass, filter_value, expected_value", create_filter_clean_params()
 )
-def test_filter_clean(app, admin, FilterClass, filter_value, expected_value):
-    flt = FilterClass("f1", "F1_LABEL", options=None)
+def test_filter_clean(
+    app: Flask,
+    admin: Admin,
+    FilterClass: type[filters.BaseFilter],
+    filter_value: t.Any,
+    expected_value: t.Any,
+) -> None:
+    flt = FilterClass(column="f1", name="F1_LABEL", options=None)
     is_execption = isinstance(expected_value, type) and issubclass(
         expected_value, Exception
     )

--- a/flask_admin/tests/test_filters.py
+++ b/flask_admin/tests/test_filters.py
@@ -1,0 +1,170 @@
+import enum
+import typing as t
+from datetime import date
+from datetime import datetime
+from datetime import time
+
+import pytest
+from bson.errors import InvalidId
+from bson.objectid import ObjectId
+
+from flask_admin.contrib.mongoengine import filters as mofilters
+from flask_admin.contrib.peewee import filters as peefilters
+from flask_admin.contrib.pymongo import filters as pymofilters
+from flask_admin.contrib.sqla import filters as safilters
+from flask_admin.model import filters
+
+
+class Day(enum.Enum):
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+def create_filter_clean_params():
+    params: list[t.Any] = []
+    all_filter_classes: list[type[filters.BaseFilter]] = []
+    all = (
+        list(peefilters.__dict__.values())
+        + list(mofilters.__dict__.values())
+        + list(pymofilters.__dict__.values())
+        + list(safilters.__dict__.values())
+    )
+
+    for FilterClass in all:
+        if isinstance(FilterClass, type) and issubclass(
+            FilterClass, filters.BaseFilter
+        ):
+            all_filter_classes.append(FilterClass)
+
+    for FilterClass in all_filter_classes:
+        if issubclass(FilterClass, filters.BaseBooleanFilter) and not issubclass(
+            FilterClass, filters.BaseEmptyFilter
+        ):
+            params.append((FilterClass, "1", ("1", True)))
+            params.append((FilterClass, "0", ("0", False)))
+
+        if issubclass(FilterClass, filters.BaseEmptyFilter):
+            params.append((FilterClass, "1", "1"))
+            params.append((FilterClass, "0", "0"))
+
+        if issubclass(FilterClass, filters.BaseIntFilter):
+            params.append((FilterClass, "", 0))
+            params.append((FilterClass, "15", 15))
+            params.append((FilterClass, "-48", -48))
+            params.append((FilterClass, "2.1", ValueError))
+
+        if issubclass(FilterClass, filters.BaseFloatFilter):
+            params.append((FilterClass, "", 0.0))
+            params.append((FilterClass, "15", 15.0))
+            params.append((FilterClass, "-48.3", -48.3))
+            params.append((FilterClass, "2.1", 2.1))
+
+        if issubclass(FilterClass, filters.BaseIntListFilter):
+            params.append((FilterClass, "", []))
+            params.append((FilterClass, "15", [15]))
+            params.append((FilterClass, "2,1", [2, 1]))
+
+        if issubclass(FilterClass, filters.BaseFloatListFilter):
+            params.append((FilterClass, "", []))
+            params.append((FilterClass, "15", [15.0]))
+            params.append((FilterClass, "-48.3", [-48.3]))
+            params.append((FilterClass, "2.1,3.4", [2.1, 3.4]))
+
+        if issubclass(FilterClass, filters.BaseDateFilter):
+            params.append((FilterClass, "2026-01-28", date(2026, 1, 28)))
+            params.append((FilterClass, "2026-30-05", ValueError))
+
+        if issubclass(FilterClass, filters.BaseDateBetweenFilter):
+            params.append(
+                (
+                    FilterClass,
+                    "2026-01-15 to 2026-01-20",
+                    [date(2026, 1, 15), date(2026, 1, 20)],
+                )
+            )
+            params.append((FilterClass, "2026-30-05", ValueError))
+
+        if issubclass(FilterClass, filters.BaseDateTimeFilter):
+            params.append(
+                (FilterClass, "2026-01-28 15:00:00", datetime(2026, 1, 28, 15, 0, 0))
+            )
+            params.append((FilterClass, "2026-05-05 03:00:00 AM", ValueError))
+
+        if issubclass(FilterClass, filters.BaseDateTimeBetweenFilter):
+            params.append(
+                (
+                    FilterClass,
+                    "2026-01-15 00:00:00 to 2026-01-20 00:00:00",
+                    [datetime(2026, 1, 15), datetime(2026, 1, 20)],
+                )
+            )
+
+        if issubclass(FilterClass, filters.BaseTimeFilter):
+            params.append((FilterClass, "15:00:00", time(15, 0, 0)))
+            params.append((FilterClass, "03:00:00 AM", ValueError))
+
+        if issubclass(FilterClass, filters.BaseTimeBetweenFilter):
+            params.append(
+                (FilterClass, "15:00:00 to 20:00:00", [time(15, 0, 0), time(20, 0, 0)])
+            )
+
+        # FIXME: test is skipped unexpectedly, need to investigate.
+        # if issubclass(FilterClass, filters.BaseUuidFilter):
+        #     v= uuid.uuid4()
+        #     params.append((FilterClass, str(v), v))
+
+        if issubclass(FilterClass, mofilters.ReferenceObjectIdFilter):
+            v = ObjectId("507f1f77bcf86cd799439011")
+            params.append(
+                (FilterClass, "507f1f77bcf86cd799439011", ObjectId(str(v).strip()))
+            )
+            params.append((FilterClass, "invalid-objectid", InvalidId))
+
+        if (
+            issubclass(FilterClass, safilters.EnumEqualFilter)
+            or issubclass(FilterClass, safilters.EnumFilterNotEqual)
+            or issubclass(FilterClass, safilters.ChoiceTypeEqualFilter)
+            or issubclass(FilterClass, safilters.ChoiceTypeNotEqualFilter)
+        ):
+            params.append((FilterClass, "SATURDAY", Day.SATURDAY.name))
+
+        if issubclass(FilterClass, safilters.EnumFilterEmpty) or issubclass(
+            FilterClass, safilters.ChoiceTypeEmptyFilter
+        ):
+            params.append((FilterClass, "0", "0"))
+            params.append((FilterClass, "1", "1"))
+
+        if issubclass(FilterClass, safilters.EnumFilterInList) or issubclass(
+            FilterClass, safilters.EnumFilterNotInList
+        ):
+            params.append(
+                (FilterClass, "SATURDAY, SUNDAY", [Day.SATURDAY.name, Day.SUNDAY.name])
+            )
+
+        if issubclass(FilterClass, safilters.ChoiceTypeLikeFilter) or issubclass(
+            FilterClass, safilters.ChoiceTypeNotLikeFilter
+        ):
+            params.append((FilterClass, "SATURDAY", Day.SATURDAY.name))
+
+    return params
+
+
+@pytest.mark.parametrize(
+    "FilterClass, filter_value, expected_value", create_filter_clean_params()
+)
+def test_filter_clean(app, admin, FilterClass, filter_value, expected_value):
+    flt = FilterClass("f1", "F1_LABEL", options=None)
+    is_execption = isinstance(expected_value, type) and issubclass(
+        expected_value, Exception
+    )
+    if is_execption:
+        assert not flt.validate(filter_value)
+        with pytest.raises(expected_value):
+            flt.clean(filter_value)
+    else:
+        actual = flt.clean(filter_value)
+        expected_value = (
+            expected_value if isinstance(expected_value, tuple) else [expected_value]
+        )
+        assert actual in expected_value
+        assert flt.validate(filter_value)

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -332,11 +332,11 @@ def test_column_searchable_list(app: Flask, admin: Admin) -> None:
 
 
 def test_column_filters(app: Flask, admin: Admin) -> None:
-    view = MockModelView(Model, column_filters=["col1", "col2"])
+    view = MockModelView(Model, column_filters=["col1", "col2", "col3"])
     admin.add_view(view)
 
     assert view._filters
-    assert len(view._filters) == 2
+    assert len(view._filters) == 3
     assert view._filters[0].name == "col1"
     assert view._filters[1].name == "col2"
     assert view._filter_groups


### PR DESCRIPTION
Fixes #2703

This PR adds a function to generate a URL with filter arguements including all types of filters (Like, NotLike, Greater....etc) and including both indexed (`flt2_3=xx`) and named (`flt3_email_like=@example.com`)

**Usage:**
```
    filtered_url = view.url_for(
        search="exam",
        filters=[
            filters.FilterLike(Model1.test1, "Email", url_value="@example.com"),
            filters.BooleanEqualFilter(Model1.bool_field, "active", url_value=False),
            filters.FloatGreaterFilter(Model1.test5, "Salary", url_value=15.3),
        ],
    )
```

**Output:**
`/admin/user/?search=exam&flt0_0=@example.com&flt1_21=0&flt2_16=15.3`

**Output with named parameters:**
`/admin/user/?search=exam&flt0_test1_contains=@example.com&flt1_bool_field_equals=0&flt4_test2_greater_than=15.3`
