### PR TITLE
fix(forms): prevent double submission and show loader on form submit

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 Bugfixes:
+* Prevent double-clicking of submit buttons in forms by disabling the button on submit. This applies to regular forms and forms in modals (e.g. file edit form in FileAdmin). This should help prevent duplicate records from being created when users double-click the submit button.
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
 

--- a/flask_admin/static/admin/js/form.js
+++ b/flask_admin/static/admin/js/form.js
@@ -664,4 +664,87 @@
     $(function() {
         faForm.applyGlobalStyles(document);
     });
+
+    /**
+     * Prevent double submit and show a loader when submitting forms. 
+     * If the page reloads with validation errors, re-enable the form and reset the button text.
+     */
+    window.lockBtnOnFormSubmit = function () {
+      //console.log("lockBtnOnFormSubmit called !!!");
+
+      $('form').on('submit', function () {
+        const $form = $(this);
+
+        // prevent double submit
+        if ($form.data('submitted')) {
+          return false;
+        }
+
+        $form.data('submitted', true);
+
+        const $btn = $form.find('button[type="submit"], input[type="submit"]');
+
+        // store original text
+        $btn.each(function () {
+          const $b = $(this);
+          $b.data('original-text', $b.html() || $b.val());
+        });
+
+        // disable + loader
+        $btn.prop('disabled', true);
+
+        $btn.each(function () {
+          const $b = $(this);
+          if ($b.is('button')) {
+            $b.html(`<i class="fa fa-spinner fa-spin"></i> ${  $b.data('original-text')}`);
+          } else {
+            $b.val(`⌛ ${  $b.data('original-text')}...`);
+          }
+        });
+
+        return true;
+      });
+
+      // ✅ RESET if page reloads with validation errors
+      const hasErrors = $('.has-error, .invalid-feedback, .alert-danger').length > 0;
+
+      if (hasErrors) {
+        const $form = $('form');
+
+        $form.data('submitted', false);
+
+        const $btn = $form.find('button[type="submit"], input[type="submit"]');
+
+        $btn.prop('disabled', false);
+
+        $btn.each(function () {
+          const $b = $(this);
+          if ($b.data('original-text')) {
+            if ($b.is('button')) {
+              $b.html($b.data('original-text'));
+            } else {
+              $b.val($b.data('original-text'));
+            }
+          }
+        });
+      }
+    };
+
+    // Affected forms:
+    // - /model/create.html
+    // - /model/edit.html
+    // - /file/form.html
+    // - search & filter forms 
+    window.lockBtnOnFormSubmit();
+    
+    $('#fa_modal_window').on('shown.bs.modal', function () {
+        // Affected forms:
+        // - /file/modal/form.html
+        // - /model/modal/create.html
+        // - /model/modal/edit.html
+
+        //console.log('xxxxxxxxxxx');
+        window.lockBtnOnFormSubmit();
+    }); 
+
 })();

--- a/flask_admin/templates/bootstrap4/admin/file/form.html
+++ b/flask_admin/templates/bootstrap4/admin/file/form.html
@@ -7,3 +7,7 @@
     {{ lib.render_form(form, dir_url) }}
   {% endblock %}
 {% endblock %}
+
+{% block tail %}
+  {{ lib.form_js() }}
+{% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/file/list.html
+++ b/flask_admin/templates/bootstrap4/admin/file/list.html
@@ -191,5 +191,7 @@
     {{ actionslib.script(_gettext('Please select at least one file.'),
                          actions,
                          actions_confirmation) }}
-  <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
+
+    {{ lib.form_js() }}
+    <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes #1473 

Prevent double-clicking of submit buttons in forms by disabling the button on submit. This applies to regular forms and forms in modals (e.g. file edit form in FileAdmin). This should help prevent duplicate records from being created when users double-click the submit button.

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/44db1626-6302-47e6-9ebe-f6f33912caf8" />

