### PR TITLE
fix(mongoengine): set Content-Disposition on api_file_view downloads

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
-* MongoEngine backend: ``api_file_view`` now emits a ``Content-Disposition`` header carrying the original GridFS filename, so downloaded files keep their name and extension instead of being saved as ``file`` (closes #2916). Originally reported and patched by `@bekab95 <https://github.com/bekab95>`_ in #2036.
+* MongoEngine fileadmin backend: downloading GridFS files now preserves their name and extension instead of saving them as ``file`` (closes #2916).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
+* MongoEngine backend: ``api_file_view`` now emits a ``Content-Disposition`` header carrying the original GridFS filename, so downloaded files keep their name and extension instead of being saved as ``file`` (closes #2916). Originally reported and patched by `@bekab95 <https://github.com/bekab95>`_ in #2036.
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -9,6 +9,7 @@ from flask import abort
 from flask import flash
 from flask import request
 from flask import Response
+from flask import send_file
 from mongoengine import Document
 from mongoengine import QuerySet
 from mongoengine.connection import get_db
@@ -724,10 +725,11 @@ class ModelView(BaseModelView):
         if not data:
             abort(404)
 
-        return Response(
-            data.read(),
-            content_type=data.content_type,
-            headers={"Content-Length": data.length},  # type: ignore[arg-type]
+        return send_file(
+            data,
+            mimetype=data.content_type,
+            download_name=data.filename,
+            as_attachment=False,
         )
 
     # Default model actions

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -2,6 +2,7 @@ import typing as t
 
 from flask import Flask
 from mongoengine import Document
+from mongoengine import FileField
 from mongoengine import StringField
 from mongoengine.connection import get_db
 from wtforms import fields
@@ -144,6 +145,43 @@ def test_model(app: Flask, db: t.Any, admin: Admin) -> None:
     data = rv.data.decode("utf-8")
     assert "test2large" not in data
     assert "test2" in data
+
+
+def test_api_file_view_sets_content_disposition(
+    app: Flask, db: t.Any, admin: Admin
+) -> None:
+    """Regression test for #2916: api_file_view must expose the original
+    GridFS filename via Content-Disposition so browsers don't save the file
+    as ``file`` with no extension.
+    """
+
+    class FileDoc(Document):  # type: ignore[misc]
+        meta = {"collection": "file_doc"}
+        name = StringField()
+        upload = FileField()
+
+    class FileDocView(ModelView):
+        pass
+
+    # Drop existing data
+    raw_db = get_db()
+    for name in raw_db.list_collection_names():
+        raw_db.drop_collection(name)
+
+    admin.add_view(FileDocView(FileDoc, "FileDoc", endpoint="filedocview"))
+
+    doc = FileDoc(name="report")
+    doc.upload.put(b"hello world", filename="report.txt", content_type="text/plain")
+    doc.save()
+
+    client = app.test_client()
+    grid_id = doc.upload.grid_id
+    rv = client.get(f"/admin/filedocview/api/file/?id={grid_id}&coll=fs&db=default")
+
+    assert rv.status_code == 200
+    assert rv.data == b"hello world"
+    assert rv.mimetype == "text/plain"
+    assert "report.txt" in rv.headers.get("Content-Disposition", "")
 
 
 def test_query_ajax_model_loader_initialization(db: t.Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,12 @@ filterwarnings = [
 
     "default:datetime\\.datetime\\.utcnow\\(\\) is deprecated and scheduled for removal in a future version:DeprecationWarning",
 
+    # PyMongo deprecated the camel-cased GridOut.contentType alias accessed by
+    # ``GridOut.content_type``. Mongoengine's ``FileField`` still exposes
+    # ``content_type`` and Flask-Admin mirrors that. Remove when the upstream
+    # property is replaced.
+    "default:GridOut property 'contentType' is deprecated and will be removed in PyMongo 5\\.0:DeprecationWarning",
+
     # `flask.testing` accesses this attribute; remove when they have updated their code.
     "default:The '__version__' attribute is deprecated and will be removed in Werkzeug 3\\.1\\.:DeprecationWarning",
 


### PR DESCRIPTION
## Summary

Closes #2916.

`ModelView.api_file_view()` in `flask_admin.contrib.mongoengine.view` served GridFS file content with `Content-Type` and `Content-Length` headers but **no `Content-Disposition`**. Browsers therefore named the saved file from the URL's last path segment (`/admin/<view>/api/file/`) — producing `file` (or `file.html` after a content-sniff) with no extension, even though GridFS already knows the original filename.

This PR switches the handler to `flask.send_file` with `download_name=data.filename`:

```python
return send_file(
    data,
    mimetype=data.content_type,
    download_name=data.filename,
    as_attachment=False,
)
```

The response now carries `Content-Disposition: inline; filename="<original>"`, which:

- preserves the **existing inline-render behavior** for images/PDFs (no behavioral regression for users who clicked a download link expecting the browser to display the file);
- supplies the original filename and extension when the user does choose "Save as";
- handles RFC 6266 encoding for non-ASCII filenames automatically (the original PR #2036's handcrafted `%(filename)s` interpolation did not);
- supports `Range` requests for free.

## Attribution

Originally reported and patched by [@bekab95](https://github.com/bekab95) in #2036 (Sep 2020). That PR bundled this change with an unrelated `DBRef` fix, went stale, and now conflicts with `master`. I've split the report into two focused issues — #2916 (this PR) and #2917 — and credited @bekab95 in the commit (`Co-authored-by`) and the changelog entry.

A companion PR for #2917 will follow.

## Test plan

- [x] Added `test_api_file_view_sets_content_disposition` in `flask_admin/tests/mongoengine/test_basic.py`. The test uploads a `report.txt` blob through a `FileField`, hits `/admin/<view>/api/file/?id=...`, and asserts `report.txt` appears in `Content-Disposition`.
- [x] Full MongoEngine test file passes locally against `mongo:7`.
- [x] Existing tests still pass (no behavioral change beyond the new header).

## Notes

`pyproject.toml` gains one warning filter for `GridOut property 'contentType' is deprecated and will be removed in PyMongo 5.0`. That deprecation is raised by `data.content_type` — which the pre-existing code already used; this PR simply added the first test that exercises that path. Migrating off the deprecated property belongs in a separate change.

---

> Disclosure: I drafted this PR with help from Claude Code while triaging stale PR #2036; the diff and the test were verified manually against a live MongoDB instance.