### PR TITLE
fix(mongoengine): stop reading deprecated GridOut.contentType

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Bugfixes:
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
 * Fix sorting arrow direction in admin list view. Now it reflects the current sorting state (closes #2933).
 * MongoEngine fileadmin backend: downloading GridFS files now preserves their name and extension instead of saving them as ``file`` (closes #2916).
+* MongoEngine backend: stop reading the deprecated ``GridOut.contentType`` property. File downloads and list/form widgets now resolve the MIME type via ``metadata["content_type"]``, the GridFS document directly (for legacy data), or filename-based guessing (closes #2920).
 
 Type hints:
 * Type hints added to all functions and methods (some using `typing.Any` where full typing not yet available)

--- a/flask_admin/contrib/mongoengine/helpers.py
+++ b/flask_admin/contrib/mongoengine/helpers.py
@@ -1,3 +1,4 @@
+import mimetypes
 import typing as t
 
 from mongoengine import FileField
@@ -6,6 +7,48 @@ from wtforms.validators import ValidationError as wtfValidationError
 
 from flask_admin._compat import as_unicode
 from flask_admin._compat import itervalues
+
+
+def gridfs_content_type(data: t.Any) -> t.Optional[str]:
+    """Return the MIME type for a GridFS ``GridOut``/``GridFSProxy`` without
+    triggering PyMongo's ``GridOut.contentType`` deprecation warning (slated
+    for removal in PyMongo 5.0).
+
+    Resolution order:
+
+    1. ``data.metadata["content_type"]`` — PyMongo 5.0-compatible location.
+    2. Legacy fallback for documents whose content type still lives at the
+       deprecated top-level ``contentType`` field (see ``_legacy_content_type``).
+    3. ``mimetypes.guess_type(data.filename)`` — best-effort from filename.
+    4. ``None`` if no source resolves.
+    """
+    metadata = getattr(data, "metadata", None) or {}
+    if isinstance(metadata, dict):
+        ct = metadata.get("content_type")
+        if ct:
+            return ct
+
+    legacy = _legacy_content_type(data)
+    if legacy:
+        return legacy
+
+    filename = getattr(data, "filename", None)
+    if filename:
+        guessed, _ = mimetypes.guess_type(filename)
+        if guessed:
+            return guessed
+
+    return None
+
+
+def _legacy_content_type(data: t.Any) -> t.Optional[str]:
+    # Reach into the raw BSON doc to avoid PyMongo's GridOut.contentType
+    # deprecation warning. Drop this helper when PyMongo 5.0 removes the
+    # property (#2920).
+    file_doc = getattr(data, "_file", None)
+    if isinstance(file_doc, dict):
+        return file_doc.get("contentType")
+    return None
 
 
 def make_gridfs_args(value: FileField) -> dict[str, t.Any]:

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -11,6 +11,7 @@ from flask_admin.model.typefmt import BASE_FORMATTERS
 from flask_admin.model.typefmt import list_formatter
 
 from . import helpers
+from .helpers import gridfs_content_type
 
 if t.TYPE_CHECKING:
     from . import ModelView
@@ -34,7 +35,7 @@ def grid_formatter(view: ModelView, value: GridOut) -> Markup | str:
             "url": view.get_url(".api_file_view", **args),
             "name": escape(value.name),
             "size": value.length // 1024,
-            "content_type": escape(value.content_type),
+            "content_type": escape(gridfs_content_type(value) or ""),
         }
     )
 

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -34,7 +34,7 @@ def grid_formatter(view: ModelView, value: GridOut) -> Markup | str:
             "url": view.get_url(".api_file_view", **args),
             "name": escape(value.name),
             "size": value.length // 1024,
-            "content_type": escape(gridfs_content_type(value) or ""),
+            "content_type": escape(helpers.gridfs_content_type(value) or ""),
         }
     )
 

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -11,7 +11,6 @@ from flask_admin.model.typefmt import BASE_FORMATTERS
 from flask_admin.model.typefmt import list_formatter
 
 from . import helpers
-from .helpers import gridfs_content_type
 
 if t.TYPE_CHECKING:
     from . import ModelView

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -23,6 +23,7 @@ from flask_admin.babel import gettext
 from flask_admin.babel import lazy_gettext
 from flask_admin.babel import ngettext
 from flask_admin.contrib.mongoengine.ajax import QueryAjaxModelLoader
+from flask_admin.contrib.mongoengine.helpers import gridfs_content_type
 from flask_admin.model import BaseModelView
 from flask_admin.model.form import BaseListForm
 from flask_admin.model.form import create_editable_list_form
@@ -727,7 +728,7 @@ class ModelView(BaseModelView):
 
         return send_file(
             data,
-            mimetype=data.content_type,
+            mimetype=gridfs_content_type(data),
             download_name=data.filename,
             as_attachment=False,
         )

--- a/flask_admin/contrib/mongoengine/widgets.py
+++ b/flask_admin/contrib/mongoengine/widgets.py
@@ -10,7 +10,6 @@ from flask_admin.helpers import get_url
 
 from ..._types import _T_MONGOENGINE_FIELD_PROTOCOL
 from . import helpers
-from .helpers import gridfs_content_type
 
 
 class MongoFileInput:

--- a/flask_admin/contrib/mongoengine/widgets.py
+++ b/flask_admin/contrib/mongoengine/widgets.py
@@ -10,6 +10,7 @@ from flask_admin.helpers import get_url
 
 from ..._types import _T_MONGOENGINE_FIELD_PROTOCOL
 from . import helpers
+from .helpers import gridfs_content_type
 
 
 class MongoFileInput:
@@ -33,7 +34,7 @@ class MongoFileInput:
 
             placeholder = self.template % {
                 "name": escape(data.name),
-                "content_type": escape(data.content_type),
+                "content_type": escape(gridfs_content_type(data) or ""),
                 "size": data.length // 1024,
                 "marker": f"_{field.name}-delete",
             }

--- a/flask_admin/contrib/mongoengine/widgets.py
+++ b/flask_admin/contrib/mongoengine/widgets.py
@@ -34,7 +34,7 @@ class MongoFileInput:
 
             placeholder = self.template % {
                 "name": escape(data.name),
-                "content_type": escape(gridfs_content_type(data) or ""),
+                "content_type": escape(helpers.gridfs_content_type(data) or ""),
                 "size": data.length // 1024,
                 "marker": f"_{field.name}-delete",
             }

--- a/flask_admin/tests/mongoengine/test_helpers.py
+++ b/flask_admin/tests/mongoengine/test_helpers.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``flask_admin.contrib.mongoengine.helpers``.
+
+These tests exercise ``gridfs_content_type`` against lightweight fakes so they
+run without a live MongoDB instance.
+"""
+
+import types
+
+from flask_admin.contrib.mongoengine.helpers import gridfs_content_type
+
+
+def _fake(**attrs: object) -> types.SimpleNamespace:
+    return types.SimpleNamespace(**attrs)
+
+
+def test_prefers_metadata_content_type() -> None:
+    data = _fake(
+        metadata={"content_type": "image/png"},
+        _file={"contentType": "application/legacy"},
+        filename="thing.txt",
+    )
+    assert gridfs_content_type(data) == "image/png"
+
+
+def test_falls_back_to_legacy_contentType_field() -> None:
+    data = _fake(
+        metadata={},
+        _file={"contentType": "application/pdf"},
+        filename="thing.txt",
+    )
+    assert gridfs_content_type(data) == "application/pdf"
+
+
+def test_falls_back_to_filename_guess() -> None:
+    data = _fake(metadata=None, _file={}, filename="report.txt")
+    assert gridfs_content_type(data) == "text/plain"
+
+
+def test_returns_none_when_nothing_resolves() -> None:
+    data = _fake(metadata=None, _file=None, filename=None)
+    assert gridfs_content_type(data) is None
+
+
+def test_returns_none_when_filename_unguessable() -> None:
+    data = _fake(metadata={}, _file={}, filename="no-extension")
+    assert gridfs_content_type(data) is None
+
+
+def test_handles_missing_attributes() -> None:
+    assert gridfs_content_type(_fake()) is None
+
+
+def test_non_dict_metadata_is_ignored() -> None:
+    data = _fake(
+        metadata="not a dict",
+        _file={"contentType": "application/pdf"},
+        filename=None,
+    )
+    assert gridfs_content_type(data) == "application/pdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,12 +166,6 @@ filterwarnings = [
 
     "default:datetime\\.datetime\\.utcnow\\(\\) is deprecated and scheduled for removal in a future version:DeprecationWarning",
 
-    # PyMongo deprecated the camel-cased GridOut.contentType alias accessed by
-    # ``GridOut.content_type``. Mongoengine's ``FileField`` still exposes
-    # ``content_type`` and Flask-Admin mirrors that. Remove when the upstream
-    # property is replaced.
-    "default:GridOut property 'contentType' is deprecated and will be removed in PyMongo 5\\.0:DeprecationWarning",
-
     # `flask.testing` accesses this attribute; remove when they have updated their code.
     "default:The '__version__' attribute is deprecated and will be removed in Werkzeug 3\\.1\\.:DeprecationWarning",
 


### PR DESCRIPTION
## Summary

Closes #2920.

PyMongo deprecated ``GridOut.contentType`` and will remove it in PyMongo 5.0. Flask-admin's MongoEngine backend reads it in three places on the file read path:

- ``ModelView.api_file_view`` — GridFS download response
- ``MongoFileInput`` — form widget rendering
- ``grid_formatter`` (typefmt) — list/detail formatter rendering

This PR routes all three through a new ``gridfs_content_type()`` helper in ``flask_admin/contrib/mongoengine/helpers.py`` that resolves the MIME type without touching the deprecated property:

1. ``data.metadata["content_type"]`` — the PyMongo 5.0-compatible location.
2. ``data._file["contentType"]`` — legacy fallback for existing deployments whose documents still store the content type at the deprecated top-level field. Reaching into the raw BSON doc avoids the deprecation warning while preserving behavior for data written before this change.
3. ``mimetypes.guess_type(data.filename)`` — best-effort from filename.
4. ``None`` if no source resolves.

The write path (``MongoFileField`` in ``fields.py``) is intentionally out of scope — it reads ``content_type`` from a Werkzeug ``FileStorage``, not from a ``GridOut``, and is unrelated to the PyMongo deprecation.

## Coordination with #2918

PR #2918 (unmerged) adds a ``default:GridOut property 'contentType'...`` entry to ``pyproject.toml``'s ``filterwarnings`` so a new test can pass under the suite's strict ``[""error""]`` policy. Whichever PR lands second should drop that entry:

- If #2918 lands first: a follow-up commit here should remove the ``filterwarnings`` line.
- If this lands first: #2918 should drop that entry from its diff.

## Test plan

- [x] Added ``flask_admin/tests/mongoengine/test_helpers.py`` with 7 unit tests covering the full resolution order against lightweight ``types.SimpleNamespace`` fakes — no live MongoDB needed. All pass.
- [x] Existing MongoEngine tests remain unchanged (behavior is preserved for both legacy and forward-compatible data layouts).

## Notes

Once PyMongo 5.0 ships and ``GridOut.contentType`` is removed, ``_legacy_content_type`` becomes dead code and can be deleted in a follow-up.

---

> Disclosure: I drafted this PR with help from Claude Code while addressing the deprecation flagged during review of #2918; the resolution order was verified against PyMongo 4.17 and MongoEngine 0.29.3, and the unit tests were run locally.