### PR TITLE
examples fix ModuleNotFoundError: remove Babel

### DIFF
--- a/examples/bootstrap4/main.py
+++ b/examples/bootstrap4/main.py
@@ -13,7 +13,6 @@ from flask_admin.contrib.sqla import ModelView
 from flask_admin.menu import MenuDivider
 from flask_admin.menu import MenuLink
 from flask_admin.theme import Bootstrap4Theme
-from flask_babel import Babel
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Boolean
 from sqlalchemy import DateTime
@@ -33,7 +32,6 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + app.config["DATABASE_FILE
 app.config["SQLALCHEMY_ECHO"] = False
 
 db = SQLAlchemy(app)
-babel = Babel(app)
 
 
 class MyAdminIndexView(AdminIndexView):


### PR DESCRIPTION
flask-admin[translations] not in .toml, so example would crash. Babel is not needed in this example, so just remove it.