### PR TITLE
build: add exclude-newer and simplify uv dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ tests = [
     "azure-storage-blob<12.28.0", # Azurite 3.35.0 only supports up to API 2025-11-05
 ]
 typing = [
-    "flask-admin[dev]",
+    "flask-admin[all]",
     "mypy",
     "pytest",
     "types-boto3", # keep
@@ -136,7 +136,8 @@ build-backend = "flit_core.buildapi"
 name = "flask_admin"
 
 [tool.uv]
-default-groups = ["dev", "pre-commit", "tests", "typing"]
+default-groups = ["dev"]
+exclude-newer = "7 days"
 
 [tool.uv.sources]
 flask-admin = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "alabaster"
 version = "1.0.0"
@@ -831,7 +835,7 @@ typing = [
     { name = "botocore" },
     { name = "flake8" },
     { name = "flask", extra = ["async"] },
-    { name = "flask-admin" },
+    { name = "flask-admin", extra = ["all"] },
     { name = "moto" },
     { name = "mypy" },
     { name = "psycopg2-binary" },
@@ -897,7 +901,6 @@ dev = [
     { name = "flake8" },
     { name = "flask", extras = ["async"] },
     { name = "flask-admin", extras = ["all"], editable = "." },
-    { name = "flask-admin", extras = ["dev"], editable = "." },
     { name = "moto" },
     { name = "mypy" },
     { name = "pallets-sphinx-themes" },
@@ -944,7 +947,7 @@ typing = [
     { name = "botocore", specifier = ">=1.35" },
     { name = "flake8" },
     { name = "flask", extras = ["async"] },
-    { name = "flask-admin", extras = ["dev"], editable = "." },
+    { name = "flask-admin", extras = ["all"], editable = "." },
     { name = "moto" },
     { name = "mypy" },
     { name = "psycopg2-binary" },


### PR DESCRIPTION
1. `exclude-newer` mitigates supply chain attacks

2. 
```
dev = [
    "flask-admin[all]",
    ...
    {include-group = "typing"},
]

typing = [
    "flask-admin[dev]",
    ...
]
```

Creates a circular relationship:

- dev includes typing
- typing installs flask-admin[dev]
- which includes typing again

Even if uv/tox tolerates it, it’s conceptually messy and can cause resolver weirdness.
This PR fixes it.