### PR TITLE
invert sorting arrows in list view

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
-* Fix sorting arrow direction in admin list view. Now it reflects the current sorting state. (closes #2933).
+* Fix sorting arrow direction in admin list view. Now it reflects the current sorting state (closes #2933).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Bugfixes:
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
+* Fix sorting arrow direction in admin list view. Now it reflects the current sorting state. (closes #2933).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/flask_admin/templates/bootstrap4/admin/file/list.html
+++ b/flask_admin/templates/bootstrap4/admin/file/list.html
@@ -42,9 +42,9 @@
                         <a href="{{ sort_url(column, dir_path, True) }}" title="{{ _gettext('Sort by %(name)s', name=column) }}">
                             {{ admin_view.column_label(column) }}
                             {% if sort_desc %}
-                                <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
-                            {% else %}
                                 <span class="fa fa-chevron-down glyphicon glyphicon-chevron-down"></span>
+                            {% else %}
+                                <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
                             {% endif %}
                         </a>
                     {% else %}

--- a/flask_admin/templates/bootstrap4/admin/model/list.html
+++ b/flask_admin/templates/bootstrap4/admin/model/list.html
@@ -89,9 +89,9 @@
                                 <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">
                                     {{ name }}
                                     {% if sort_desc %}
-                                        <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
-                                    {% else %}
                                         <span class="fa fa-chevron-down glyphicon glyphicon-chevron-down"></span>
+                                    {% else %}
+                                        <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
                                     {% endif %}
                                 </a>
                             {% else %}


### PR DESCRIPTION
I found that in admin list view the direction of sorting arrow is inversed and opennen issue about it after asking in official discord channel. In short: If you sort by column in descending order you get arrow pointing UP, and if order is ascending then arrow points DOWN. Usually its done the other way around so I proposed to fix this.

There are 2 places in code that set the sorting in list view, in model/list.html and file/list.html, and I swaped the icons for descending and ascending order there.

fixes #2933
