### PR TITLE
fix(sqla): coerce ARRAY element type in conv_ARRAY (closes #1724)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
+* SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/flask_admin/_types.py
+++ b/flask_admin/_types.py
@@ -280,3 +280,7 @@ class _T_MONGOENGINE_FIELD_PROTOCOL(t.Protocol):
     id: t.Any
     data: t.Any
     name: str
+
+
+class T_FIELD_ARGS_VALIDATORS_COERCE(T_FIELD_ARGS_VALIDATORS, total=False):
+    coerce: t.Callable[[t.Any], t.Any]

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -623,6 +623,24 @@ class AdminModelConverter(ModelConverterBase):
     def conv_ARRAY(
         self, field_args: T_FIELD_ARGS_VALIDATORS, **extra: t.Any
     ) -> form.Select2TagsField:
+        # Without `coerce`, all submitted values fall back to `text_type`,
+        # so a Postgres `ARRAY(Integer)` column is sent back to the DB as
+        # text[] and the INSERT/UPDATE fails with
+        #     column "x" is of type integer[] but expression is of type text[]
+        # (see #1724). When we can introspect the column we infer the inner
+        # `python_type` and pass it through as the per-tag coerce callable so
+        # the resulting Python list matches the column's element type. We
+        # fall back silently for types that don't implement `python_type`
+        # (e.g. SQLAlchemy's `JSON`).
+        column = extra.get("column")
+        item_type = getattr(getattr(column, "type", None), "item_type", None)
+        if item_type is not None:
+            try:
+                python_type = item_type.python_type
+            except (AttributeError, NotImplementedError):
+                python_type = None
+            if python_type is not None and python_type is not str:
+                field_args.setdefault("coerce", python_type)  # type: ignore[typeddict-unknown-key]
         return form.Select2TagsField(save_as_list=True, **field_args)
 
     @converts("HSTORE")

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -643,9 +643,7 @@ class AdminModelConverter(ModelConverterBase):
                 # `coerce` isn't part of T_FIELD_ARGS_VALIDATORS (it's a
                 # Select2TagsField-specific kwarg), so smuggle it via a cast
                 # rather than widening the TypedDict.
-                t.cast(dict[str, t.Any], field_args).setdefault(
-                    "coerce", python_type
-                )
+                t.cast(dict[str, t.Any], field_args).setdefault("coerce", python_type)
         return form.Select2TagsField(save_as_list=True, **field_args)
 
     @converts("HSTORE")

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -35,6 +35,7 @@ from ..._types import T_FIELD_ARGS_LABEL
 from ..._types import T_FIELD_ARGS_PLACES
 from ..._types import T_FIELD_ARGS_VALIDATORS
 from ..._types import T_FIELD_ARGS_VALIDATORS_ALLOW_BLANK
+from ..._types import T_FIELD_ARGS_VALIDATORS_COERCE
 from ..._types import T_FIELD_ARGS_VALIDATORS_FILES
 from ..._types import T_INSTRUMENTED_ATTRIBUTE
 from ..._types import T_MODEL_VIEW
@@ -621,17 +622,10 @@ class AdminModelConverter(ModelConverterBase):
         "sqlalchemy.dialects.postgresql.base.ARRAY", "sqlalchemy.sql.sqltypes.ARRAY"
     )
     def conv_ARRAY(
-        self, field_args: T_FIELD_ARGS_VALIDATORS, **extra: t.Any
+        self, field_args: T_FIELD_ARGS_VALIDATORS_COERCE, **extra: t.Any
     ) -> form.Select2TagsField:
-        # Without `coerce`, all submitted values fall back to `text_type`,
-        # so a Postgres `ARRAY(Integer)` column is sent back to the DB as
-        # text[] and the INSERT/UPDATE fails with
-        #     column "x" is of type integer[] but expression is of type text[]
-        # (see #1724). When we can introspect the column we infer the inner
-        # `python_type` and pass it through as the per-tag coerce callable so
-        # the resulting Python list matches the column's element type. We
-        # fall back silently for types that don't implement `python_type`
-        # (e.g. SQLAlchemy's `JSON`).
+        # Ensure Select2TagsField uses the correct Python type for ARRAY element values.
+        # Otherwise, WTForms defaults to text_type, causing Postgres ARRAY type errors.
         column = extra.get("column")
         item_type = getattr(getattr(column, "type", None), "item_type", None)
         if item_type is not None:
@@ -640,10 +634,7 @@ class AdminModelConverter(ModelConverterBase):
             except (AttributeError, NotImplementedError):
                 python_type = None
             if python_type is not None and python_type is not str:
-                # `coerce` isn't part of T_FIELD_ARGS_VALIDATORS (it's a
-                # Select2TagsField-specific kwarg), so smuggle it via a cast
-                # rather than widening the TypedDict.
-                t.cast(dict[str, t.Any], field_args).setdefault("coerce", python_type)
+                field_args.setdefault("coerce", python_type)
         return form.Select2TagsField(save_as_list=True, **field_args)
 
     @converts("HSTORE")

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -640,7 +640,12 @@ class AdminModelConverter(ModelConverterBase):
             except (AttributeError, NotImplementedError):
                 python_type = None
             if python_type is not None and python_type is not str:
-                field_args.setdefault("coerce", python_type)  # type: ignore[typeddict-unknown-key]
+                # `coerce` isn't part of T_FIELD_ARGS_VALIDATORS (it's a
+                # Select2TagsField-specific kwarg), so smuggle it via a cast
+                # rather than widening the TypedDict.
+                t.cast(dict[str, t.Any], field_args).setdefault(
+                    "coerce", python_type
+                )
         return form.Select2TagsField(save_as_list=True, **field_args)
 
     @converts("HSTORE")

--- a/flask_admin/tests/sqla/test_form.py
+++ b/flask_admin/tests/sqla/test_form.py
@@ -83,7 +83,7 @@ class TestArrayConverter:
 
     def test_conv_ARRAY_integer_coerces_each_item_to_int(self) -> None:
         converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
-        column = Column("x", ARRAY(Integer))
+        column: Column[t.Any] = Column("x", ARRAY(Integer))
         bound = self._bind(
             converter.conv_ARRAY(field_args={"validators": []}, column=column)
         )
@@ -97,7 +97,7 @@ class TestArrayConverter:
 
     def test_conv_ARRAY_float_coerces_each_item_to_float(self) -> None:
         converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
-        column = Column("x", ARRAY(Float))
+        column: Column[t.Any] = Column("x", ARRAY(Float))
         bound = self._bind(
             converter.conv_ARRAY(field_args={"validators": []}, column=column)
         )
@@ -112,7 +112,7 @@ class TestArrayConverter:
         spurious coercion that would round-trip values through `int()`.
         """
         converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
-        column = Column("x", ARRAY(String))
+        column: Column[t.Any] = Column("x", ARRAY(String))
         bound = self._bind(
             converter.conv_ARRAY(field_args={"validators": []}, column=column)
         )

--- a/flask_admin/tests/sqla/test_form.py
+++ b/flask_admin/tests/sqla/test_form.py
@@ -4,6 +4,11 @@ from unittest.mock import MagicMock
 
 import pytest
 import wtforms
+from sqlalchemy import ARRAY
+from sqlalchemy import Column
+from sqlalchemy import Float
+from sqlalchemy import Integer
+from sqlalchemy import String
 from wtforms.fields.simple import StringField
 
 from flask_admin.contrib.sqla.form import AdminModelConverter
@@ -53,3 +58,87 @@ class TestAdminModelConverter:
             pass
 
         assert field() == "<p>widget overridden</p>"
+
+
+class TestArrayConverter:
+    """Regression tests for `AdminModelConverter.conv_ARRAY` -- see issue #1724.
+
+    Without an inner-type-aware coerce callable, every submitted value for a
+    Postgres `ARRAY(Integer)` column is sent back to the DB as a Python
+    `str`, so the resulting `text[]` value is rejected with
+        column "x" is of type integer[] but expression is of type text[]
+    The converter now passes a `coerce` derived from the array element's
+    `python_type` so the round-trip lines up with the column type.
+    """
+
+    def _bind(self, unbound_field: t.Any) -> t.Any:
+        """The converter returns a wtforms UnboundField. Bind it onto a real
+        form so we can drive `process_formdata` and inspect `.data`.
+        """
+
+        class _F(wtforms.Form):
+            x = unbound_field
+
+        return _F().x
+
+    def test_conv_ARRAY_integer_coerces_each_item_to_int(self) -> None:
+        converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
+        column = Column("x", ARRAY(Integer))
+        bound = self._bind(
+            converter.conv_ARRAY(field_args={"validators": []}, column=column)
+        )
+
+        bound.process_formdata(["1,2,3"])
+
+        assert bound.data == [1, 2, 3]
+        # Hard-pin element types so a future change of the inner coerce can't
+        # silently regress to strings.
+        assert all(isinstance(v, int) for v in bound.data), bound.data
+
+    def test_conv_ARRAY_float_coerces_each_item_to_float(self) -> None:
+        converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
+        column = Column("x", ARRAY(Float))
+        bound = self._bind(
+            converter.conv_ARRAY(field_args={"validators": []}, column=column)
+        )
+
+        bound.process_formdata(["1.5, 2.0"])
+
+        assert bound.data == [1.5, 2.0]
+        assert all(isinstance(v, float) for v in bound.data), bound.data
+
+    def test_conv_ARRAY_string_keeps_string_default(self) -> None:
+        """String arrays must continue to work exactly as before -- no
+        spurious coercion that would round-trip values through `int()`.
+        """
+        converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
+        column = Column("x", ARRAY(String))
+        bound = self._bind(
+            converter.conv_ARRAY(field_args={"validators": []}, column=column)
+        )
+
+        bound.process_formdata(["alpha,beta,gamma"])
+
+        assert bound.data == ["alpha", "beta", "gamma"]
+
+    def test_conv_ARRAY_missing_item_type_falls_back_to_text(self) -> None:
+        """If the column object can't be introspected (e.g. legacy callers
+        passing a MagicMock), the converter must not raise. The previous
+        default (string coerce) is preserved.
+        """
+        converter = AdminModelConverter(None, None)  # type: ignore[arg-type]
+        # MagicMock().type.item_type silently returns another MagicMock, whose
+        # python_type access would itself succeed and return a MagicMock --
+        # which is precisely the kind of pathological case we need to handle
+        # without exploding.
+        column = MagicMock()
+        # Force item_type to be absent so the fallback branch is exercised.
+        column.type.spec_set = ["item_type"]
+        del column.type.item_type
+
+        bound = self._bind(
+            converter.conv_ARRAY(field_args={"validators": []}, column=column)
+        )
+
+        bound.process_formdata(["x,y"])
+        assert bound.data == ["x", "y"]


### PR DESCRIPTION
## Summary

`AdminModelConverter.conv_ARRAY` returned a `Select2TagsField` with no
`coerce` callable, so every submitted value was cast via the default
`text_type` and the resulting Python list was always `list[str]`. For a
Postgres `ARRAY(Integer)` column that round-trip fails on save with

```
column "x" is of type integer[] but expression is of type text[]
```

(originally reported in #1724 in 2018 and still reproducible on
`master`; the long-standing workaround in that thread is to subclass
`Select2TagsField` and override `process_formdata` to call `int()` on
each entry).

Fixes #1724.

## Context

- The buggy converter is at
  `flask_admin/contrib/sqla/form.py:620-626` (pre-change):

  ```python
  @converts(
      "sqlalchemy.dialects.postgresql.base.ARRAY", "sqlalchemy.sql.sqltypes.ARRAY"
  )
  def conv_ARRAY(self, field_args, **extra):
      return form.Select2TagsField(save_as_list=True, **field_args)
  ```

- `Select2TagsField` already supports a `coerce` parameter
  (`flask_admin/form/fields.py:228`) that is applied to each tag in
  `process_formdata` (`flask_admin/form/fields.py:253-256`).
- SQLAlchemy's `ARRAY` exposes `column.type.item_type`, and standard
  inner types implement `.python_type`. Detect that and use it as
  `coerce`.

## Changes

- `flask_admin/contrib/sqla/form.py`: in `conv_ARRAY`, look up the
  column's `item_type.python_type`. When that returns a non-`str` type
  (`int`, `float`, `bool`, ...) pass it through to `Select2TagsField` as
  `coerce`. Fall back silently when `python_type` is missing
  (`AttributeError` / `NotImplementedError`) or the column object can't
  be introspected -- the previous behavior for `ARRAY(String)` is
  preserved unchanged.
- `flask_admin/tests/sqla/test_form.py`: four new tests in
  `TestArrayConverter`:
  - `test_conv_ARRAY_integer_coerces_each_item_to_int`
  - `test_conv_ARRAY_float_coerces_each_item_to_float`
  - `test_conv_ARRAY_string_keeps_string_default`
  - `test_conv_ARRAY_missing_item_type_falls_back_to_text`
- `doc/changelog.rst`: `[unreleased]` bugfix entry.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/pallets-eco/flask-admin.git /tmp/fa-1724 && cd /tmp/fa-1724
uv venv .venv --python 3.12
source .venv/bin/activate
uv pip install -e ".[sqlalchemy]" pytest

# --- BEFORE: origin/master, integer ARRAY tags stay as strings ---
git checkout origin/master
git fetch https://github.com/jbbqqf/flask-admin.git fix/1724-array-integer-coerce
git checkout FETCH_HEAD -- flask_admin/tests/sqla/test_form.py
pytest flask_admin/tests/sqla/test_form.py::TestArrayConverter -v
# Expected: 2 failed, 2 passed
#   - test_conv_ARRAY_integer_coerces_each_item_to_int  -> ['1', '2', '3'] != [1, 2, 3]
#   - test_conv_ARRAY_float_coerces_each_item_to_float -> ['1.5', '2.0'] != [1.5, 2.0]
git checkout origin/master -- flask_admin/tests/sqla/test_form.py

# --- AFTER: this branch, element types are coerced from item_type.python_type ---
git checkout FETCH_HEAD
pytest flask_admin/tests/sqla/test_form.py::TestArrayConverter -v
# Expected: 4 passed
```

## What I ran locally

- New tests, focused:
  ```
  pytest flask_admin/tests/sqla/test_form.py::TestArrayConverter -v
  # 4 passed
  ```
- Whole test_form.py file (covers all converters, including the
  parametrized "can_override_widget" matrix where `conv_ARRAY` is
  already exercised):
  ```
  pytest flask_admin/tests/sqla/test_form.py -v
  # 27 passed
  ```
- Broader regression sweep on the SQLA + generic model code paths:
  ```
  pytest flask_admin/tests/sqla/test_basic.py flask_admin/tests/sqla/test_form.py \
         flask_admin/tests/test_model.py -q --tb=no
  # 229 passed, 56 skipped, 11 xfailed
  ```
- Lint:
  ```
  ruff check  flask_admin/contrib/sqla/form.py flask_admin/tests/sqla/test_form.py
  ruff format --check flask_admin/contrib/sqla/form.py flask_admin/tests/sqla/test_form.py
  # All checks passed! / 2 files already formatted
  ```

## Edge cases

| # | Scenario | Inner type | Submitted | Expected `field.data` | Verified by |
|---|---|---|---|---|---|
| 1 | `ARRAY(Integer)` | `Integer` -> `int` | `"1,2,3"` | `[1, 2, 3]` | `test_conv_ARRAY_integer_coerces_each_item_to_int` |
| 2 | `ARRAY(Float)` | `Float` -> `float` | `"1.5, 2.0"` | `[1.5, 2.0]` | `test_conv_ARRAY_float_coerces_each_item_to_float` |
| 3 | `ARRAY(String)` | `String` -> `str` | `"alpha,beta,gamma"` | `["alpha", "beta", "gamma"]` (unchanged) | `test_conv_ARRAY_string_keeps_string_default` |
| 4 | `column.type` without `item_type` (mocked/legacy) | n/a | `"x,y"` | `["x", "y"]` (fallback) | `test_conv_ARRAY_missing_item_type_falls_back_to_text` |
| 5 | Inner type without `python_type` (e.g. `JSON`) | raises `NotImplementedError` | unchanged | no `coerce` injected, no crash | covered by the `try/except` branch in the new code path |

## Risk / blast radius

- Only `conv_ARRAY` is modified, plus its tests.
- For `ARRAY(String)` -- the only inner type that has historically
  worked end-to-end -- the new code path explicitly skips injecting a
  `coerce` (it's already the default), so existing apps using string
  arrays see no behavior change.
- Users who had subclassed `Select2TagsField` to add their own
  per-element `int()` cast (per the workaround in the issue thread)
  keep working as before, because:
  - the converter only sets `coerce` when the inner type's
    `python_type` is not `str`;
  - it does it via `setdefault`, so an explicit user-provided
    `field_args["coerce"]` wins.
- No template/JS/static touched.

## Release note

```release-note
SQLAlchemy backend: scaffolded forms for Postgres `ARRAY(Integer)` /
`ARRAY(Float)` columns now save correctly. The `Select2TagsField` field
generated by `conv_ARRAY` infers the inner type's `python_type` and
uses it as the per-tag coerce callable, so saved values match the
column's element type instead of being sent back as `text[]`.
```

---

*PR drafted with assistance from Claude Code (Anthropic). The change was
reviewed manually against flask-admin's source -- file:line references in
the body were checked against the cloned tree, and the copy-paste
BEFORE/AFTER reproducer block is the one I used during development;
reviewers can paste it verbatim.*
