### PR TITLE
fix(filters): BaseTimeBetweenFilter.validate() returns False on invalid input

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 Bugfixes:
+* ``BaseTimeBetweenFilter.validate()`` now returns ``False`` on invalid input instead of raising an exception.
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
 

--- a/flask_admin/model/filters.py
+++ b/flask_admin/model/filters.py
@@ -300,7 +300,6 @@ class BaseTimeBetweenFilter(BaseFilter):
             else:
                 return False
         except ValueError:
-            raise
             return False
 
 

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -914,3 +914,26 @@ def test_form_submit(app: Flask, admin: Admin, url: str, age: int, msg: str) -> 
     assert rv.status_code == 200
     data = rv.data.decode("utf-8")
     assert all([part in data for part in msg.split("|")])
+
+
+def test_time_between_filter_validate_invalid_input() -> None:
+    """BaseTimeBetweenFilter.validate() must return False for bad input, not raise."""
+    flt = filters.BaseTimeBetweenFilter("time_col")
+
+    # Valid range returns True
+    assert flt.validate("08:00:00 to 17:00:00") is True
+
+    # Start == end is still True (boundary)
+    assert flt.validate("12:00:00 to 12:00:00") is True
+
+    # Start after end returns False
+    assert flt.validate("17:00:00 to 08:00:00") is False
+
+    # Missing " to " separator must return False, not raise ValueError
+    assert flt.validate("notavalidtime") is False
+
+    # Malformed time values must return False, not raise ValueError
+    assert flt.validate("99:99:99 to 99:99:99") is False
+
+    # Empty string must return False, not raise ValueError
+    assert flt.validate("") is False

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -916,7 +916,7 @@ def test_form_submit(app: Flask, admin: Admin, url: str, age: int, msg: str) -> 
     assert all([part in data for part in msg.split("|")])
 
 
-def test_time_between_filter_validate_invalid_input() -> None:
+def test_base_time_between_filter_validate() -> None:
     """BaseTimeBetweenFilter.validate() must return False for bad input, not raise."""
     flt = filters.BaseTimeBetweenFilter("time_col")
 


### PR DESCRIPTION
`BaseTimeBetweenFilter.validate()` in `flask_admin/model/filters.py` had a bare `raise` in its `except ValueError` block, followed by unreachable `return False`. This caused an unhandled `ValueError` (HTTP 500) whenever a malformed time range string — e.g. missing the `" to "` separator, garbage values like `notavalidtime`, or out-of-range times — was submitted via the URL query string.

The two analogous filters in the same file already handle this correctly:
- `BaseDateBetweenFilter.validate()` — `return False` on `ValueError`
- `BaseDateTimeBetweenFilter.validate()` — `return False` on `ValueError`

**Fix:** remove the `raise` so `ValueError` results in `return False`, matching the existing pattern.

A test covering valid and invalid inputs is added to `flask_admin/tests/test_model.py`.