### PR TITLE
docs(inline): correct inline post-processing example and fix Peewee parity (#1738)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
+* Peewee backend: invoke ``InlineFormAdmin.postprocess_form`` from the inline-model converter so it can contribute extra fields onto inline forms, matching the long-standing SQLAlchemy behavior (part of #1738).
+
+Documentation:
+* Fix the ``inline_model_form_converter`` docstrings in the SQLAlchemy and Peewee model views. They previously showed a ``post_process`` method on a converter subclass, which is never invoked anywhere in the codebase. The hook actually called by the converter is ``InlineFormAdmin.postprocess_form``; the examples now reflect that (closes #1738).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
-* Peewee backend: invoke ``InlineFormAdmin.postprocess_form`` from the inline-model converter so it can contribute extra fields onto inline forms, matching the long-standing SQLAlchemy behavior (part of #1738).
+* Peewee backend: invoke ``InlineFormAdmin.postprocess_form`` matching SQLAlchemy behavior (#1738).
 
 Documentation:
 * Fix the ``inline_model_form_converter`` docstrings in the SQLAlchemy and Peewee model views. They previously showed a ``post_process`` method on a converter subclass, which is never invoked anywhere in the codebase. The hook actually called by the converter is ``InlineFormAdmin.postprocess_form``; the examples now reflect that (closes #1738).

--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -328,6 +328,11 @@ class InlineModelConverter(InlineModelConverterBase):
                 converter=converter,
             )
 
+        # Give InlineFormAdmin subclasses a chance to contribute extra fields
+        # onto the generated inline form, matching the behavior of the
+        # SQLAlchemy backend (see flask_admin/contrib/sqla/form.py).
+        child_form = info.postprocess_form(child_form)  # type: ignore[attr-defined]
+
         try:
             prop_name = reverse_field.related_name  # type: ignore[attr-defined]
         except AttributeError:

--- a/flask_admin/contrib/peewee/form.py
+++ b/flask_admin/contrib/peewee/form.py
@@ -331,7 +331,7 @@ class InlineModelConverter(InlineModelConverterBase):
         # Give InlineFormAdmin subclasses a chance to contribute extra fields
         # onto the generated inline form, matching the behavior of the
         # SQLAlchemy backend (see flask_admin/contrib/sqla/form.py).
-        child_form = info.postprocess_form(child_form)  # type: ignore[attr-defined]
+        child_form = info.postprocess_form(child_form)  # type: ignore[arg-type,assignment]
 
         try:
             prop_name = reverse_field.related_name  # type: ignore[attr-defined]

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -110,16 +110,23 @@ class ModelView(BaseModelView):
 
     inline_model_form_converter: type[InlineModelConverter] = InlineModelConverter
     """
-        Inline model conversion class. If you need some kind of post-processing for
-        inline forms, you can customize behavior by doing something like this::
+        Inline model conversion class. Override this if you need custom
+        scaffolding logic for inline forms; for simple per-field tweaks, prefer
+        overriding ``postprocess_form`` on an ``InlineFormAdmin`` subclass and
+        passing it to ``inline_models`` (this is the hook actually invoked by
+        the converter)::
 
-            class MyInlineModelConverter(AdminModelConverter):
-                def post_process(self, form_class, info):
-                    form_class.value = TextField('value')
+            from flask_admin.contrib.peewee import ModelView
+            from flask_admin.model.form import InlineFormAdmin
+            from wtforms import StringField
+
+            class MyInlineForm(InlineFormAdmin):
+                def postprocess_form(self, form_class):
+                    form_class.value = StringField('value')
                     return form_class
 
             class MyAdminView(ModelView):
-                inline_model_form_converter = MyInlineModelConverter
+                inline_models = (MyInlineForm(MyInlineModel),)
     """
 
     filter_converter: filters.FilterConverter = filters.FilterConverter()

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -211,16 +211,23 @@ class ModelView(BaseModelView):
         form.InlineModelConverter
     )
     """
-        Inline model conversion class. If you need some kind of post-processing for
-        inline forms, you can customize behavior by doing something like this::
+        Inline model conversion class. Override this if you need custom
+        scaffolding logic for inline forms; for simple per-field tweaks, prefer
+        overriding ``postprocess_form`` on an ``InlineFormAdmin`` subclass and
+        passing it to ``inline_models`` (this is the hook actually invoked by
+        the converter)::
 
-            class MyInlineModelConverter(InlineModelConverter):
-                def post_process(self, form_class, info):
+            from flask_admin.contrib.sqla import ModelView
+            from flask_admin.model.form import InlineFormAdmin
+            import wtforms as wtf
+
+            class MyInlineForm(InlineFormAdmin):
+                def postprocess_form(self, form_class):
                     form_class.value = wtf.StringField('value')
                     return form_class
 
             class MyAdminView(ModelView):
-                inline_model_form_converter = MyInlineModelConverter
+                inline_models = (MyInlineForm(MyInlineModel),)
     """
 
     filter_converter: sqla_filters.FilterConverter = sqla_filters.FilterConverter()
@@ -1110,13 +1117,13 @@ class ModelView(BaseModelView):
     def _apply_search(
         self,
         query: T_SQLALCHEMY_QUERY,
-        count_query: t.Optional[T_SQLALCHEMY_QUERY],
+        count_query: T_SQLALCHEMY_QUERY | None,
         joins: dict[tuple[bool, t.Any], t.Any],
         count_joins: dict[tuple[bool, t.Any], t.Any],
         search: str,
     ) -> tuple[
         T_SQLALCHEMY_QUERY,
-        t.Optional[T_SQLALCHEMY_QUERY],
+        T_SQLALCHEMY_QUERY | None,
         dict[tuple[bool, t.Any], t.Any],
         dict[tuple[bool, t.Any], t.Any],
     ]:
@@ -1167,13 +1174,13 @@ class ModelView(BaseModelView):
     def _apply_filters(
         self,
         query: T_SQLALCHEMY_QUERY,
-        count_query: t.Optional[T_SQLALCHEMY_QUERY],
+        count_query: T_SQLALCHEMY_QUERY | None,
         joins: dict[tuple[bool, t.Any], t.Any],
         count_joins: dict[tuple[bool, t.Any], t.Any],
         filters: t.Sequence[T_FILTER],
     ) -> tuple[
         T_SQLALCHEMY_QUERY,
-        t.Optional[T_SQLALCHEMY_QUERY],
+        T_SQLALCHEMY_QUERY | None,
         dict[tuple[bool, t.Any], t.Any],
         dict[tuple[bool, t.Any], t.Any],
     ]:

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -1196,7 +1196,7 @@ def test_inline_form_postprocess_form_hook(
     Model1, Model2 = create_models(db)
 
     class Model2InlineForm(InlineFormAdmin):
-        def postprocess_form(self, form_class):  # type: ignore[no-untyped-def]
+        def postprocess_form(self, form_class):
             form_class.extra = fields.StringField("extra")
             return form_class
 
@@ -1207,7 +1207,7 @@ def test_inline_form_postprocess_form_hook(
     # as an UnboundField whose first positional arg is the per-row form
     # class; ``postprocess_form`` is supposed to mutate that class.
     create_form_cls = view._create_form_class
-    inline_unbound = create_form_cls.model2_set  # backref name on Model2
+    inline_unbound = create_form_cls.model2_set  # type: ignore[attr-defined]
     inline_form_cls = inline_unbound.args[0]
     assert hasattr(inline_form_cls, "extra"), (
         "InlineFormAdmin.postprocess_form should contribute extra fields on "

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -1188,16 +1188,13 @@ def test_inline_form_postprocess_form_hook(
 ) -> None:
     """``InlineFormAdmin.postprocess_form`` should be invoked by the Peewee
     inline-model converter, mirroring the behavior already provided by the
-    SQLAlchemy backend. Before the fix accompanying this test the Peewee
-    backend never called the hook, so subclassing ``InlineFormAdmin`` to
-    contribute extra fields onto an inline form was silently a no-op (this
-    is what issue #1738 was really about for the Peewee docstring example).
+    SQLAlchemy backend.
     """
     Model1, Model2 = create_models(db)
 
     class Model2InlineForm(InlineFormAdmin):
         def postprocess_form(self, form_class):
-            form_class.extra = fields.StringField("extra")
+            form_class.extra = fields.StringField("FooBarExtraField")
             return form_class
 
     view = CustomModelView(Model1, inline_models=(Model2InlineForm(Model2),))
@@ -1209,7 +1206,4 @@ def test_inline_form_postprocess_form_hook(
     create_form_cls = view._create_form_class
     inline_unbound = create_form_cls.model2_set  # type: ignore[attr-defined]
     inline_form_cls = inline_unbound.args[0]
-    assert hasattr(inline_form_cls, "extra"), (
-        "InlineFormAdmin.postprocess_form should contribute extra fields on "
-        "the Peewee backend just like it does on the SQLAlchemy backend."
-    )
+    assert inline_form_cls.extra.args == ("FooBarExtraField",)

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -15,6 +15,7 @@ from flask_admin._compat import as_unicode
 from flask_admin._compat import iteritems
 from flask_admin._types import T_PEEWEE_MODEL
 from flask_admin.contrib.peewee import ModelView
+from flask_admin.model.form import InlineFormAdmin
 
 
 class CustomModelView(ModelView):
@@ -1060,7 +1061,7 @@ def test_customising_page_size(
     with app.app_context():
         M1, _ = create_models(db)
 
-        instances = [M1(f"instance-{x+1:03d}") for x in range(101)]
+        instances = [M1(f"instance-{x + 1:03d}") for x in range(101)]
         for instance in instances:
             instance.save()
 
@@ -1180,3 +1181,35 @@ def test_export_csv(app: Flask, db: peewee.SqliteDatabase, admin: Admin) -> None
     data = rv.data.decode("utf-8")
     assert rv.status_code == 200
     assert len(data.splitlines()) > 21
+
+
+def test_inline_form_postprocess_form_hook(
+    app: Flask, db: peewee.SqliteDatabase, admin: Admin
+) -> None:
+    """``InlineFormAdmin.postprocess_form`` should be invoked by the Peewee
+    inline-model converter, mirroring the behavior already provided by the
+    SQLAlchemy backend. Before the fix accompanying this test the Peewee
+    backend never called the hook, so subclassing ``InlineFormAdmin`` to
+    contribute extra fields onto an inline form was silently a no-op (this
+    is what issue #1738 was really about for the Peewee docstring example).
+    """
+    Model1, Model2 = create_models(db)
+
+    class Model2InlineForm(InlineFormAdmin):
+        def postprocess_form(self, form_class):  # type: ignore[no-untyped-def]
+            form_class.extra = fields.StringField("extra")
+            return form_class
+
+    view = CustomModelView(Model1, inline_models=(Model2InlineForm(Model2),))
+    admin.add_view(view)
+
+    # The inline relationship is exposed on the generated create-form class
+    # as an UnboundField whose first positional arg is the per-row form
+    # class; ``postprocess_form`` is supposed to mutate that class.
+    create_form_cls = view._create_form_class
+    inline_unbound = create_form_cls.model2_set  # backref name on Model2
+    inline_form_cls = inline_unbound.args[0]
+    assert hasattr(inline_form_cls, "extra"), (
+        "InlineFormAdmin.postprocess_form should contribute extra fields on "
+        "the Peewee backend just like it does on the SQLAlchemy backend."
+    )

--- a/flask_admin/tests/sqla/test_inlineform.py
+++ b/flask_admin/tests/sqla/test_inlineform.py
@@ -401,7 +401,7 @@ def test_inline_form_postprocess_form_hook(
         sqla_db_ext.create_all()
 
         class UserInfoInlineForm(InlineFormAdmin):
-            def postprocess_form(self, form_class):  # type: ignore[no-untyped-def]
+            def postprocess_form(self, form_class):
                 # Contribute an extra field that does not exist on the SQLA
                 # model. If `postprocess_form` is not invoked by the converter,
                 # this attribute will be missing on the generated form class.

--- a/flask_admin/tests/sqla/test_inlineform.py
+++ b/flask_admin/tests/sqla/test_inlineform.py
@@ -1,5 +1,4 @@
 import typing as t
-from typing import Optional
 
 from flask import Flask
 from sqlalchemy import Column
@@ -18,6 +17,7 @@ from flask_admin import form
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.fields import InlineModelFormList
 from flask_admin.contrib.sqla.validators import ItemsRequired
+from flask_admin.model.form import InlineFormAdmin
 from flask_admin.tests.conftest import skip_or_return_session_or_db
 from flask_admin.tests.conftest import T_ANY_SQLA_PROVIDER
 from flask_admin.tests.conftest import T_LITERAL_SESSION_OR_DB
@@ -38,7 +38,7 @@ def test_inline_form(
             id = Column(Integer, primary_key=True)
             name = Column(String, unique=True)
 
-            def __init__(self, name: Optional[str] = None) -> None:
+            def __init__(self, name: str | None = None) -> None:
                 self.name = name  # type: ignore[assignment]
 
         class UserInfo(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
@@ -153,7 +153,7 @@ def test_inline_form_required(
             id = Column(Integer, primary_key=True)
             name: str | None = Column(String, unique=True)  # type: ignore[assignment]
 
-            def __init__(self, name: Optional[str] = None) -> None:
+            def __init__(self, name: str | None = None) -> None:
                 self.name = name
 
         class UserEmail(sqla_db_ext.Base):  # type: ignore[misc,name-defined]
@@ -219,7 +219,7 @@ def test_inline_form_ajax_fk(
             id = Column(Integer, primary_key=True)
             name: str | None = Column(String, unique=True)  # type: ignore[assignment]
 
-            def __init__(self, name: Optional[str] = None) -> None:
+            def __init__(self, name: str | None = None) -> None:
                 self.name = name
 
         class Tag(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
@@ -309,7 +309,7 @@ def test_inline_form_base_class(
             id = Column(Integer, primary_key=True)
             name: str | None = Column(String, unique=True)  # type: ignore[assignment]
 
-            def __init__(self, name: Optional[str] = None) -> None:
+            def __init__(self, name: str | None = None) -> None:
                 self.name = name
 
         class UserEmail(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
@@ -358,3 +358,71 @@ def test_inline_form_base_class(
         assert rv.status_code == 200
         assert sqla_db_ext.db.session.query(func.count(User.id)).scalar() == 0
         assert b"success!" in rv.data, rv.data
+
+
+def test_inline_form_postprocess_form_hook(
+    app: Flask,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
+    """``InlineFormAdmin.postprocess_form`` is the hook invoked by the
+    inline-model converter to contribute extra fields onto the generated
+    inline form class. The matching docstrings in
+    ``flask_admin.contrib.sqla.view`` and ``flask_admin.contrib.peewee.view``
+    used to advertise a ``post_process`` method on a converter subclass, which
+    is never actually invoked anywhere in the codebase -- see issue #1738.
+
+    This test pins the real, working API so the docs cannot drift away from it
+    again: subclass ``InlineFormAdmin``, override ``postprocess_form``, pass
+    an instance through ``inline_models``, and verify the extra field appears
+    on the generated inline form class.
+    """
+    with app.app_context():
+        # Set up models and database
+        class User(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "users"
+            id = Column(Integer, primary_key=True)
+            name = Column(String, unique=True)
+
+        class UserInfo(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "user_info"
+            id = Column(Integer, primary_key=True)
+            key = Column(String, nullable=False)
+            val = Column(String)
+            user_id = Column(Integer, ForeignKey(User.id))
+            user = relationship(
+                User,
+                backref=backref(
+                    "info", cascade="all, delete-orphan", single_parent=True
+                ),
+            )
+
+        sqla_db_ext.create_all()
+
+        class UserInfoInlineForm(InlineFormAdmin):
+            def postprocess_form(self, form_class):  # type: ignore[no-untyped-def]
+                # Contribute an extra field that does not exist on the SQLA
+                # model. If `postprocess_form` is not invoked by the converter,
+                # this attribute will be missing on the generated form class.
+                form_class.extra = fields.StringField("extra")
+                return form_class
+
+        class UserModelView(ModelView):
+            inline_models = (UserInfoInlineForm(UserInfo),)
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view = UserModelView(User, param)
+        admin.add_view(view)
+
+        # On the parent form, the inline relationship lives as an UnboundField
+        # whose first positional arg is the generated per-row form class. That
+        # class is what `postprocess_form` mutates; assert the contributed
+        # field is present on it.
+        unbound_info = view._create_form_class.info  # type: ignore[attr-defined]
+        inline_form_cls = unbound_info.args[0]
+        assert hasattr(inline_form_cls, "extra"), (
+            "InlineFormAdmin.postprocess_form should contribute extra fields; "
+            "if this fails the converter is no longer calling the hook the "
+            "docstrings document."
+        )

--- a/flask_admin/tests/sqla/test_inlineform.py
+++ b/flask_admin/tests/sqla/test_inlineform.py
@@ -10,6 +10,7 @@ from sqlalchemy import String
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from wtforms import fields
+from wtforms import StringField
 from wtforms.form import Form
 
 from flask_admin import Admin
@@ -57,8 +58,15 @@ def test_inline_form(
         sqla_db_ext.create_all()
 
         # Set up Admin
+
+        class UserInfoInlineForm(InlineFormAdmin):
+            def postprocess_form(self, form_class):
+                # Contribute an extra field that does not exist on the model
+                form_class.extra = fields.StringField("FooBarExtraField")
+                return form_class
+
         class UserModelView(ModelView):
-            inline_models = (UserInfo,)
+            inline_models = (UserInfoInlineForm(UserInfo),)
 
         param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
         view = UserModelView(User, param)
@@ -136,6 +144,13 @@ def test_inline_form(
         assert rv.status_code == 302
         assert sqla_db_ext.db.session.query(func.count(User.id)).scalar() == 0
         assert sqla_db_ext.db.session.query(func.count(UserInfo.id)).scalar() == 0
+
+        form_class = view._create_form_class
+        inline_field = form_class.info  # type: ignore[attr-defined]
+        subform_class = inline_field.args[0]
+        extra = subform_class.extra
+        assert extra.field_class is StringField
+        assert extra.args == ("FooBarExtraField",)
 
 
 def test_inline_form_required(
@@ -358,71 +373,3 @@ def test_inline_form_base_class(
         assert rv.status_code == 200
         assert sqla_db_ext.db.session.query(func.count(User.id)).scalar() == 0
         assert b"success!" in rv.data, rv.data
-
-
-def test_inline_form_postprocess_form_hook(
-    app: Flask,
-    sqla_db_ext: T_ANY_SQLA_PROVIDER,
-    admin: Admin,
-    session_or_db: T_LITERAL_SESSION_OR_DB,
-) -> None:
-    """``InlineFormAdmin.postprocess_form`` is the hook invoked by the
-    inline-model converter to contribute extra fields onto the generated
-    inline form class. The matching docstrings in
-    ``flask_admin.contrib.sqla.view`` and ``flask_admin.contrib.peewee.view``
-    used to advertise a ``post_process`` method on a converter subclass, which
-    is never actually invoked anywhere in the codebase -- see issue #1738.
-
-    This test pins the real, working API so the docs cannot drift away from it
-    again: subclass ``InlineFormAdmin``, override ``postprocess_form``, pass
-    an instance through ``inline_models``, and verify the extra field appears
-    on the generated inline form class.
-    """
-    with app.app_context():
-        # Set up models and database
-        class User(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "users"
-            id = Column(Integer, primary_key=True)
-            name = Column(String, unique=True)
-
-        class UserInfo(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "user_info"
-            id = Column(Integer, primary_key=True)
-            key = Column(String, nullable=False)
-            val = Column(String)
-            user_id = Column(Integer, ForeignKey(User.id))
-            user = relationship(
-                User,
-                backref=backref(
-                    "info", cascade="all, delete-orphan", single_parent=True
-                ),
-            )
-
-        sqla_db_ext.create_all()
-
-        class UserInfoInlineForm(InlineFormAdmin):
-            def postprocess_form(self, form_class):
-                # Contribute an extra field that does not exist on the SQLA
-                # model. If `postprocess_form` is not invoked by the converter,
-                # this attribute will be missing on the generated form class.
-                form_class.extra = fields.StringField("extra")
-                return form_class
-
-        class UserModelView(ModelView):
-            inline_models = (UserInfoInlineForm(UserInfo),)
-
-        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
-        view = UserModelView(User, param)
-        admin.add_view(view)
-
-        # On the parent form, the inline relationship lives as an UnboundField
-        # whose first positional arg is the generated per-row form class. That
-        # class is what `postprocess_form` mutates; assert the contributed
-        # field is present on it.
-        unbound_info = view._create_form_class.info  # type: ignore[attr-defined]
-        inline_form_cls = unbound_info.args[0]
-        assert hasattr(inline_form_cls, "extra"), (
-            "InlineFormAdmin.postprocess_form should contribute extra fields; "
-            "if this fails the converter is no longer calling the hook the "
-            "docstrings document."
-        )


### PR DESCRIPTION
## Summary

The `inline_model_form_converter` docstrings in
`flask_admin.contrib.sqla.view` and `flask_admin.contrib.peewee.view`
advertise a `post_process` method on a converter subclass. That method
name is never invoked anywhere in the codebase, so following the
documented example is silently a no-op. The hook the SQLAlchemy
converter actually calls is `InlineFormAdmin.postprocess_form` (see
`flask_admin/contrib/sqla/form.py:1014,1139`); the `examples/sqla_custom_inline_forms/main.py:132`
example uses that real hook.

Fixes #1738.

## Context

- `flask_admin/contrib/sqla/view.py:213-224` (pre-change) and
  `flask_admin/contrib/peewee/view.py:112-123` (pre-change) showed:

  ```python
  class MyInlineModelConverter(InlineModelConverter):
      def post_process(self, form_class, info):
          ...
  ```

  Grepping the repo for `post_process` returns only those two docstring
  occurrences -- nothing in the code path ever calls a method by that
  name.

- The real contract is on `InlineBaseFormAdmin`:
  `flask_admin/model/form.py:120-134` defines
  `postprocess_form(self, form_class)` and the SQLA converter invokes it
  at `flask_admin/contrib/sqla/form.py:1014` and `:1139`.

- The Peewee inline converter (`flask_admin/contrib/peewee/form.py:287-350`)
  never invoked `postprocess_form` at all, so the documented pattern was
  effectively broken on the Peewee backend as well.

## Changes

- `flask_admin/contrib/sqla/view.py`, `flask_admin/contrib/peewee/view.py`:
  rewrite the `inline_model_form_converter` docstring example to use
  `InlineFormAdmin.postprocess_form` (the hook the converter actually
  invokes) and to pass the subclass through `inline_models`.
- `flask_admin/contrib/peewee/form.py`: call
  `info.postprocess_form(child_form)` inside
  `InlineModelConverter.contribute`, mirroring the long-standing SQLA
  behavior so the documented hook works on both backends.
- `flask_admin/tests/sqla/test_inlineform.py`:
  add `test_inline_form_postprocess_form_hook` that subclasses
  `InlineFormAdmin`, contributes an extra `StringField` via
  `postprocess_form`, and asserts the field lands on the generated
  inline form class. Pins the documented contract.
- `flask_admin/tests/peeweemodel/test_basic.py`:
  add a matching regression test that fails on `origin/main` (the hook
  was never called) and passes on this branch.
- `doc/changelog.rst`: add `[unreleased]` entries for the documentation
  fix and the Peewee bug fix.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/pallets-eco/flask-admin.git /tmp/fa-1738 && cd /tmp/fa-1738
uv venv .venv --python 3.12
source .venv/bin/activate
uv pip install -e ".[sqlalchemy,peewee]" pytest flask-sqlalchemy-lite

# --- BEFORE: origin/master, Peewee `postprocess_form` hook is never called ---
git checkout origin/master
git fetch https://github.com/jbbqqf/flask-admin.git docs/1738-inline-postprocess-form
git checkout FETCH_HEAD -- flask_admin/tests/peeweemodel/test_basic.py
pytest flask_admin/tests/peeweemodel/test_basic.py::test_inline_form_postprocess_form_hook -v
# Expected: FAILED -- "InlineFormAdmin.postprocess_form should contribute
#                      extra fields on the Peewee backend just like it
#                      does on the SQLAlchemy backend."
git checkout origin/master -- flask_admin/tests/peeweemodel/test_basic.py

# --- AFTER: this branch, both SQLA and Peewee fire the documented hook ---
git checkout FETCH_HEAD
pytest \
  flask_admin/tests/peeweemodel/test_basic.py::test_inline_form_postprocess_form_hook \
  flask_admin/tests/sqla/test_inlineform.py::test_inline_form_postprocess_form_hook \
  -v
# Expected: 4 passed, 1 skipped (SQLALite-with-session_deprecated is skipped
#           by the conftest fixture; the SQLA + Peewee cases all pass).
```

## What I ran locally

- New tests, focused:
  ```
  pytest flask_admin/tests/peeweemodel/test_basic.py::test_inline_form_postprocess_form_hook \
         flask_admin/tests/sqla/test_inlineform.py::test_inline_form_postprocess_form_hook -v
  # 4 passed, 1 skipped
  ```
- Whole inline test file:
  ```
  pytest flask_admin/tests/sqla/test_inlineform.py -q
  # 18 passed, 6 skipped
  ```
- Broader regression sweep (excluding the Postgres-only test module, which
  needs `psycopg2`):
  ```
  pytest flask_admin/tests/peeweemodel/ flask_admin/tests/sqla/ \
         flask_admin/tests/test_base.py flask_admin/tests/test_model.py \
         --ignore=flask_admin/tests/sqla/test_postgres.py -q
  # 335 passed, 81 skipped, 13 xfailed
  ```
- Lint:
  ```
  ruff check flask_admin/contrib/peewee/form.py flask_admin/contrib/peewee/view.py \
             flask_admin/contrib/sqla/view.py \
             flask_admin/tests/peeweemodel/test_basic.py \
             flask_admin/tests/sqla/test_inlineform.py
  # All checks passed!
  ```

## Edge cases

| # | Scenario | Input | Expected | Verified by |
|---|---|---|---|---|
| 1 | SQLA backend, subclass `InlineFormAdmin` and contribute `extra` field via `postprocess_form` | `inline_models = (UserInfoInlineForm(UserInfo),)` | `view._create_form_class.info.args[0]` has `extra` attribute | new `test_inline_form_postprocess_form_hook[SQLAProvider-*]` |
| 2 | Peewee backend, same subclass-and-contribute pattern | `inline_models = (Model2InlineForm(Model2),)` | generated inline form class has `extra` attribute | new `test_inline_form_postprocess_form_hook` (peewee) |
| 3 | Plain `inline_models = (Model,)` with no `InlineFormAdmin` subclass | existing behavior | continues to work unchanged | existing `test_inline_form` / `test_inline_form_required` / `test_inline_form_self` / `test_inline_form_base_class` all still pass |
| 4 | Peewee `InlineFormAdmin` returning a custom form via `get_form()` (skips the auto-generated path) | `info.get_form()` returns non-None | still passes through `postprocess_form` after assignment | code path now uniformly calls `postprocess_form` after the `if child_form is None` branch, matching the SQLA backend's structure |

## Risk / blast radius

- Docstring-only change for SQLA: no behavior change.
- Peewee `InlineModelConverter.contribute`: now calls
  `info.postprocess_form(child_form)`. The default
  `InlineFormAdmin.postprocess_form` (`flask_admin/model/form.py:134`)
  returns the form class unchanged, so existing call sites that never
  overrode the hook see no diff. Behavior changes only for users who
  *do* override the hook -- which is the previously-documented but
  broken case we're fixing.
- All non-Postgres tests pass locally; the Postgres test module fails
  to import only because `psycopg2` isn't installed in my dev env (it's
  unrelated to this diff).

## Release note

```release-note
Fix the SQLAlchemy/Peewee `inline_model_form_converter` docstring example
to point at the real `InlineFormAdmin.postprocess_form` hook, and wire
the Peewee backend to call that hook so the documented pattern actually
works there.
```

---

*PR drafted with assistance from Claude Code (Anthropic). The change was
reviewed manually against flask-admin's source -- file:line references in
the body were checked against the cloned tree, and the copy-paste
BEFORE/AFTER reproducer block is the one I used during development;
reviewers can paste it verbatim.*
